### PR TITLE
GitHub Issue NOAA-EMC/GSI#235. An NSST update package for GFSv16.5

### DIFF
--- a/scripts/exgdas_efsoi_update.sh
+++ b/scripts/exgdas_efsoi_update.sh
@@ -361,6 +361,10 @@ cat > enkf.nml << EOFnml
    sattypes_rad(68)= 'ahi_himawari8', dsis(68)= 'ahi_himawari8',
    sattypes_rad(69)= 'abi_g16',       dsis(69)= 'abi_g16',
    sattypes_rad(70)= 'abi_g17',       dsis(70)= 'abi_g17',
+   sattypes_rad(71)= 'iasi_metop-c',  dsis(71)= 'iasi_metop-c',
+   sattypes_rad(72)= 'viirs-m_npp',   dsis(72)= 'viirs-m_npp',
+   sattypes_rad(73)= 'viirs-m_j1',    dsis(73)= 'viirs-m_j1',
+
    $SATOBS_ENKF
 /
 &ozobs_enkf

--- a/scripts/exgdas_enkf_update.sh
+++ b/scripts/exgdas_enkf_update.sh
@@ -350,6 +350,8 @@ cat > enkf.nml << EOFnml
    sattypes_rad(69)= 'abi_g16',       dsis(69)= 'abi_g16',
    sattypes_rad(70)= 'abi_g17',       dsis(70)= 'abi_g17',
    sattypes_rad(71)= 'iasi_metop-c',  dsis(71)= 'iasi_metop-c',
+   sattypes_rad(72)= 'viirs-m_npp',   dsis(72)= 'viirs-m_npp',
+   sattypes_rad(73)= 'viirs-m_j1',    dsis(73)= 'viirs-m_j1',
    $SATOBS_ENKF
 /
 &ozobs_enkf

--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -150,6 +150,7 @@ GMI1CRBF=${GMI1CRBF:-${COMIN_OBS}/${OPREFIX}gmi1cr.tm00.bufr_d${OSUFFIX}}
 SAPHIRBF=${SAPHIRBF:-${COMIN_OBS}/${OPREFIX}saphir.tm00.bufr_d${OSUFFIX}}
 SEVIRIBF=${SEVIRIBF:-${COMIN_OBS}/${OPREFIX}sevcsr.tm00.bufr_d${OSUFFIX}}
 AHIBF=${AHIBF:-${COMIN_OBS}/${OPREFIX}ahicsr.tm00.bufr_d${OSUFFIX}}
+SSTVIIRS=${SSTVIIRS:-${COMIN_OBS}/${OPREFIX}sstvcw.tm00.bufr_d${OSUFFIX}}
 ABIBF=${ABIBF:-${COMIN_OBS}/${OPREFIX}gsrcsr.tm00.bufr_d${OSUFFIX}}
 CRISBF=${CRISBF:-${COMIN_OBS}/${OPREFIX}cris.tm00.bufr_d${OSUFFIX}}
 ESCRIS=${ESCRIS:-${COMIN_OBS}/${OPREFIX}escris.tm00.bufr_d${OSUFFIX}}
@@ -533,6 +534,7 @@ $NLN $B1AVHPM          avhpmbufr
 $NLN $AHIBF            ahibufr
 $NLN $ABIBF            abibufr
 $NLN $HDOB             hdobbufr
+$NLN $SSTVIIRS         sstviirs
 
 [[ $DONST = "YES" ]] && $NLN $NSSTBF nsstbufr
 
@@ -802,7 +804,7 @@ cat > gsiparm.anl << EOF
   $OBSQC
 /
 &OBS_INPUT
-  dmesh(1)=145.0,dmesh(2)=150.0,dmesh(3)=100.0,time_window_max=3.0,
+  dmesh(1)=145.0,dmesh(2)=150.0,dmesh(3)=100.0,dmesh(4)=70.0,time_window_max=3.0,
   $OBSINPUT
 /
 OBS_INPUT::
@@ -893,10 +895,10 @@ OBS_INPUT::
    gsnd1bufr      sndrd4      g15         sndrD4_g15          0.0     1     0
    oscatbufr      uv          null        uv                  0.0     0     0
    mlsbufr        mls30       aura        mls30_aura          0.0     0     0
-   avhambufr      avhrr       metop-a     avhrr3_metop-a      0.0     1     0
-   avhpmbufr      avhrr       n18         avhrr3_n18          0.0     1     0
-   avhambufr      avhrr       metop-b     avhrr3_metop-b      0.0     1     0
-   avhpmbufr      avhrr       n19         avhrr3_n19          0.0     1     0
+   avhambufr      avhrr       metop-a     avhrr3_metop-a      0.0     4     0
+   avhpmbufr      avhrr       n18         avhrr3_n18          0.0     4     0
+   avhambufr      avhrr       metop-b     avhrr3_metop-b      0.0     4     0
+   avhpmbufr      avhrr       n19         avhrr3_n19          0.0     4     0
    amsr2bufr      amsr2       gcom-w1     amsr2_gcom-w1       0.0     3     0
    gmibufr        gmi         gpm         gmi_gpm             0.0     3     0
    saphirbufr     saphir      meghat      saphir_meghat       0.0     3     0
@@ -912,6 +914,8 @@ OBS_INPUT::
    amsuabufr      amsua       metop-c     amsua_metop-c       0.0     1     1
    mhsbufr        mhs         metop-c     mhs_metop-c         0.0     1     1
    iasibufr       iasi        metop-c     iasi_metop-c        0.0     1     1
+   sstviirs       viirs-m     npp         viirs-m_npp         0.0     4     0
+   sstviirs       viirs-m     j1          viirs-m_j1          0.0     4     0
 ::
 &SUPEROB_RADAR
   $SUPERRAD

--- a/src/gsi/gsi_obOperTypeManager.F90
+++ b/src/gsi/gsi_obOperTypeManager.F90
@@ -345,6 +345,7 @@ function dtype2index_(dtype) result(index_)
         !
     case("avhrr_navy"); index_= iobOper_rad
     case("avhrr"  ); index_= iobOper_rad
+    case("viirs-m"  ); index_= iobOper_rad
 
   case("tcp"    ,"[tcpoper]"    ); index_= iobOper_tcp
 

--- a/src/gsi/ncepnems_io.f90
+++ b/src/gsi/ncepnems_io.f90
@@ -132,6 +132,7 @@ module ncepnems_io
   public read_nemsatm
   public read_nemssfc
   public read_nemssfc_anl
+  public berror_read_hsst
   public write_fv3atm_nems  
   public write_nemsatm
   public write_nemssfc
@@ -166,6 +167,10 @@ module ncepnems_io
 
   interface read_nemssfc_anl
      module procedure read_nemssfc_anl_
+  end interface
+
+  interface berror_read_hsst
+     module procedure berror_read_hsst_
   end interface
 
   interface read_nemsnst
@@ -1787,6 +1792,152 @@ contains
     call mpi_bcast(isli_anl,npts,mpi_itype,iope,mpi_comm_world,iret)
 
   end subroutine read_nemssfc_anl_
+
+  subroutine read_hsst_(hsst,cwoption)
+!
+! abstract : read sst bg error correlation length from berror fix file
+!
+!     03/13/2020 - Xu Li (based on read_wgt)
+!
+   use kinds,     only : i_kind,r_single,r_kind
+   use gridmod,   only : nlat,nlon,nsig
+   use mpeu_util, only : check_iostat
+
+   implicit none
+
+   integer(i_kind)                    , intent(in   ) :: cwoption
+   real(r_single),dimension(nlat,nlon), intent(out  ) :: hsst
+
+   real(r_single),dimension(nlat,nlon) :: corsst
+   character(len=*),parameter :: myname_=myname//'::read_hsst'
+
+   real(r_single),dimension(nlat,nsig,nsig):: agvin
+   real(r_single),dimension(nlat,nsig) :: wgvin,bvin
+
+   integer(i_kind) :: inerr,istat,ier
+   integer(i_kind) :: nsigstat,nlatstat
+   integer(i_kind) :: isig
+   character(len=5) :: var
+
+   real(r_single), allocatable, dimension(:,:) :: hwllin
+   real(r_single), allocatable, dimension(:,:) :: corzin
+   real(r_single), allocatable, dimension(:,:) :: corq2
+   real(r_single), allocatable, dimension(:,:) :: vscalesin
+
+   character(len=256) :: berror_stats = "berror_stats"      ! filename
+
+   ! Open background error statistics file
+   inerr = 22
+   open(inerr,file=berror_stats,form='unformatted',status='old',iostat=ier)
+   call check_iostat(ier,myname_,'open('//trim(berror_stats)//')')
+
+   ! Read header.  Ensure that vertical resolution is consistent
+   ! with that specified via the user namelist
+
+   rewind inerr
+   read(inerr,iostat=ier)nsigstat,nlatstat
+   call check_iostat(ier,myname_,'read('//trim(berror_stats)//') for (nsigstat,nlatstat)')
+
+   if ( nsigstat/=nsig .or. nlatstat/=nlat ) then
+      write(6,*)'PREBAL: **ERROR** resolution of berror_stats incompatiable with GSI'
+
+      write(6,*)'PREBAL:  berror nsigstat,nlatstat=', nsigstat,nlatstat, &
+         ' -vs- GSI nsig,nlat=',nsig,nlat
+      call stop2(101)
+   endif
+
+   write(6,*) myname_,'(read_hsst):  read error amplitudes ', &
+     '"',trim(berror_stats),'".  ', &
+     'nsigstat,nlatstat =',nsigstat,nlatstat
+
+   read(inerr,iostat=ier) agvin,bvin,wgvin
+   call check_iostat(ier,myname_,'read('//trim(berror_stats)//') for (agvin,bvin,wgvin)')
+
+   write(*,*) 'in read_hsst_, cwoption = ',cwoption
+
+   readloop: do
+      read(inerr,iostat=istat) var, isig
+      if ( istat/=0 ) exit
+      write(*,*) 'var, isig, istat : ',var, isig, istat
+      allocate(corzin(nlat,isig))
+      if ( var=='q' .or. var=='cw' ) allocate(corq2(nlat,isig))
+      allocate(hwllin(nlat,isig))
+      if ( isig>1 ) allocate(vscalesin(nlat,isig))
+      if ( var/='sst' ) then
+         if ( var=='q' .or. var=='Q' .or. (var=='cw' .and. cwoption==2) ) then
+            read(inerr,iostat=ier) corzin,corq2
+            call check_iostat(ier,myname_,'read('//trim(berror_stats)//') for (corzin,corq2)')
+         else
+            read(inerr,iostat=ier) corzin
+            call check_iostat(ier,myname_,'read('//trim(berror_stats)//') for (corzin)')
+         endif
+         read(inerr,iostat=ier) hwllin
+         call check_iostat(ier,myname_,'read('//trim(berror_stats)//') for (hwllin)')
+         if ( isig>1 ) then
+            read(inerr,iostat=ier) vscalesin
+            call check_iostat(ier,myname_,'read('//trim(berror_stats)//') for (vscalein)')
+         endif
+      else
+         read(inerr,iostat=ier) corsst
+         call check_iostat(ier,myname_,'read('//trim(berror_stats)//') for (corsst)')
+         read(inerr,iostat=ier) hsst
+         call check_iostat(ier,myname_,'read('//trim(berror_stats)//') for (hsst)')
+      endif
+
+
+      deallocate(corzin,hwllin)
+      if (isig>1) deallocate(vscalesin)
+      if ( var=='q' .or. var=='cw' ) deallocate(corq2)
+
+   enddo readloop
+   close(inerr)
+
+   return
+  end subroutine read_hsst_
+
+  subroutine berror_read_hsst_(iope,hsst)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    berror_read_hsst_     read hsst from berror_stats file
+!   prgmmr: xuli          org: np23                date: 2020-03-13
+!
+! program history log:
+!
+!   input argument list:
+!     iope        - mpi task handling i/o
+!
+!   output argument list:
+!     hsst      - sst bg error correlation length (km)
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+!$$$
+    use kinds, only: r_kind,i_kind,r_single
+    use gridmod, only: nlat,nlon
+    use mpimod, only: mpi_itype,mpi_rtype4,mpi_comm_world,mype
+    use jfunc, only: cwoption
+    implicit none
+
+!   Declare passed variables
+    integer(i_kind),                       intent(in)  :: iope
+    real(r_single),  dimension(nlat,nlon), intent(out) :: hsst
+
+!   Declare local variables
+    integer(i_kind):: iret,npts
+
+!-----------------------------------------------------------------------------
+!   Read surface history file on processor iope
+    if(mype == iope)then
+       call read_hsst_(hsst,cwoption)
+       write(*,*) 'read hsst from berror_stats'
+    endif
+
+!   Load onto all processors
+    npts=nlat*nlon
+    call mpi_bcast(hsst,npts,mpi_rtype4,iope,mpi_comm_world,iret)
+  end subroutine berror_read_hsst_
 
   subroutine read_nst_ (tref,dt_cool,z_c,dt_warm,z_w,c_0,c_d,w_0,w_d)
 

--- a/src/gsi/qcmod.f90
+++ b/src/gsi/qcmod.f90
@@ -580,7 +580,7 @@ contains
       tzchk = 0.50_r_kind
     elseif ( obstype == 'amsua' .or. obstype == 'ssmis' .or. obstype == 'ssmi' ) then
       tzchk = 0.12_r_kind
-    elseif (  obstype == 'avhrr' .or. obstype == 'avhrr_navy' ) then 
+    elseif (  obstype == 'avhrr' .or. obstype == 'avhrr_navy' .or. obstype == 'viirs') then 
       tzchk = 0.85_r_kind
     elseif (  obstype == 'hirs2' .or. obstype == 'hirs3' .or. obstype == 'hirs4' .or. & 
               obstype == 'sndr' .or. obstype == 'sndrd1' .or. obstype == 'sndrd2'.or. &

--- a/src/gsi/radiance_mod.f90
+++ b/src/gsi/radiance_mod.f90
@@ -322,6 +322,7 @@ contains
 !   2018-04-04  zhu -- move rad_type_info(k)%cclr and rad_type_info(k)%ccld to this subroutine
 !   2018-04-06  derber -- change rad_type_info(k)%cclr default value from zero to a large number
 !   2019-03-21  Wei/Martin - fix capabilities for AOD assimilation
+!   2021-03-05  X.Li - add viirs (viirs-m with sstviirs data set)
 !
 !   input argument list:
 !
@@ -401,6 +402,7 @@ contains
        if (index(dtype(i),'sndr') /= 0)   rtype(i)='sndr'
        if (index(dtype(i),'hirs') /= 0)   rtype(i)='hirs'
        if (index(dtype(i),'avhrr') /= 0)  rtype(i)='avhrr'
+       if (index(dtype(i),'viirs-m') /= 0)  rtype(i)='viirs'
        if (index(dtype(i),'modis') /= 0)  rtype(i)='modis'
        if (index(dtype(i),'seviri') /= 0) rtype(i)='seviri'
 
@@ -411,7 +413,7 @@ contains
           rtype(i) == 'avhrr'  .or. rtype(i) == 'amsre'    .or.  rtype(i) == 'ssmis'  .or. & 
           rtype(i) == 'ssmi'   .or. rtype(i) == 'atms'     .or.  rtype(i) == 'cris'   .or. & 
           rtype(i) == 'amsr2'  .or. rtype(i) == 'gmi'      .or.  rtype(i) == 'saphir' .or. &
-          rtype(i) == 'cris-fsr' .or. rtype(i) == 'abi' ) then
+          rtype(i) == 'cris-fsr' .or. rtype(i) == 'abi'    .or.  rtype(i) == 'viirs' ) then
           drtype(i)='rads'
        end if
     end do

--- a/src/gsi/radinfo.f90
+++ b/src/gsi/radinfo.f90
@@ -1690,7 +1690,7 @@ contains
    logical mean_only
    logical ssmi,ssmis,amsre,amsre_low,amsre_mid,amsre_hig,tmi,gmi,amsr2,saphir
    logical ssmis_las,ssmis_uas,ssmis_env,ssmis_img
-   logical avhrr,avhrr_navy,goessndr,goes_img,ahi,seviri,abi
+   logical avhrr,avhrr_navy,goessndr,goes_img,ahi,seviri,abi,viirs
 
    character(len=20):: obstype,platid
    character(len=20):: satsens,satsens_id
@@ -1872,6 +1872,7 @@ contains
       ahi        = obstype == 'ahi'
       abi        = obstype == 'abi'
       avhrr      = obstype == 'avhrr'
+      viirs      = obstype == 'viirs-m'
       avhrr_navy = obstype == 'avhrr_navy'
       ssmi       = obstype == 'ssmi'
       amsre_low  = obstype == 'amsre_low'

--- a/src/gsi/read_viirs.f90
+++ b/src/gsi/read_viirs.f90
@@ -1,58 +1,25 @@
-subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
+subroutine read_sst_viirs(mype,val_viirs,ithin,rmesh,jsatid,&
      gstime,infile,lunout,obstype,nread,ndata,nodata,twind,sis, &
      mype_root,mype_sub,npe_sub,mpi_comm_sub,nobs, &
      nrec_start,dval_use)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
-! subprogram:    read_avhrr_gac                  read gac avhrr data
-!   prgmmr: li, xu           org: np23                date: 2005-10-20
+! subprogram:  read_sst_viirs,  read M-Band (12, 15 and 16) VIIRS radiance data from the SST VIIRS data file
 !
-! abstract:  This routine reads BUFR format AVHRR GAC 1b radiance (brightness
-!            temperature) files, which are bufrized from the NESDIS 1b data.  Optionally, the
-!            data are thinned to a specified resolution using simple
-!            quality control checks.
+!   prgmmr: li, xu           org: np23                date: 2019-08-29
+!
+! abstract:  This routine reads BUFR format VIIRS 1b radiance (brightness
+!            temperature) from the SST VIIRS files
 !
 !            When running the gsi in regional mode, the code only
 !            retains those observations that fall within the regional
 !            domain
 !
 ! program history log:
-!   2005-10-20  li
-!   2005-11-29  parrish - modify getsfc to work for different regional options
-!   2006-02-01  parrish - remove getsfc (different version called now in read_obs)
-!   2006-02-03  derber  - modify for new obs control and obs count
-!   2006-04-27  derber  - clean up code
-!   2006-05-19  eliu    - add logic to reset relative weight when all channels not used
-!   2006-07-28  derber  - add solar and satellite azimuth angles remove isflg from output
-!   2007-03-01  tremolet - measure time from beginning of assimilation window
-!   2007-03-28  derber  - add CLAVR (CLAVR cloud flag)
-!   2008-04-21  safford - rm unused vars and uses
-!   2008-10-10  derber  - modify to allow mpi_io
-!   2008-12-30  todling - memory leak fix (data_crit)
-!   2009-04-21  derber  - add ithin to call to makegrids
-!   2011-04-08  li      - (1) use nst_gsi, nstinfo, fac_dtl, fac_tsl and add NSST vars 
-!                         (2) get zob, tz_tr (call skindepth and cal_tztr)
-!                         (3) interpolate NSST Variables to Obs. location (call deter_nst)
-!                         (4) add more elements (nstinfo) in data array
-!                         (5) add observation scoring for thinning
-!   2011-08-01  lueken  - added module use deter_sfc_mod, fixed indentation
-!   2012-03-05  akella  - nst now controlled via coupler
-!   2013-01-22  zhu     - add newpc4pred option
-!   2013-01-26  parrish - change from grdcrd to grdcrd1 (to allow successful debug compile on WCOSS)
-!   2013-02-16  akella  - only 1 processor should check for bad obs and write out data_all 
-!                         after call to combine_radobs. Clean up for retrieval case.
-!                         Add call to checkob. Bug fix for scoring of obs, by including newchn,
-!                         also add another ob scoring approach based on observed Tb only.
-!                         add check: bufsat(jsatid) == satellite id
-!   2015-02-23  Rancic/Thomas - add thin4d to time window logical
-!   2015-10-01  guo     - consolidate use of ob location (in deg)
-!   2018-05-21  j.jin   - added time-thinning. Moved the checking of thin4d into satthin.F90.
-!   2021-02-21  x.li    - modifying thinning scheme
-!  
 !
 !   input argument list:
 !     mype     - mpi task id
-!     val_avhrr- weighting factor applied to super obs
+!     val_viirs- weighting factor applied to super obs
 !     ithin    - flag to thin data
 !     rmesh    - thinning mesh size (km)
 !     jsatid   - satellite to read
@@ -65,9 +32,9 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
 !     nrec_start - first subset with useful information
 !
 !   output argument list:
-!     nread    - number of BUFR GAC AVHRR observations read
-!     ndata    - number of BUFR GAC AVHRR profiles retained for further processing
-!     nodata   - number of BUFR GAC AVHRR observations retained for further processing
+!     nread    - number of BUFR VIIRS observations read
+!     ndata    - number of BUFR VIIRS profiles retained for further processing
+!     nodata   - number of BUFR VIIRS observations retained for further processing
 !     nobs     - array of observations on each subdomain for each processor
 !
 ! attributes:
@@ -79,68 +46,61 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
   use satthin, only: super_val,itxmax,makegrids,map2tgrid,destroygrids, &
                      checkob, finalcheck,score_crit
   use satthin, only: radthin_time_info,tdiff2crit
-  use obsmod,  only: time_window_max
+  use obsmod,  only: time_window_max,ianldate
   use satthin, only: hsst
   use gridmod, only: diagnostic_reg,regional,nlat,nlon,tll2xy,txy2ll,rlats,rlons
   use constants, only: deg2rad, zero, one, two, half, rad2deg, r60inv
-! use radinfo, only: cbias,predx,air_rad,ang_rad,newpc4pred
-  use radinfo, only: retrieval,iuse_rad,jpch_rad,nusis, &
-                     newchn
+  use radinfo, only: iuse_rad,jpch_rad,nusis
   use gsi_4dvar, only: l4dvar,l4densvar,iwinbgn,winlen
   use deter_sfc_mod, only: deter_sfc
   use obsmod, only: bmiss
   use gsi_nstcouplermod, only: nst_gsi,nstinfo
   use gsi_nstcouplermod, only: gsi_nstcoupler_skindepth, gsi_nstcoupler_deter
+  use sfcobsqc, only: get_sunangle
   use mpimod, only: npe
-
-! use radiance_mod, only: rad_obs_type
   implicit none
 
 
 ! Declare passed variables
-  character(len=*), intent(in  ) :: infile,obstype,jsatid
-  character(len=20),intent(in  ) :: sis
-  integer(i_kind) ,intent(in   ) :: mype,lunout,ithin,nrec_start
-  integer(i_kind) ,intent(inout) :: nread
-  integer(i_kind),dimension(npe) ,intent(inout) :: nobs
-  integer(i_kind) ,intent(inout) :: ndata,nodata
-  real(r_kind)    ,intent(in   ) :: rmesh,gstime,twind
-  real(r_kind)    ,intent(inout) :: val_avhrr
-  integer(i_kind) ,intent(in   ) :: mype_root
-  integer(i_kind) ,intent(in   ) :: mype_sub
-  integer(i_kind) ,intent(in   ) :: npe_sub
-  integer(i_kind) ,intent(in   ) :: mpi_comm_sub
-  logical         ,intent(in   ) :: dval_use
+  character(len=*),                intent(in  )  :: infile,obstype,jsatid
+  character(len=20),               intent(in  )  :: sis
+  integer(i_kind),                 intent(in  )  :: mype,lunout,ithin,nrec_start
+  integer(i_kind),                 intent(inout) :: nread
+  integer(i_kind), dimension(npe), intent(inout) :: nobs
+  integer(i_kind),                 intent(inout) :: ndata,nodata
+  real(r_kind),                    intent(in   ) :: rmesh,gstime,twind
+  real(r_kind),                    intent(inout) :: val_viirs
+  integer(i_kind),                 intent(in   ) :: mype_root
+  integer(i_kind),                 intent(in   ) :: mype_sub
+  integer(i_kind),                 intent(in   ) :: npe_sub
+  integer(i_kind),                 intent(in   ) :: mpi_comm_sub
+  logical,                         intent(in   ) :: dval_use
 
 ! Declare local parameters
-  character(6),parameter:: file_sst='SST_AN'
-  integer(i_kind),parameter:: mlat_sst = 3000
-  integer(i_kind),parameter:: mlon_sst = 5000
   real(r_kind),parameter:: r6=6.0_r_kind
-  real(r_kind),parameter:: scan_start=-52.612_r_kind, scan_inc=1.182_r_kind
+  real(r_kind),parameter:: scan_start=-56.28_r_kind, scan_inc=1.26472_r_kind
   real(r_double),parameter:: r360=360.0_r_double
   real(r_kind),parameter:: tbmin=50.0_r_kind
   real(r_kind),parameter:: tbmax=550.0_r_kind
 
-  real(r_kind),parameter :: ngac=409.0_r_kind,nfov=90.0_r_kind,cut_spot=11.0_r_kind
+  real(r_kind),parameter :: r_earth=6370.0_r_kind, sat_hgt=829.0_r_kind
+  real(r_kind),parameter :: nviirs=6304.0_r_kind,nfov=90.0_r_kind
   character(len=80),parameter ::  &
-     headr='YEAR MNTH DAYS HOUR MINU SECO CLATH CLONH SAID FOVN SAZA SOZA CLAVR'
+     headr='YEAR MNTH DAYS HOUR MINU SECO CLATH CLONH SAID SAZA'
 
 ! Declare local variables  
   logical outside,iuse,assim
   character(len=8) :: subset
-
   integer(i_kind) :: nmesh
+
   integer(i_kind) klon1,klatp1,klonp1,klat1
-  integer(i_kind) nchanl,iret,ifov, ich4, ich_offset
-! integer(i_kind) ich_win
+  integer(i_kind) nchanl,iret,ich_m15
   integer(i_kind) idate,maxinfo
   integer(i_kind) ilat,ilon
   integer(i_kind),dimension(5):: idate5
   integer(i_kind) nmind,isflg,idomsfc
   integer(i_kind) itx,k,i,bufsat,n
   integer(i_kind) nreal,nele,itt
-  integer(i_kind) nlat_sst,nlon_sst
   integer(i_kind) ksatid
 
   real(r_kind) dlon,dlat,rsc
@@ -148,55 +108,47 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
   real(r_kind) dlon_earth_deg,dlat_earth_deg
   real(r_kind) w00,w01,w10,w11,dx1,dy1
   real(r_kind) pred,crit1,tdiff,sstime,dx,dy,dist1
-  real(r_kind) dlat_sst,dlon_sst,sst_hires
   real(r_kind) t4dv
 
   real(r_kind),dimension(0:4):: rlndsea
   real(r_kind),dimension(0:3):: sfcpct
   real(r_kind),dimension(0:3):: ts
-  real(r_kind),dimension(mlat_sst):: rlats_sst
-  real(r_kind),dimension(mlon_sst):: rlons_sst
-  real(r_kind),allocatable,dimension(:,:):: sst_an
-  real(r_kind), allocatable, dimension(:,:) :: data_mesh
-  real(r_kind), allocatable, dimension(:,:) :: data_all
+  real(r_kind),allocatable,dimension(:,:):: data_mesh
+  real(r_kind),allocatable,dimension(:,:):: data_all
   real(r_kind) :: tsavg,vty,vfr,sty,stp,sm,sn,zz,ff10
   real(r_kind) :: zob,tref,dtw,dtc,tz_tr
-  real(r_kind) :: scan_pos,scan_angle,dfov,r01
-! real(r_kind) :: ch_win,ch_win_flg
+  real(r_kind) :: scan_ang,sat_zen,dfov,r01
+  real(r_single) :: sol_zen
+  integer(i_kind) :: scan_pos
 
-  real(r_double), dimension(13) :: hdr
-  real(r_double), dimension(3,5) :: bufrf
-  integer(i_kind) :: lnbufr,ireadsb,ireadmg,iskip,irec,next
-  integer(i_kind), allocatable, dimension(:) :: nrec
+  real(r_double), dimension(10) :: hdr
+  real(r_double), dimension(2,3) :: bufrf
+  integer(i_kind) lnbufr,ireadsb,ireadmg,iskip,irec,next
+  integer(i_kind),allocatable,dimension(:)::nrec
   real(r_kind), allocatable, dimension(:) :: amesh
   real(r_kind), allocatable, dimension(:) :: hsst_thd
 
   real(r_kind) cdist,disterr,disterrmax,dlon00,dlat00,hsst_xy,dmsh
   integer(i_kind) ntest
   integer(i_kind) :: imesh,ndata_mesh,iele
-
-! real(r_kind), dimension(3,2) :: bandcor_a,bandcor_b
-! data bandcor_a/-1.70686_r_kind,-0.27201_r_kind,-0.30949_r_kind,-1.70388_r_kind,-0.43725_r_kind,-0.25342_r_kind/
-! data bandcor_b/1.002629_r_kind,1.001207_r_kind,1.000989_r_kind,1.003049_r_kind,1.001395_r_kind,1.000944_r_kind/
   real(r_kind)    :: ptime,timeinflat,crit0
   integer(i_kind) :: ithin_time,n_tbin,it_mesh
 
 !**************************************************************************
 
 ! Start routine here.  Set constants.  Initialize variables
-  maxinfo = 33
+  maxinfo = 31
   lnbufr = 10
   disterrmax=zero
   ntest=0
   ndata  = 0
   nodata  = 0
   nread   = 0
-  nchanl = 3
-  ich_offset    = 2               ! avhrr, channels 1 & 2 are skipped
-  ich4          = ich_offset + 2
+  nchanl = 5
+  ich_m15    = 2
   r01 = 0.01_r_kind
 
-  if ( rmesh == 888.0_r_kind ) then
+  if ( rmesh == 888 ) then
      nmesh = 6
      allocate(amesh(nmesh),hsst_thd(0:nmesh))
 !
@@ -212,7 +164,7 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
      hsst_thd(0) = max(two,half*amesh(1))
      hsst_thd(nmesh) = 2000.0_r_kind
      do imesh = 1, nmesh - 1
-        hsst_thd(imesh) = amesh(imesh) + half*dmsh 
+        hsst_thd(imesh) = amesh(imesh) + half*dmsh
      enddo
 
   else
@@ -223,7 +175,7 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
      hsst_thd(1) = 2000.0_r_kind
   endif
 
-  dfov = (ngac - two*cut_spot - one)/nfov
+  dfov = (nviirs - one)/nfov
 
   ilon=3
   ilat=4
@@ -238,16 +190,16 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
   rlndsea(3) = 30._r_kind
   rlndsea(4) = 30._r_kind
 
-                                        ! 205,206,207,208 or 209 for  NOAA-14,15,16,17, 18 and 19 respectively
-  if(jsatid == 'n14')bufsat = 205
-  if(jsatid == 'n15')bufsat = 206
-  if(jsatid == 'n16')bufsat = 207
-  if(jsatid == 'n17')bufsat = 208
-  if(jsatid == 'n18')bufsat = 209
-  if(jsatid == 'n19')bufsat = 223
-  if(jsatid == 'metop-a')bufsat = 4
-  if(jsatid == 'metop-b')bufsat = 3
-  if(jsatid == 'metop-c')bufsat = 5
+  if (jsatid == 'npp') then
+     bufsat = 224
+  elseif (jsatid == 'j1') then
+     bufsat = 225
+  elseif (jsatid == 'n21') then
+     bufsat = 226
+  else
+     write(*,*) 'READ_SST_VIIRS: Unrecognized value for jsatid '//jsatid//':RETURNING'
+     return
+  end if
 
 ! If all channels of a given sensor are set to monitor or not
 ! assimilate mode (iuse_rad<1), reset relative weight to zero.
@@ -261,22 +213,15 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
         exit search
      endif
   end do search
-  if (.not.assim) val_avhrr=zero
+  if (.not.assim) val_viirs=zero
 
   call radthin_time_info(obstype, jsatid, sis, ptime, ithin_time)
   if( ptime > 0.0_r_kind) then
-     n_tbin=nint(2*time_window_max/ptime)
+     n_tbin=nint(two*time_window_max/ptime)
   else
      n_tbin=1
   endif
 
-! Read hi-res sst analysis
-  if (retrieval) then
-     allocate(sst_an(mlat_sst, mlon_sst))
-     call rdgrbsst(file_sst,mlat_sst,mlon_sst,&
-     sst_an,rlats_sst,rlons_sst,nlat_sst,nlon_sst)
-  endif
-     
 ! Allocate arrays to hold all data for given satellite
   if(dval_use) maxinfo = maxinfo + 2
   nreal = maxinfo + nstinfo
@@ -285,7 +230,7 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
   ndata = 0
   do imesh = 1, nmesh
 !    Make thinning grids, including determination of itxmax
-     call makegrids(amesh(imesh),ithin,n_tbin=n_tbin)
+     call makegrids(amesh(imesh),ithin)
 
      allocate( data_mesh(nele,itxmax) )
      allocate( nrec(itxmax) )
@@ -303,43 +248,40 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
      next=0
      nrec=999999
      irec=0
-!    Read BUFR AVHRR GAC 1b data
+!    Read BUFR VIIRS 1b data
      read_msg: do while (ireadmg(lnbufr,subset,idate) >= 0)
+
         irec=irec+1
         if(irec < nrec_start) cycle read_msg
         next=next+1
         if(next == npe_sub)next=0
         if(next /= mype_sub)cycle
         read_loop: do while (ireadsb(lnbufr) == 0)
-           call ufbint(lnbufr,hdr,13,1,iret,headr)
-           call ufbrep(lnbufr,bufrf, 3,5,iret,'INCN ALBD TMBR')
+           call ufbint(lnbufr,hdr,10,1,iret,headr)
+           call ufbrep(lnbufr,bufrf,2,3,iret,'CHNM TMBR')
            if(iret <= 0) cycle read_loop
            ksatid  = nint(hdr(9))                ! Extract satellite id from bufr file
            if(ksatid /= bufsat) cycle read_loop  ! If this sat is not the one we want, read next record
-           if (hdr(10) <= real(cut_spot) .or. hdr(10) > real(ngac-cut_spot)) cycle read_loop! drop starting and ending pixels
-           if (hdr(13) /= zero ) cycle read_loop ! toss pixel with CLAVR partly cloud flag
-
+ 
            iskip = 0
-           do k=1,nchanl
-              if(bufrf(3,ich_offset+k) < zero .or. bufrf(3,ich_offset+k) > tbmax) then
+           do k=1,nchanl-2
+              if(bufrf(2,k) < zero .or. bufrf(2,k) > tbmax) then
                  iskip=iskip+1
               end if
            end do
            if(iskip >= nchanl)cycle read_loop
 
-!          Get lat/lon in degree          
+!          Convert obs location to radians
            if (abs(hdr(7))>90.0_r_double .or. abs(hdr(8))>r360) cycle read_loop
-
            if (hdr(8)==r360) hdr(8)=hdr(8)-r360
            if (hdr(8)< zero) hdr(8)=hdr(8)+r360
 
            dlon_earth_deg = hdr(8)
            dlat_earth_deg = hdr(7)
 
-!          Convert obs location to radians
            dlon_earth = hdr(8)*deg2rad   !convert degrees to radians
            dlat_earth = hdr(7)*deg2rad
-
+           sat_zen =  hdr(10)
 !          Regional case
            if(regional)then
               call tll2xy(dlon_earth,dlat_earth,dlon,dlat,outside)
@@ -354,7 +296,7 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
               end if
               if(outside) cycle read_loop
 
-!          Global casea: Get relative lat/lon in analysis grids
+!          Global case
            else
               dlat = dlat_earth
               dlon = dlon_earth
@@ -363,7 +305,6 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
            endif
 
 !          Interpolate hsst(nlat,nlon) to obs.location
-           if ( rmesh == 888.0_r_kind ) then
            klon1=int(dlon); klat1=int(dlat)
            dx  =dlon-klon1; dy  =dlat-klat1
            dx1 =one-dx;         dy1 =one-dy
@@ -377,11 +318,10 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
            hsst_xy=w00*hsst(klat1,klon1 ) + w10*hsst(klatp1,klon1 ) + &
                    w01*hsst(klat1,klonp1) + w11*hsst(klatp1,klonp1)
 !
-!          Only process the obs. at the location where hsst is in the current processed range
+!          Only process the obs. at the location where hsst is in the current
+!          processed range
 !
            if ( hsst_xy < hsst_thd(imesh-1) .or. hsst_xy >= hsst_thd(imesh) ) cycle read_loop
-
-           endif
 
 !          Extract date information.  If time outside window, skip this obs
            idate5(1) = nint(hdr(1))    !year
@@ -403,7 +343,7 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
 
            nread = nread + 1
 !
-!          map observations to the thinning grid 
+!          map observations to the thinning grid
 !
            crit0 = 0.01_r_kind
            timeinflat=6.0_r_kind
@@ -424,76 +364,39 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
 !                3 snow
 !                4 mixed                          
 
+
            call deter_sfc(dlat,dlon,dlat_earth,dlon_earth,t4dv,isflg,idomsfc,sfcpct, &
-              ts,tsavg,vty,vfr,sty,stp,sm,sn,zz,ff10,sfcr)
-!          if(isflg /= zero)  cycle read_loop
+                       ts,tsavg,vty,vfr,sty,stp,sm,sn,zz,ff10,sfcr)
            if(sfcpct(0) < 0.15_r_kind)  cycle read_loop
 
            call checkob(dist1,crit1,itx,iuse)
            if(.not. iuse)cycle read_loop
-!
-!       Get scan position (1 - 90) based on (409 - 2*cut_spot - 1) = 386 here,  GAC pixels
-!       avhrr gac scan has 409 positions. we drop tails: 1- 11 & 399- 409 [the two ends]
-!       here we linearly map pixels: 12- 398 to 1 - 90 scan positions
-           if ( mod(hdr(10)-cut_spot,dfov) < half*dfov ) then
-              scan_pos = real(nint((hdr(10)-cut_spot)/dfov) + 1) 
-           else
-              scan_pos = real(nint((hdr(10)-cut_spot)/dfov)) 
-           endif
 
-           if ( scan_pos > nfov ) scan_pos = nfov
-
-           ifov = nint(scan_pos)
-           scan_angle = (scan_start+real(ifov-1)*scan_inc)*deg2rad
 
 !          Set common predictor parameters
 
 !          Compute "score" for observation.  All scores>=0.0.  Lowest score is "best"
 
-!          if (newpc4pred) then
-!             ch_win = bufrf(3,2+ich_win) -ang_rad(ich_win)*cbias(ifov,ich_win)- &
-!                         predx(1,ich_win)*air_rad(ich_win)
-!          else
-!             ch_win = bufrf(3,2+ich_win) -ang_rad(ich_win)*cbias(ifov,ich_win)- &
-!                         r01*predx(1,ich_win)*air_rad(ich_win)
-!          end if
-!          ch_win_flg = tsavg-ch_win
-!          pred   = 10.0_r_kind*max(zero,ch_win_flg)
-
-!          above commented calculation of pred uses tsavg (from bkg). There is no reason why
-!          1. we should use bkg to SCORE an ob., 2. even if we do use bkg based tsavg, 
-!          tsavg-ch_win could be misleading, if there are low clouds. 
-!          instead we will TRY following simpler approach- so that ob with colder Tb gets a high score.
-           pred   = (600.0_r_kind - bufrf(3,ich4)) * r01
+           pred   = (600.0_r_kind - bufrf(2,ich_m15)) * r01
 
            crit1=crit1+rlndsea(isflg)
            crit1 = crit1+pred  
            call finalcheck(dist1,crit1,itx,iuse)
 
            if(.not. iuse)cycle read_loop
-
-           if (retrieval) then
-!             Interpolate hi-res sst analysis to observation location
-              dlat_sst = dlat_earth
-              dlon_sst = dlon_earth
-              call grdcrd1(dlat_sst,rlats_sst,nlat_sst,1)
-              call grdcrd1(dlon_sst,rlons_sst,nlon_sst,1)
-
-              klon1=int(dlon_sst); klat1=int(dlat_sst)
-              dx  =dlon_sst-klon1; dy  =dlat_sst-klat1
-              dx1 =one-dx;         dy1 =one-dy
-              w00=dx1*dy1; w10=dx1*dy; w01=dx*dy1; w11=dx*dy
-
-              klat1=min(max(1,klat1),nlat_sst); klon1=min(max(0,klon1),nlon_sst)
-              if(klon1==0) klon1=nlon_sst
-              klatp1=min(nlat_sst,klat1+1); klonp1=klon1+1
-              if(klonp1==nlon_sst+1) klonp1=1
-
-              sst_hires=w00*sst_an(klat1,klon1 ) + w10*sst_an(klatp1,klon1 ) + &
-                        w01*sst_an(klat1,klonp1) + w11*sst_an(klatp1,klonp1)
-           else
-              sst_hires=zero
-           endif       !  if (retrieval) then
+!
+!          calculate scan angle
+!
+           scan_ang = asin(r_earth/(r_earth+sat_hgt)*sin(sat_zen*deg2rad))/deg2rad
+!
+!          get scan position (1 to 90) 
+!
+           scan_pos = 1+(scan_ang-scan_start)/scan_inc
+           if ( scan_pos > nfov ) scan_pos = nfov
+!
+!          calculate solar zenith angle
+!
+           call get_sunangle(ianldate,t4dv,dlon_earth,dlat_earth,sol_zen)
 !
 !       interpolate NSST variables to Obs. location and get dtw, dtc, tz_tr
 !
@@ -508,16 +411,16 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
            endif
            
 !          Transfer information to work array
-           data_mesh(1, itx) = hdr(9)                 ! satellite id (207 = NOAA-16, 208 = NOAA-17, 209 = NOAA-18)
+           data_mesh(1, itx) = hdr(9)                 ! satellite id 
            data_mesh(2, itx) = t4dv                   ! time (hours)
            data_mesh(3, itx) = dlon                   ! grid relative longitude
            data_mesh(4, itx) = dlat                   ! grid relative latitude
-           data_mesh(5, itx) = hdr(11)*deg2rad        ! satellite zenith angle (radians)
-           data_mesh(6, itx) = bmiss                  ! satellite azimuth angle
-           data_mesh(7, itx) = scan_angle             ! scan angle
-           data_mesh(8, itx) = scan_pos               ! scan position
-           data_mesh(9, itx) = hdr(12)                ! solar zenith angle (radians)
-           data_mesh(10,itx) = bmiss                  ! solar azimuth angle (radians)
+           data_mesh(5, itx) = sat_zen*deg2rad        ! satellite zenith angle (radians)
+           data_mesh(6, itx) = bmiss                  ! satellite azimuth angle (degree)
+           data_mesh(7, itx) = scan_ang*deg2rad       ! scan angle (radians)
+           data_mesh(8, itx) = real(scan_pos)         ! scan position
+           data_mesh(9, itx) = 90.0_r_kind-sol_zen    ! solar zenith angle (degree)
+           data_mesh(10,itx) = bmiss                  ! solar azimuth angle (degree)
            data_mesh(11,itx) = sfcpct(0)              ! sea percentage of
            data_mesh(12,itx) = sfcpct(1)              ! land percentage
            data_mesh(13,itx) = sfcpct(2)              ! sea ice percentage
@@ -539,36 +442,39 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
            data_mesh(29,itx) = ff10                   ! ten meter wind factor
            data_mesh(30,itx) = dlon_earth_deg         ! earth relative longitude (degrees)
            data_mesh(31,itx) = dlat_earth_deg         ! earth relative latitude (degrees)
-           data_mesh(32,itx) = hdr(13)                ! CLAVR Cloud flag (only 0 = clear and 1 = probably clear included the data set used now)
-           data_mesh(33,itx) = sst_hires              ! interpolated hires SST (deg K)
            if(dval_use)then
-              data_mesh(34,itx) = val_avhrr              ! weighting factor applied to super obs
-              data_mesh(35,itx) = itt                    !
+              data_mesh(32,itx) = val_viirs           ! weighting factor applied to super obs
+              data_mesh(33,itx) = itt                 !
            end if
 
            if(nst_gsi>0) then
-              data_mesh(maxinfo+1,itx) = tref            ! foundation temperature
-              data_mesh(maxinfo+2,itx) = dtw             ! dt_warm at zob
-              data_mesh(maxinfo+3,itx) = dtc             ! dt_cool at zob
-              data_mesh(maxinfo+4,itx) = tz_tr           ! d(Tz)/d(Tr)
+              data_mesh(maxinfo+1,itx) = tref         ! foundation temperature
+              data_mesh(maxinfo+2,itx) = dtw          ! dt_warm at zob
+              data_mesh(maxinfo+3,itx) = dtc          ! dt_cool at zob
+              data_mesh(maxinfo+4,itx) = tz_tr        ! d(Tz)/d(Tr)
            endif
-   
-           do k=1,nchanl
-              data_mesh(k+nreal,itx)= bufrf(3,ich_offset+k) ! Tb for avhrr ch-3, ch-4 and ch-5; ich_offset is set to 2.
-           end do
+
+           data_mesh(1+nreal,itx) = bufrf(2,1)
+           data_mesh(2+nreal,itx) = bmiss
+           data_mesh(3+nreal,itx) = bmiss
+           data_mesh(4+nreal,itx) = bufrf(2,2)
+           data_mesh(5+nreal,itx) = bufrf(2,3)
+
            nrec(itx)=irec
 
-!       End of satellite read block
+!    End of satellite read block
 
         enddo read_loop
      enddo read_msg
      call closbf(lnbufr)
 
+
+
      call combine_radobs(mype_sub,mype_root,npe_sub,mpi_comm_sub,&
           nele,itxmax,nread,ndata_mesh,data_mesh,score_crit,nrec)
 
      if ( nread > 0 ) then
-        write(*,'(a,a10,I3,F6.1,3I10)') 'read_avhrr,satid,imesh,amesh,itxmax,nread,ndata_mesh : ',jsatid,imesh,amesh(imesh),itxmax,nread,ndata_mesh
+        write(*,'(a,a10,I3,F6.1,3I10)') 'read_viirs,jsatid,imesh,amesh,itxmax,nread,ndata_mesh :',jsatid,imesh,amesh(imesh),itxmax,nread,ndata_mesh
      endif
 !
 !    get data_all by combining data from all thinning box sizes
@@ -586,6 +492,7 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
 
   enddo     ! do imesh = 1, nmesh
 
+
 ! Allow single task to check for bad obs, update superobs sum,
 ! and write out data to scratch file for further processing.
   if (mype_sub==mype_root.and.ndata>0) then
@@ -597,8 +504,8 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
      end do
      if(dval_use .and. assim)then
         do n=1,ndata
-           itt=nint(data_all(35,n))
-           super_val(itt)=super_val(itt)+val_avhrr
+           itt=nint(data_all(33,n))
+           super_val(itt)=super_val(itt)+val_viirs
         end do
      end if
  
@@ -610,12 +517,11 @@ subroutine read_avhrr(mype,val_avhrr,ithin,rmesh,jsatid,&
 
 ! Deallocate local arrays
   deallocate(data_all)
-  if(retrieval) deallocate(sst_an)
 
   if(diagnostic_reg.and.ntest>0 .and. mype_sub==mype_root) &
-     write(6,*)'READ_AVHRR:  ',&
+     write(6,*)'READ_VIIRS-M:  ',&
      'mype,ntest,disterrmax=',mype,ntest,disterrmax
 
 ! End of routine
   return
-end subroutine read_avhrr
+end subroutine read_sst_viirs

--- a/src/gsi/satthin.F90
+++ b/src/gsi/satthin.F90
@@ -142,6 +142,7 @@ module satthin
   public :: makegvals
   public :: makegrids
   public :: getsfc
+  public :: get_hsst
   public :: map2tgrid
   public :: destroygrids
   public :: destroy_sfc
@@ -154,6 +155,7 @@ module satthin
   public :: fact10_full,isli_full,soil_moi_full,veg_frac_full,soil_temp_full
   public :: isli_anl,sno_anl
   public :: checkob,score_crit,itxmax,finalcheck,zs_full_gfs,zs_full
+  public :: hsst
 
   integer(i_kind) mlat,superp,maxthin,itxmax
   integer(i_kind) itxmax0
@@ -183,6 +185,8 @@ module satthin
   integer(i_kind),allocatable, dimension(:,:)   :: isli_anl
 ! declare local array sno_anl 
   real(r_single),allocatable, dimension(:,:,:)   :: sno_anl
+! declare the dummy variables of routine berror_read_hsst
+  real(r_single), allocatable, dimension(:,:) :: hsst
 
   logical use_all
 
@@ -470,6 +474,22 @@ contains
 
     return
   end subroutine makegrids
+
+  subroutine get_hsst(mype_io)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    get_hsst
+!     prgmmr:    Xu     org: np23                date: 2020-03-13
+!
+! abstract:  read hsst from berror_stats
+  use gridmod, only:  nlat,nlon
+  use ncepnems_io, only: berror_read_hsst
+  integer(i_kind), intent(in) :: mype_io
+
+  allocate(hsst(nlat,nlon))
+  call berror_read_hsst(mype_io,hsst)
+
+  end subroutine get_hsst
 
   subroutine getsfc(mype,mype_io,use_sfc,use_sfc_any)
 !$$$  subprogram documentation block

--- a/src/gsi/setuprad.f90
+++ b/src/gsi/setuprad.f90
@@ -215,6 +215,7 @@ contains
 !   2019-03-13  eliu    - add calculation of scattering index for MHS/ATMS 
 !   2019-03-27  h. liu  - add ABI assimilation
 !   2019-08-20  zhu     - add flexibility to allow radiances being assimilated without bias correction
+!   2021-02-20  x.li    - add viirs
 !
 !  input argument list:
 !     lunin   - unit from which to read radiance (brightness temperature, tb) obs
@@ -361,7 +362,7 @@ contains
   logical cao_flag                       
   logical hirs2,msu,goessndr,hirs3,hirs4,hirs,amsua,amsub,airs,hsb,goes_img,ahi,mhs,abi
   type(sparr2) :: dhx_dx
-  logical avhrr,avhrr_navy,lextra,ssu,iasi,cris,seviri,atms
+  logical avhrr,avhrr_navy,viirs,lextra,ssu,iasi,cris,seviri,atms
   logical ssmi,ssmis,amsre,amsre_low,amsre_mid,amsre_hig,amsr2,gmi,saphir
   logical ssmis_las,ssmis_uas,ssmis_env,ssmis_img
   logical sea,mixed,land,ice,snow,toss,l_may_be_passive,eff_area
@@ -497,6 +498,7 @@ contains
   goes_img   = obstype == 'goes_img'
   ahi        = obstype == 'ahi'
   avhrr      = obstype == 'avhrr'
+  viirs      = obstype == 'viirs-m'
   avhrr_navy = obstype == 'avhrr_navy'
   ssmi       = obstype == 'ssmi'
   amsre_low  = obstype == 'amsre_low'
@@ -1510,6 +1512,28 @@ contains
               wavenumber,ptau5,prsltmp,tvp,temp,wmix,emissivity_k,ts, &
               id_qc,aivals,errf,varinv,varinv_use,cld,cldp)
 
+        else if (viirs) then
+
+           frac_sea=data_s(ifrac_sea,n)
+
+!  NOTE:  use qc_avhrr for viirs qc
+           do i=1,nchanl
+              m=ich(i)
+              if (varinv(i) < tiny_r_kind) then
+                 varinv_use(i) = zero
+              else
+                 if ((icld_det(m)>0)) then
+                    varinv_use(i) = varinv(i)
+                 else
+                    varinv_use(i) = zero
+                 end if
+              end if
+           end do
+
+           call qc_avhrr(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse(n),   &
+              zsges,cenlat,frac_sea,pangs,trop5,tzbgr,tsavg5,tbc,tb_obs,tnoise, &
+              wavenumber,ptau5,prsltmp,tvp,temp,wmix,emissivity_k,ts, &
+              id_qc,aivals,errf,varinv,varinv_use,cld,cldp)
 
 !  ---------- SSM/I , SSMIS, AMSRE  -------------------
 !       SSM/I, SSMIS, & AMSRE Q C


### PR DESCRIPTION
This PR is to incorporate an NSST package into GSI master.

This package includes 4 items:

The update of the horizontal background error correlation length (hsst)
The reduction of the thinning mesh from 145 km to 70 km for AVHRR and VIIRS radiances. The capability to apply multiple and hsst dependent thinning mesh for AVHRR and VIIRS is included in the code changes and it is optional and controlled by dmesh (applied when it is 888.0). This option is tested with GFSv15.2 C768 but not in GFSv16.0 C384 experiment. 
The exclusion of the partly clear AVHRR radiance
The addition of VIIRS radiance, including NPP and J1/N20
This package has been tested with GFSv15.2 at full resolution (C768), the whole package and individual item. The results have shown a significant improved GFS NSST analysis. It has been tested with GFSv16.0 at C384, the evaluation shows the consistent improvement as seen with GFSv15.2 C768 experiments in terms of the NSST analysis, and also shows the impact on the weather prediction is neutral to positive. See #235 for the issue description and tests results.

The branch has been updated to the master (20211202), all the regression tests passed, except for global_4denvar_T126 and global_fv3_4denvar_T126. This is expected since the code changes to exclude the partly clear avhrr radiance and the threshold of the water surface type. These two tests passed by removing these two changes as shown in a test. Therefore, all regression tests are fine.

It is ready to merge into GSI master for the future GFSv16.5.