### PR TITLE
call_crtm bug fix for gmi

### DIFF
--- a/src/gsi/crtm_interface.f90
+++ b/src/gsi/crtm_interface.f90
@@ -2074,7 +2074,7 @@ subroutine call_crtm(obstype,obstime,data_s,nchanl,nreal,ich, &
      hwp_total = sum(hwp_guess(:))
      theta_700 = atmosphere(1)%temperature(idx700)*(r1000/atmosphere(1)%pressure(idx700))**rd_over_cp
      theta_sfc = data_s(itsavg)*(r100/ps)**rd_over_cp
-     stability = theta_700 - theta_sfc
+     if (present(stability)) stability = theta_700 - theta_sfc
   endif
 
 ! Set clouds for CRTM


### PR DESCRIPTION
In line 933 in setuprad.f90, the function call_crtm is called without the optional parameter 'stability'. The function call_crtm has been assigning a value to stability without checking if it is present. This fixes this bug.