### PR TITLE
Remove jlogfiles and postmsg from JJOBS.

### DIFF
--- a/jobs/JGDAS_ATMOS_ANALYSIS_DIAG
+++ b/jobs/JGDAS_ATMOS_ANALYSIS_DIAG
@@ -125,8 +125,7 @@ export DOGAUSFCANL=${DOGAUSFCANL:-"YES"}
 ###############################################################
 # Run relevant script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on $(hostname)"
 $LOGSCRIPT
 
 
@@ -147,8 +146,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 
 ##########################################

--- a/jobs/JGDAS_ATMOS_CHGRES_FORENKF
+++ b/jobs/JGDAS_ATMOS_CHGRES_FORENKF
@@ -101,8 +101,7 @@ export COMIN_GES_ENS="$ROTDIR/enkfgdas.$gPDY/$gcyc/$COMPONENT"
 ###############################################################
 # Run relevant script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on $(hostname)"
 $LOGSCRIPT
 
 
@@ -123,8 +122,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 
 ##########################################

--- a/jobs/JGDAS_ENKF_DIAG
+++ b/jobs/JGDAS_ENKF_DIAG
@@ -107,9 +107,7 @@ fi
 # Link observational data
 export PREPQC="$COMIN_ANL/${OPREFIX}prepbufr"
 if [ ! -f $PREPQC ]; then
-    echo "WARNING: PREPBUFR FILE $PREPQC MISSING"
-    msg="WARNING : Global PREPBUFR file is missing"
-    postmsg "$jlogfile" "$msg"
+    echo "WARNING: Global PREPBUFR FILE $PREPQC MISSING"
 fi
 export PREPQCPF="$COMIN_ANL/${OPREFIX}prepbufr.acft_profiles"
 export TCVITL="$COMIN_ANL/${OPREFIX}syndata.tcvitals.tm00"
@@ -153,8 +151,7 @@ done
 ###############################################################
 # Run relevant script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on $(hostname)"
 $LOGSCRIPT
 
 
@@ -175,8 +172,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 
 ##########################################

--- a/jobs/JGDAS_ENKF_ECEN
+++ b/jobs/JGDAS_ENKF_ECEN
@@ -107,8 +107,7 @@ export COMIN_GES_ENS="$ROTDIR/enkf$CDUMP.$gPDY/$gcyc/$COMPONENT"
 ###############################################################
 # Run relevant script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on $(hostname)"
 $LOGSCRIPT
 
 
@@ -129,8 +128,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 
 ##########################################

--- a/jobs/JGDAS_ENKF_FCST
+++ b/jobs/JGDAS_ENKF_FCST
@@ -87,8 +87,7 @@ export ENSBEG=$((ENSEND - NMEM_EFCSGRP + 1))
 ###############################################################
 # Run relevant script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on $(hostname)"
 $LOGSCRIPT
 
 
@@ -131,8 +130,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 
 ##########################################

--- a/jobs/JGDAS_ENKF_POST
+++ b/jobs/JGDAS_ENKF_POST
@@ -81,8 +81,7 @@ export LEVS=$((LEVS-1))
 ###############################################################
 # Run relevant script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on $(hostname)"
 $LOGSCRIPT
 
 
@@ -103,8 +102,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 
 ##########################################

--- a/jobs/JGDAS_ENKF_SELECT_OBS
+++ b/jobs/JGDAS_ENKF_SELECT_OBS
@@ -110,9 +110,7 @@ status=$?
 # Link observational data
 export PREPQC="$COMIN_ANL/${OPREFIX}prepbufr"
 if [ ! -f $PREPQC ]; then
-    echo "WARNING: PREPBUFR FILE $PREPQC MISSING"
-    msg="WARNING : Global PREPBUFR file is missing"
-    postmsg "$jlogfile" "$msg"
+    echo "WARNING: Global PREPBUFR FILE $PREPQC MISSING"
 fi
 export PREPQCPF="$COMIN_ANL/${OPREFIX}prepbufr.acft_profiles"
 export TCVITL="$COMIN_ANL/${OPREFIX}syndata.tcvitals.tm00"
@@ -155,8 +153,7 @@ done
 ###############################################################
 # Run relevant script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on $(hostname)"
 $LOGSCRIPT
 
 
@@ -185,8 +182,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 
 ##########################################

--- a/jobs/JGDAS_ENKF_SFC
+++ b/jobs/JGDAS_ENKF_SFC
@@ -107,8 +107,7 @@ export COMIN_GES_ENS="$ROTDIR/enkf$CDUMP.$gPDY/$gcyc/$COMPONENT"
 ###############################################################
 # Run relevant script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on $(hostname)"
 $LOGSCRIPT
 
 
@@ -129,8 +128,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 
 ##########################################

--- a/jobs/JGDAS_ENKF_UPDATE
+++ b/jobs/JGDAS_ENKF_UPDATE
@@ -85,8 +85,7 @@ export COMOUT_ANL_ENS="$ROTDIR/enkf$CDUMP.$PDY/$cyc/$COMPONENT"
 ###############################################################
 # Run relevant script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on $(hostname)"
 $LOGSCRIPT
 
 ${ENKFUPDSH:-$SCRgfs/exgdas_enkf_update.sh}
@@ -114,8 +113,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 
 ##########################################

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS
@@ -127,9 +127,7 @@ fi
 # Link observational data
 export PREPQC="${COMOUT}/${OPREFIX}prepbufr"
 if [ ! -f $PREPQC ]; then
-    echo "WARNING: PREPBUFR FILE $PREPQC MISSING"
-    msg="WARNING : Global PREPBUFR file is missing"
-    postmsg "$jlogfile" "$msg"
+    echo "WARNING: Global PREPBUFR FILE $PREPQC MISSING"
 fi
 export PREPQCPF="${COMOUT}/${OPREFIX}prepbufr.acft_profiles"
 export TCVITL="${COMOUT}/${OPREFIX}syndata.tcvitals.tm00"
@@ -147,8 +145,7 @@ export DOGAUSFCANL=${DOGAUSFCANL:-"YES"}
 ###############################################################
 # Run relevant script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on $(hostname)"
 $LOGSCRIPT
 
 
@@ -179,8 +176,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 
 ##########################################

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
@@ -136,8 +136,7 @@ export DOGAUSFCANL=${DOGAUSFCANL:-"YES"}
 ###############################################################
 # Run relevant script
 env
-msg="HAS BEGUN on `hostname`"
-postmsg "$jlogfile" "$msg"
+echo "HAS BEGUN on $(hostname)"
 $LOGSCRIPT
 
 
@@ -158,8 +157,7 @@ if [ -e "$pgmout" ] ; then
 fi
 
 
-msg="ENDED NORMALLY."
-postmsg "$jlogfile" "$msg"
+echo "ENDED NORMALLY."
 
 
 ##########################################


### PR DESCRIPTION
This PR:
- removes references for `jlogfile` and `postmsg` from the Global GSI J-Jobs.