### PR TITLE
Fix issue #104, remove file collision in ConMon

### DIFF
--- a/util/Conventional_Monitor/image_gen/ush/Transfer.sh
+++ b/util/Conventional_Monitor/image_gen/ush/Transfer.sh
@@ -14,7 +14,8 @@ function usage {
 
 
 set -ax
-echo start Transfer.sh
+mybin=`ls ~/bin`
+echo "test: $mybin"
 
 nargs=$#
 if [[ $nargs -lt 1 || $nargs -gt 3 ]]; then
@@ -80,7 +81,7 @@ export jobname=transfer_${CMON_SUFFIX}_conmon
 if [[ $MY_MACHINE == "wcoss_d" || $MY_MACHINE == "wcoss_c" ]]; then
    $SUB -P $PROJECT -q $JOB_QUEUE -o ${logfile} -M 80 -W 1:30 \
         -R affinity[core] -J ${jobname} -cwd ${PWD} \
-        ${C_IG_SCRIPTS}/transfer.sh
+        ${C_IG_SCRIPTS}/transfer_imgs.sh
 else
    echo "Unable to transfer files from $MY_MACHINE to $WEBSVR."
    echo "Manual intervention is required."

--- a/util/Conventional_Monitor/image_gen/ush/transfer_imgs.sh
+++ b/util/Conventional_Monitor/image_gen/ush/transfer_imgs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo begin transfer.sh
+echo begin transfer_imgs.sh
 
 if [[ ${C_IMGNDIR} != "/" ]]; then
    echo "C_IMGNDIR   = $C_IMGNDIR"
@@ -15,5 +15,5 @@ if [[ ${C_IMGNDIR} != "/" ]]; then
    fi
 fi
 
-echo end transfer.sh
+echo end transfer_imgs.sh
 exit


### PR DESCRIPTION
The ConMon file transfer scripts were overhauled and renamed using Transfer.sh and transfer.sh.  This created a potential file collision for MacOS and any other file systems that are case insensitive.  Renaming transfer.sh to transfer_imgs.sh fixes the problem.