### PR TITLE
Change cp to mv for RadMon's warning files.

### DIFF
--- a/util/Radiance_Monitor/nwprod/radmon_shared.v3.0.0/ush/radmon_verf_time.sh
+++ b/util/Radiance_Monitor/nwprod/radmon_shared.v3.0.0/ush/radmon_verf_time.sh
@@ -555,15 +555,15 @@ EOF
    #  copy new bad_pen, bad_chan, and low_count files to $TANKverf_rad
    #   
    if [[ -s ${bad_chan} ]]; then
-      $NCP ${bad_chan} ${TANKverf_rad}/.
+      mv ${bad_chan} ${TANKverf_rad}/.
    fi
 
    if [[ -s ${bad_pen} ]]; then
-      $NCP ${bad_pen} ${TANKverf_rad}/.
+      mv ${bad_pen} ${TANKverf_rad}/.
    fi
 
    if [[ -s ${low_count} ]]; then
-      $NCP ${low_count} ${TANKverf_rad}/.
+      mv ${low_count} ${TANKverf_rad}/.
    fi
 fi
 


### PR DESCRIPTION
Changed cp to mv for RadMon's warning files (bad_*.txt).  The common workflow uses the same directory for RadMon and OznMon processing and the RadMon's bad_pen.${PDY} file was ending up in both the RadMon and OznMon $TANKdir locations.  Changing the RadMon's copy to a move fixes that.