### PR TITLE
GitHub Issue NOAA-EMC/GSI#174 correct append_diag bug

### DIFF
--- a/src/gsi/setupcldtot.F90
+++ b/src/gsi/setupcldtot.F90
@@ -922,7 +922,7 @@ subroutine setupcldtot(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_di
         endif
      end if
 
-     call nc_diag_init(diag_conv_file)
+     call nc_diag_init(diag_conv_file, append=append_diag)
 
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )

--- a/src/gsi/setuplwcp.f90
+++ b/src/gsi/setuplwcp.f90
@@ -759,7 +759,7 @@ subroutine setuplwcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diag
         endif
      end if
 
-     call nc_diag_init(diag_conv_file)
+     call nc_diag_init(diag_conv_file, append=append_diag)
 
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )

--- a/src/gsi/setupq.f90
+++ b/src/gsi/setupq.f90
@@ -1073,7 +1073,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         endif
      end if
 
-     call nc_diag_init(diag_conv_file)
+     call nc_diag_init(diag_conv_file, append=append_diag)
 
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )

--- a/src/gsi/setupswcp.f90
+++ b/src/gsi/setupswcp.f90
@@ -804,7 +804,7 @@ subroutine setupswcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diag
         endif
      end if
 
-     call nc_diag_init(diag_conv_file)
+     call nc_diag_init(diag_conv_file, append=append_diag)
 
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )


### PR DESCRIPTION
As documented in NOAA-EMC/GSI issue #174, four setup routines in `src/gsi` are missing the optional argument `append_diag` in the call to `nc_diag_init`.   For those cases in which the GSI reads data for a given observation type from multiple input files variable `append_diag` is set to `.true.` so that the file pointer is correctly on subsequent calls to the given setup routine.   Without `append_diag` present, the resulting netcdf diagnostic files do not properly capture all information for the given observation type.   

This bug is present in the following `src/gsi` files:  `setupcldtot.F90`, `setuplwcp.f90`, `setupq.f90`, `setupswcp.f90`.

This bug impacts conventional data monitoring of q observations.   This bug also impacts the assimilation of q observations by the EnKF update code.