### PR TITLE
GitHub Issue NOAA-EMC/GSI#212 updates to correlated error code

### DIFF
--- a/src/gsi/correlated_obsmod.F90
+++ b/src/gsi/correlated_obsmod.F90
@@ -444,7 +444,7 @@ logical :: corr_obs
       endif
       coun=0
       ErrorCov%R=zero
-      do ii=1,nctot !this should not be nctot, but something from satinfo KAB
+      do ii=1,nctot 
          if (iuse_rad(ii+istart)>0) then
             coun=coun+1
             ErrorCov%indxR(coun)=ii

--- a/src/gsi/correlated_obsmod.F90
+++ b/src/gsi/correlated_obsmod.F90
@@ -55,11 +55,11 @@ usually embedded in the {\it anavinfo} file. An example of such table follows:
 \begin{verbatim}
 correlated_observations::
 ! isis       method   kreq   kmut  type    cov_file
-  airs281_aqua  1      60.   1.0   ice     airs_rcov.bin
-  airs281_aqua  1      60.   1.0   land    airs_rcov.bin
-  airs281_aqua  1      60.   1.0   sea     airs_rcov.bin
-  airs281_aqua  1      60.   1.0   snow    airs_rcov.bin
-  airs281_aqua  1      60.   1.0   mixed   airs_rcov.bin
+  airs_aqua  1      60.   1.0   ice     airs_rcov.bin
+  airs_aqua  1      60.   1.0   land    airs_rcov.bin
+  airs_aqua  1      60.   1.0   sea     airs_rcov.bin
+  airs_aqua  1      60.   1.0   snow    airs_rcov.bin
+  airs_aqua  1      60.   1.0   mixed   airs_rcov.bin
 # cris_npp      1     -99.   1.0   snow    cris_rcov.bin
 # cris_npp      1     -99.   1.0   land    cris_rcov.bin
 # cris_npp      1     -99.   1.0   sea     cris_rcov.bin
@@ -201,13 +201,13 @@ logical :: GMAO_ObsErrorCov=.false.
 type ObsErrorCov
      character(len=40) :: name                        ! R covariance name
      character(len=20) :: instrument                  ! instrument
-     integer(i_kind)   :: nch_active=-1               ! active channels
-     integer(i_kind)   :: nctot=-1                    ! total number of channels (active+passive)
+     integer(i_kind)   :: nch_active=-1               ! number of channels actively assimilated, according to the satinfo
+     integer(i_kind)   :: nctot=-1                    ! total number of channels (active+passive), according to the covariance file
      integer(i_kind)   :: method    =-1               ! define method of computation
      real(r_kind)      :: kreq      =-99._r_kind      ! Weston et al-like spectrum adjustment factor
      real(r_kind)      :: kmut      =-99._r_kind      ! multiplicative inflation factor
      character(len=20) :: mask      ='global'         ! Apply covariance for profiles over all globe
-     integer(i_kind),pointer :: indxR(:)   =>NULL()   ! indexes of active channels in between 1 and nchanl
+     integer(i_kind),pointer :: indxR(:)   =>NULL()   ! indexes of active channels in between 1 and nchanl, according to the satinfo
      real(r_kind),   pointer :: R(:,:)     =>NULL()   ! nch_active x nch_active
      real(r_kind),   pointer :: Revals(:)  =>NULL()   ! eigenvalues of R
 end type
@@ -333,7 +333,8 @@ end subroutine ini_
 ! !INTERFACE:
 !
 subroutine set_(instrument,fname,mask,method,kreq,kmut,ErrorCov)
-use radinfo, only: nusis,iuse_rad,jpch_rad
+use radinfo, only: nusis,iuse_rad,jpch_rad,varch
+use constants, only: zero
 implicit none
 
 ! !INPUT PARAMETERS:
@@ -368,10 +369,13 @@ type(ObsErrorCov),intent(inout) :: ErrorCov ! cov(R) for this instrument
 !BOC
 
 character(len=*),parameter :: myname_=myname//'*set'
-integer(i_kind) nch_active,lu,ii,ioflag,iprec,nctot,coun
-
-real(r_single),allocatable, dimension(:,:) :: readR4  ! nch_active x nch_active x ninstruments
-real(r_double),allocatable, dimension(:,:) :: readR8  ! nch_active x nch_active x ninstruments
+integer(i_kind) nch_active   !number of channels accounted for in the covariance file
+integer(i_kind) nctot        !the total number of channels (active+passive), according to the covariance file
+integer(i_kind) lu,ii,jj,ioflag,iprec,coun,couns,istart,indR
+integer(i_kind),dimension(:),allocatable:: indxR !channel indices read in from the covariance file
+real(r_kind),dimension(:,:),allocatable:: Rcov   !covariance matrix read in from the covariance file
+real(r_single),allocatable, dimension(:,:) :: readR4  ! nch_active x nch_active 
+real(r_double),allocatable, dimension(:,:) :: readR8  ! nch_active x nch_active 
 real(r_kind),allocatable, dimension(:) :: diag
 logical :: corr_obs
 
@@ -393,56 +397,112 @@ logical :: corr_obs
          read(lu,IOSTAT=ioflag) nch_active, nctot, iprec
       endif
       if(ioflag/=0) call die(myname_,' failed to read nch from '//trim(fname))
-!     if no data available, turn off Correlated Error
       coun=0
+      couns=0
+      istart=0 
       do ii=1,jpch_rad
         if (nusis(ii)==ErrorCov%instrument) then
-           if (iuse_rad(ii)>0) coun=coun+1
+           if (couns==0) then 
+              istart=ii-1
+              couns=1
+           endif
+           if (iuse_rad(ii)>0) then
+              coun=coun+1
+           endif
         endif
       enddo
-      if (coun<nch_active) then
+!     if no data available, turn off Correlated Error
+      if (coun==0) then
          if (iamroot_) write(6,*) 'WARNING: ',trim(ErrorCov%instrument), &
                        ' is not initiallized. Turning off Correlated Error'
          return
       endif
-      ErrorCov%nch_active = nch_active
+      ErrorCov%nch_active = coun
       if (.not.GMAO_ObsErrorCov) ErrorCov%nctot = nctot
-      call create_(nch_active,ErrorCov)
+      call create_(coun,ErrorCov)
+      allocate(indxR(nch_active),Rcov(nctot,nctot))
 
 !     Read GSI-like channel numbers used in estimating R for this instrument
-      read(lu,IOSTAT=ioflag) ErrorCov%indxR
+      read(lu,IOSTAT=ioflag) indxR
       if(ioflag/=0) call die(myname_,' failed to read indx from '//trim(fname))
 
 !     Read estimate of observation error covariance
+      Rcov=0.0_r_kind
       if(iprec==4) then
         allocate(readR4(nch_active,nch_active))
         read(lu,IOSTAT=ioflag) readR4
         if(ioflag/=0) call die(myname_,' failed to read R from '//trim(fname))
-        ErrorCov%R = readR4
+        Rcov(1:nch_active,1:nch_active)=readR4
         deallocate(readR4)
       endif
       if(iprec==8) then
         allocate(readR8(nch_active,nch_active))
         read(lu,IOSTAT=ioflag) readR8
         if(ioflag/=0) call die(myname_,' failed to read R from '//trim(fname))
-        ErrorCov%R = readR8
+        Rcov(1:nch_active,1:nch_active)=readR8
         deallocate(readR8)
       endif
-
+      coun=0
+      ErrorCov%R=zero
+      do ii=1,nctot !this should not be nctot, but something from satinfo KAB
+         if (iuse_rad(ii+istart)>0) then
+            coun=coun+1
+            ErrorCov%indxR(coun)=ii
+         endif
+      enddo
+!Add rows and columns for active channels in the satinfo that are not in the covariance file
+     couns=1
+     do ii=1,ErrorCov%nch_active
+        indR=0
+        do jj=couns,nch_active 
+           if (indxR(jj)==ErrorCov%indxR(ii)) then
+              indR=jj
+              couns=jj+1
+              exit
+           endif
+        enddo
+        if (indR==0) then
+           do jj=nctot-1,ii,-1
+              Rcov(jj+1,:)=Rcov(jj,:)
+              Rcov(:,jj+1)=Rcov(:,jj)
+           enddo
+           Rcov(ii,:)=zero
+           Rcov(:,ii)=zero
+           Rcov(ii,ii)=varch(istart+ErrorCov%indxR(ii))*varch(istart+ErrorCov%indxR(ii))
+        endif
+     enddo
+!Remove rows and columns that are in the covariance file, but not in the satinfo
+      couns=1
+      do ii=1,nch_active
+        indR=0
+        do jj=couns,ErrorCov%nch_active
+           if (ErrorCov%indxR(jj)==indxR(ii)) then
+              indR=jj
+              couns=jj+1
+              exit
+            endif
+        enddo
+        if (indR==0) then
+           do jj=ii,nctot-1
+              Rcov(jj,:)=Rcov(jj+1,:)
+              Rcov(:,jj)=Rcov(:,jj+1) 
+           enddo
+         endif
+      enddo
+      ErrorCov%R(1:ErrorCov%nch_active,1:ErrorCov%nch_active)=Rcov(1:ErrorCov%nch_active,1:ErrorCov%nch_active)
 !     Done reading file
       close(lu)
    else
       if (iamroot_) write(6,*) 'No Rcov files found.  Turning off Correlated Error'
       return
    end if
-
 !  If method<0 there is really nothing else to do
 !  ----------------------------------------------
    if (method<0) then
       initialized_=.true.
       return
    endif
-
+   nch_active=ErrorCov%nch_active
    if (VERBOSE_) then
        allocate(diag(nch_active))
        do ii=1,nch_active
@@ -471,7 +531,7 @@ logical :: corr_obs
        endif
        deallocate(diag)
    endif
-
+   deallocate(indxR,Rcov)
    initialized_=.true.
 end subroutine set_
 !EOC
@@ -906,9 +966,9 @@ subroutine upd_varch_
                do jj=1,nch_active
                   nn=GSI_BundleErrorCov(itbl)%indxR(jj)
                   mm=ich1(nn)
-                  if( iuse_rad(mm)<1 ) then
-                    call die(myname_,' active channels used in R do not match those used in GSI, aborting')
-                  endif
+!                  if( iuse_rad(mm)<1 ) then
+!                    call die(myname_,' active channels used in R do not match those used in GSI, aborting')
+!                  endif
                   if(isurf==1) then 
                     if(iamroot_)write(6,'(1x,a6,a20,2i6,2f20.15)')'>>>',idnames(itbl),jj,nn,varch(mm),sqrt(GSI_BundleErrorCov(itbl)%R(jj,jj))
                     varch_sea(mm)=sqrt(GSI_BundleErrorCov(itbl)%R(jj,jj))
@@ -945,9 +1005,6 @@ subroutine upd_varch_
                   endif 
                enddo
                ncp=count(ircv>0) ! number of active channels in profile
-               if(ncp/=nch_active) then
-                  call die(myname_,'serious inconsistency in handling correlated obs')
-               endif
                allocate(IRsubset(ncp)) ! these indexes apply to the matrices/vec in ErrorCov
                allocate(IJsubset(ncp)) ! these indexes in 1 to nchanl
                iii=0;jjj=0


### PR DESCRIPTION
This update will allow for easier handling of correlated error in the case that an instrument has failures in active channels. If CrIS N20 looses the midwave channels, the only necessary change will be to the satinfo file. There is also the option now to turn on channels in the satinfo, without affecting correlated error.

If no changes are made to the satinfo, this update will not result in any difference to GSI results.