### PR TITLE
GitHub Issue NOAA-EMC/GSI#68. Switches assimilating Ta to Tb.

### DIFF
--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -461,6 +461,7 @@ for file in $(awk '{if($1!~"!"){print $1}}' satinfo | sort | uniq); do
    $NLN $RTMFIX/${file}.SpcCoeff.bin ./crtm_coeffs/
    $NLN $RTMFIX/${file}.TauCoeff.bin ./crtm_coeffs/
 done
+$NLN $RTMFIX/amsua_metop-a_v2.SpcCoeff.bin ./crtm_coeffs/amsua_metop-a_v2.SpcCoeff.bin
 
 $NLN $RTMFIX/Nalli.IRwater.EmisCoeff.bin   ./crtm_coeffs/Nalli.IRwater.EmisCoeff.bin
 $NLN $RTMFIX/NPOESS.IRice.EmisCoeff.bin    ./crtm_coeffs/NPOESS.IRice.EmisCoeff.bin

--- a/src/gsi/antcorr_application.f90
+++ b/src/gsi/antcorr_application.f90
@@ -10,6 +10,9 @@
 !                       paul.vandelst@noaa.gov
 !
 !   2011-04-25   A.Collard   Modified to be consistent with CRTM 2.1
+!   2020-12-13   S.Sieron    Added Apply_Antcorr for assimilation of
+!                            brightness temperatures instead of antenna
+!                            temperatures
 ! 
 
 MODULE AntCorr_Application
@@ -35,6 +38,7 @@ MODULE AntCorr_Application
   ! The AntCorr structure definition
   PUBLIC :: ACCoeff_type
   PUBLIC :: Remove_AntCorr
+  PUBLIC :: Apply_AntCorr
   
   ! -----------------
   ! Module parameters
@@ -153,5 +157,102 @@ CONTAINS
       T(l) = AC%A_earth(iFOV,l)*T(l) + AC%A_platform(iFOV,l)*T(l) + AC%A_space(iFOV,l)*TSPACE
     END DO
   END SUBROUTINE Remove_AntCorr
+
+!--------------------------------------------------------------------------------
+!
+! NAME:
+!       Apply_AntCorr
+!
+! PURPOSE:
+!       Subroutine to apply an antenna correction to microwave instrument
+!       antenna temperatures, Ta, to produce brightness temperatures, Tb.
+!
+! CALLING SEQUENCE:
+!       CALL Apply_AntCorr( AC  , &  ! Input
+!                           iFOV, &  ! Input
+!                           T     )  ! In/Output
+!
+! INPUT ARGUMENTS:
+!       AC:             Structure containing the antenna correction coefficients
+!                       for the sensor of interest.
+!                       UNITS:      N/A
+!                       TYPE:       TYPE(ACCoeff_type)
+!                       DIMENSION:  Scalar
+!                       ATTRIBUTES: INTENT(IN)
+!
+!       iFOV:           The FOV index for a scanline of the sensor of interest.
+!                       UNITS:      N/A
+!                       TYPE:       INTEGER
+!                       DIMENSION:  Scalar
+!                       ATTRIBUTES: INTENT(IN)
+!
+!       T:              On input, this argument contains the antenna
+!                       temperatures for the sensor channels.
+!                       UNITS:      Kelvin
+!                       TYPE:       REAL(fp)
+!                       DIMENSION:  Rank-1 (n_Channels)
+!                       ATTRIBUTES: INTENT(IN OUT)
+!
+! OUTPUT ARGUMENTS:
+!       T:              On output, this argument contains the brightness
+!                       temperatures for the sensor channels.
+!                       If an error occurs, the return values are all -1.
+!                       UNITS:      Kelvin
+!                       TYPE:       REAL(fp)
+!                       DIMENSION:  Rank-1 (n_Channels)
+!                       ATTRIBUTES: INTENT(IN OUT)
+!
+! SIDE EFFECTS:
+!       The temperature array argument, T, is modified.
+!
+! PROCEDURE:
+!       For every FOV and channel, the antenna temperature, Ta, is converted
+!       to brightness temperature, Tb, using,
+!
+!         Tb = (Ta - As.Ts) / (Ae + Ap)
+!
+!       where Ae == antenna efficiency for the Earth view
+!             Ap == antenna efficiency for satellite platform view
+!             As == antenna efficiency for cold space view
+!             Ts == cosmic background temperature.
+!
+!       Note that the observed earth view brightness temperature is used as a
+!       proxy for the platform temperature for the (Ap.Tb) component since
+!       there is no measurement of the platform temperature in-flight.
+!
+!--------------------------------------------------------------------------------
+
+  SUBROUTINE Apply_AntCorr( AC  , &  ! Input
+                            iFOV, &  ! Input
+                            T     )  ! In/Output
+    implicit none
+
+    ! Arguments
+    TYPE(ACCoeff_type), INTENT(IN)     :: AC
+    INTEGER           , INTENT(IN)     :: iFOV
+    REAL(fp)          , INTENT(IN OUT) :: T(:)
+    ! Local parameters
+    CHARACTER(*), PARAMETER :: ROUTINE_NAME = 'Apply_AntCorr'
+    ! Local variables
+    INTEGER :: l
+
+    ! Check input
+    IF ( iFOV < 1 .OR. iFOV > AC%n_FOVS ) THEN
+      CALL Display_Message( ROUTINE_NAME, 'Input iFOV inconsistent with AC data', FAILURE )
+      T = INVALID
+      RETURN
+    END IF
+    IF ( SIZE(T) /= AC%n_Channels ) THEN
+      CALL Display_Message( ROUTINE_NAME, 'Size of T() inconsistent with AC data', FAILURE )
+      T = INVALID
+      RETURN
+    END IF
+    ! Compute the brightness temperature
+    DO l = 1, AC%n_Channels
+      T(l) = (T(l) - AC%A_space(iFOV,l)*TSPACE) / (AC%A_earth(iFOV,l) + &
+              AC%A_platform(iFOV,l))
+    END DO
+  END SUBROUTINE Apply_AntCorr
+
   
 END MODULE AntCorr_Application

--- a/src/gsi/read_atms.f90
+++ b/src/gsi/read_atms.f90
@@ -37,6 +37,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 !  2018-02-05  collard - get orbit height from BUFR file
 !  2018-04-19  eliu - allow data selection for precipitation-affected data 
 !  2018-05-21  j.jin  - added time-thinning, to replace thin4d
+!  2020-12-13  s.sieron - change from reading antenna to brightness temperature
 !
 !   input argument list:
 !     mype     - mpi task id
@@ -479,10 +480,11 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
            solazi_save(iob)=bfr2bhdr(4) 
 
 !          Read data record.  Increment data counter
-!          TMBR is actually the antenna temperature for most microwave sounders but for
-!          ATMS it is stored in TMANT.
+!          Though TMBR is actually the antenna temperature for most microwave sounders,
+!          for ATMS, TMBR is brightness temperature. (Antenna temperature is in
+!          TMANT.) 
 !          ATMS is assumed not to come via EARS
-           call ufbrep(lnbufr,data1b8,1,nchanl,iret,'TMANT')
+           call ufbrep(lnbufr,data1b8,1,nchanl,iret,'TMBR')
 
            bt_save(1:nchanl,iob) = data1b8(1:nchanl)
 


### PR DESCRIPTION
This PR switches from assimilating satellite microwave antenna temperature (Ta) observations to brightness temperatures (Tb). This required:
- a function to apply the antenna correction to antenna temperatures
- changing which mnemonic is read from bufr files

Another set of changes, required for accurate Tb assimilation, is adding the support for multiple versions of antenna correction coefficients (ACCoeffs), each of which is in a version of CRTM SpcCoeff files. This required
- reading the satellite antenna correction version from the bufr file
- checking for the existence of multiple versions of the SpcCoeff file for a given satellite/sensor
- if a different version of ACCoeffs is used for a given observation, then remove this antenna correction, and then apply the first version of the antenna correction

Several regression tests failed, noted in the issue.

