### PR TITLE
fix a bug in EnKF that can cause segfault in a diagnostic print 

### DIFF
--- a/src/enkf/mpi_readobs.f90
+++ b/src/enkf/mpi_readobs.f90
@@ -317,8 +317,8 @@ subroutine mpi_getobs(obspath, datestring, nobs_conv, nobs_oz, nobs_sat, nobs_to
                                      maxval(sprd_ob(nobs_conv+nobs_oz+1:nobs_tot))
        do nob =nobs_conv+nobs_oz+1 , nobs_tot
           if (sprd_ob(nob) > 1000.) then 
-             print *, nob, ' sat spread: ', sprd_ob(nob), ', ensmean_ob: ', ensmean_obbc(nob), &
-                           ', anal_ob: ', anal_ob(:,nob), ', mem_ob: ', mem_ob(nob)
+             print *, nob, trim(obtype(nob)),ob(nob),' sat spread: ', sprd_ob(nob), ', ensmean_ob: ', ensmean_obbc(nob), &
+                           ', anal_ob: ', anal_ob(:,nob)
           endif
        enddo
     endif


### PR DESCRIPTION
in src/enkf/mpi_readobs, if the ensemble spread in observation space exceeds a value of 1000 a print statement is triggered that tries to print an array (mem_ob) that has already been deallocated.  This causes a segfault on Orion.  The fix is simply to not print mem_ob.  

Does not affect results, but protects against a possible segfault if ensemble spread exceeds the threshold value.