### PR TITLE
GitHub Issue NOAA-EMC/GSI#136.  Fixed occasional bus error in conmon_…

### DIFF
--- a/util/Conventional_Monitor/data_extract/ush/ConMon_DE.sh
+++ b/util/Conventional_Monitor/data_extract/ush/ConMon_DE.sh
@@ -229,7 +229,7 @@ if [ -s $cnvstat  -a -s $pgrbf00 -a -s $pgrbf06 ]; then
       fi
 
       if [[ $MY_MACHINE = "wcoss_d" || $MY_MACHINE = "wcoss_c" ]]; then
-        $SUB -q $JOB_QUEUE -P $PROJECT -o ${logfile} -M 900 \
+        $SUB -q $JOB_QUEUE -P $PROJECT -o ${logfile} -M 1500 \
 		-R affinity[core] -W 0:50 -J ${jobname} \
 		-cwd $PWD ${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON
 


### PR DESCRIPTION
…time.x executable.

Reported "bus error" was actually a simple OOM situation that arose occasionally with uv data in NetCDF formatted diagnostic files.