### PR TITLE
Port gsi to WCOSS2 & Remove hardwired version nums

### DIFF
--- a/modulefiles/modulefile.ProdGSI.wcoss2
+++ b/modulefiles/modulefile.ProdGSI.wcoss2
@@ -1,0 +1,60 @@
+#%Module######################################################################
+#                                                         Xianwu.Xue@noaa.gov
+#                                                           NOAA/NWS/NCEP/EMC
+# GDAS_ENKF
+#_____________________________________________________
+#proc ModulesHelp { } {
+#puts stderr "Set environment veriables for GDAS_ENKF"
+#puts stderr "This module initializes the environment "
+#puts stderr "for the Intel Compiler Suite $version\n"
+##}
+#module-whatis " GDAS_ENKF whatis description"
+
+#set ver
+
+set COMP ftn
+set COMP_MP ftn
+set COMP_MPI ftn
+
+set C_COMP cc
+set C_COMP_MP cc
+
+# Known conflicts
+
+# Loading pe environment
+module load envvar/${envvar_ver:-1.0}
+
+# Loading Intel Compiler Suite
+module load intel/${intel_ver:-19.1.3.304}
+module load PrgEnv-intel/${PrgEnv_intel_ver:-8.1.0}
+
+# Loading intel mpi
+module load craype/${craype_ver:-2.7.10}
+module load cray-mpich/${cray_mpich_ver:-8.1.9}
+
+# Loading production utilities (ndate)
+module load prod_util/${prod_util_ver:-2.0.10}
+
+# Loading nceplibs modules
+module load bufr/${bufr_ver:-11.5.0}
+module load ip/${ip_ver:-3.3.3}
+module load nemsio/${nemsio_ver:-2.5.2}
+module load sfcio/${sfcio_ver:-1.4.1}
+module load sigio/${sigio_ver:-2.3.2}
+module load sp/${sp_ver:-2.3.3}
+module load w3nco/${w3nco_ver:-2.4.1}
+module load w3emc/${w3emc_ver:-2.7.3}
+module load bacio/${bacio_ver:-2.4.1}
+
+# Loading cmake
+module load cmake/${cmake_ver:-3.20.2}
+
+# Loading python
+module load python/${python_ver:-3.8.6}
+
+# Load modules from nceplibs (until installed by NCO)
+module load crtm/${crtm_ver:-2.3.0}
+module load hdf5/${hdf5_ver:-1.10.6}
+module load netcdf/${netcdf_ver:-4.7.4}
+module load curl/${curl_ver:-7.72.0}
+

--- a/ush/build_all_cmake.sh
+++ b/ush/build_all_cmake.sh
@@ -18,6 +18,8 @@ elif [[ -d /cm ]] ; then
 elif [[ -d /ioddev_dell ]]; then
     . $MODULESHOME/init/sh
     target=wcoss_d
+elif [[ -d /apps/prod ]]; then
+    target=wcoss2
 elif [[ -d /scratch1 ]] ; then
     . /apps/lmod/lmod/init/sh
     target=hera
@@ -74,6 +76,10 @@ elif [ $target = wcoss_c ]; then
     module load $dir_modules/modulefile.ProdGSI.$target
 elif [ $target = discover ]; then
     module load $dir_modules/modulefile.ProdGSI.$target
+elif [ $target = wcoss2 ]; then
+    module purge
+    source $dir_modules/modulefile.ProdGSI.$target
+    module list
 else 
     module purge
     source $dir_modules/modulefile.ProdGSI.$target


### PR DESCRIPTION
1) Port GSI for GEFSv12 to WCOSS2
2) Update build modules to remove hardwired version numbers

 On branch feature/gefs_v12_port2wcoss2
 Changes to be committed:
	new file:   modulefiles/modulefile.ProdGSI.wcoss2
	modified:   ush/build_all_cmake.sh

Refs: #183