### PR TITLE
Hotfix to allow for contrib modules to still load on Hera

### DIFF
--- a/modulefiles/modulefile.ProdGSI.hera
+++ b/modulefiles/modulefile.ProdGSI.hera
@@ -18,12 +18,12 @@ set C_COMP_MP mpcc
 # Load compiler, mpi, cmake, and hdf5/netcdf
 module load intel/18.0.5.274
 # python
-module use -a /contrib/modulefiles
+module use -a /contrib/anaconda/modulefiles
 module load anaconda/2.3.0 
 
 module load impi/2018.0.4
 
-module load contrib
+module use -a /contrib/cmake/modulefiles
 module load cmake/3.9.0
 
 # Load libraries


### PR DESCRIPTION
From Leslie Hart
The current method of loading "sutils" module:
     module load contrib
     module load sutils
 
The new method for loading “sutils” module (available now, and required starting 6/11/20):
     module use -a /contrib/sutils/modulefiles
     module load sutils

GSI modulefile for Hera has been modified to support these changes