### PR TITLE
GitHub Issue NOAA-EMC/GSI#267. Corrected the OznMon and RadMon ports for S4 and Jet

### DIFF
--- a/util/Ozone_Monitor/data_xtrct/ush/find_cycle.pl
+++ b/util/Ozone_Monitor/data_xtrct/ush/find_cycle.pl
@@ -134,10 +134,13 @@
       do {
  
          $hr_ctr = $hr_ctr - 1;
-         
+
          $newdir = "${dirpath}/${sortmm[$ctr]}/${hrs[$hr_ctr]}/atmos/oznmon/time";
          if( ! -d $newdir ) {
             $newdir = "${dirpath}/${sortmm[$ctr]}/${hrs[$hr_ctr]}/oznmon/time";
+            if( ! -d $newdir ) {
+               $newdir = "${dirpath}/${sortmm[$ctr]}/time";
+            }
          }
 
          if( -d $newdir ) {

--- a/util/Ozone_Monitor/image_gen/ush/mk_err_rpt.sh
+++ b/util/Ozone_Monitor/image_gen/ush/mk_err_rpt.sh
@@ -116,6 +116,9 @@ fi
 
 
 OZN_TANKDIR_TIME=${TANKDIR}/${RUN}.${PDY}/${cyc}/oznmon/time
+if [[ ! -d ${OZN_TANKDIR_TIME} ]]; then
+   OZN_TANKDIR_TIME=${TANKDIR}/${RUN}.${PDY}/time
+fi
 echo "OZN_TANKDIR_TIME = $OZN_TANKDIR_TIME"
 
 
@@ -132,6 +135,9 @@ prev_pdy=`echo $prev_cycle | cut -c1-8`
 prev_cyc=`echo $prev_cycle | cut -c9-10`
 
 OZN_TANKDIR_PREV=${TANKDIR}/${RUN}.${prev_pdy}/${prev_cyc}/oznmon/time
+if [[ ! -d ${OZN_TANKDIR_PREV} ]]; then
+   OZN_TANKDIR_TIME=${TANKDIR}/${RUN}.${prev_pdy}/time
+fi
 echo "OZN_TANKDIR_PREV = $OZN_TANKDIR_PREV"
 
 prev_bad_cnt=`ls $OZN_TANKDIR_PREV/bad_cnt.${prev_cycle}`

--- a/util/Radiance_Monitor/build_RadMon_cmake.sh
+++ b/util/Radiance_Monitor/build_RadMon_cmake.sh
@@ -37,7 +37,7 @@ elif [[ -d /scratch1 ]] ; then
     . /apps/lmod/lmod/init/sh
     target=hera
 elif [[ -d /data ]] ; then
-    . /opt/apps/lmod/lmod/init/sh
+    . /usr/share/lmod/lmod/init/sh
     target=s4
 elif [[ -d /work ]]; then
     . $MODULESHOME/init/sh


### PR DESCRIPTION
This corrects the port of the OznMon and RadMon to S4 and Jet.  For OznMon, this adds the default global workflow `TANKDIR` template to the search path of find_cycle.pl and mk_err_rpt.sh.  For RadMon, it points to a newer `lmod` initialization script.  This addresses #267.