### PR TITLE
GitHub Issue NOAA-EMC/GSI#180.  correct typo in exgdas_enkf_select_obs.sh

### DIFF
--- a/scripts/exgdas_enkf_select_obs.sh
+++ b/scripts/exgdas_enkf_select_obs.sh
@@ -72,7 +72,8 @@ cd $DATA || exit 8
 ################################################################################
 # ObsInput file from ensemble mean
 rm -f obs_input*
-$NLN $SELECT_OBS obs_input.tar
+rm -f obsinput.tar
+$NLN $SELECT_OBS obsinput.tar
 
 # Whether to save or skip obs
 if [ $RUN_SELECT = "YES" -a $USE_SELECT = "NO" ]; then


### PR DESCRIPTION
Issue #180 documents a bug found during TAC2BFR parallel testing.  Script `exgdas_enkf_select_obs.sh` contains a typo.   The filename `obs_input.tar` should be `obsinput.tar`.   The bug generates a `No such file` error message when the script is executed.  The bug does not alter analysis results.   

This PR is opened to merge the bug fix (correct the typo) into the authoritative master.