### PR TITLE
GitHub Issue NOAA-EMC/GSI#246.  Applied bug fix to general_read_gfsatm.f90 and read_obs.F90

### DIFF
--- a/src/gsi/read_obs.F90
+++ b/src/gsi/read_obs.F90
@@ -1885,7 +1885,7 @@ subroutine read_obs(ndata,mype)
 !   Write collective obs selection information to scratch file.
     if (lread_obs_save .and. mype==0) then
        write(6,*)'READ_OBS:  write collective obs selection info to ',trim(obs_input_common)
-       call unformatted_open(lunsave,file=obs_input_common,class=".obs_input.")
+       call unformatted_open(lunsave,file=obs_input_common,class=".obs_input.",silent=.true.)
        write(lunsave) ndata,ndat,npe,superp,nprof_gps,ditype
        write(lunsave) super_val1
        write(lunsave) nobs_sub


### PR DESCRIPTION
Applied bug fix to general_read_gfsatm.f90 to correct the MPI rank issue where L127runs hang with 1020 or more tasks.  Also, added ",silent=.true." to the call to unformatted_open in read_obs.F90 to remove warning messages in the output.

Changes were run on Dogwood and results are reproducible.