### PR TITLE
Change gdasechgres namelist for new version of enkf_chgres_recenter_ncio

### DIFF
--- a/scripts/exglobal_enkf_chgres_fv3gfs.sh.ecf
+++ b/scripts/exglobal_enkf_chgres_fv3gfs.sh.ecf
@@ -172,7 +172,7 @@ j_output=$LATB_ENKF
 input_file="fcst.0$FHR"
 output_file="fcst.ensres.0$FHR"
 terrain_file="atmens_fcst"
-vcoord_file="$SIGLEVEL"
+ref_file="atmens_fcst"
 /
 EOF
      if [ $USE_CFP = "YES" ]; then
@@ -199,7 +199,7 @@ EOF
          export ERR=$?
          export err=$ERR
          $ERRSCRIPT || exit 3
-      fi      
+      fi
    fi
 
 else


### PR DESCRIPTION
Don't merge in until corresponding changes have been merged into global-workflow/feature/gfsv16b.

Changes one line of namelist generation from vcoord_file=$SIGLEVEL to ref_file to be the same as terrain_file.