### PR TITLE
GSI GitHub Issue NOAA-EMC/GSI#253.  Update OznMon satype file.

### DIFF
--- a/util/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_satype.txt
+++ b/util/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_satype.txt
@@ -1,1 +1,1 @@
-gome_metop-a gome_metop-b omi_aura sbuv2_n19 ompsnp_npp ompstc8_npp
+gome_metop-b omi_aura sbuv2_n19 ompsnp_npp ompstc8_npp


### PR DESCRIPTION
Update gdas_oznmon_satype.txt file to remove reference to gome_metop-a.