### PR TITLE
GitHub Issue NOAA-EMC/GSI#280. Add code to GSI IO interface with fv3lam to handle subdomain restart files

### DIFF
--- a/src/gsi/gridmod.F90
+++ b/src/gsi/gridmod.F90
@@ -92,6 +92,7 @@ module gridmod
 !   2019-09-04  martin  - add write_fv3_incr to write netCDF increment rather than analysis in NEMSIO format
 !   2019-09-23  martin  - add use_gfs_ncio to read global first guess from netCDF file
 !   2020-12-18  Hu      - add grid_type_fv3_regional
+!   2021-12-30  Hu      - add fv3_io_layout_y
 !
 !                        
 !
@@ -146,7 +147,7 @@ module gridmod
   public :: nlat_regional,nlon_regional,update_regsfc,half_grid,gencode
   public :: diagnostic_reg,nmmb_reference_grid,filled_grid
   public :: grid_ratio_nmmb,isd_g,isc_g,dx_gfs,lpl_gfs,nsig5,nmmb_verttype
-  public :: grid_ratio_fv3_regional,fv3_regional,grid_type_fv3_regional
+  public :: grid_ratio_fv3_regional,fv3_io_layout_y,fv3_regional,grid_type_fv3_regional
   public :: l_reg_update_hydro_delz
   public :: nsig3,nsig4,grid_ratio_wrfmass
   public :: use_gfs_ozone,check_gfs_ozone_date,regional_ozone,nvege_type
@@ -205,6 +206,7 @@ module gridmod
   character(1) nmmb_reference_grid      ! ='H': use nmmb H grid as reference for analysis grid
                                         ! ='V': use nmmb V grid as reference for analysis grid
   real(r_kind) grid_ratio_fv3_regional  ! ratio of analysis grid to fv3 model grid in fv3 grid units.
+  integer(i_kind) fv3_io_layout_y       ! = io_layout(2) of fv3 regional model (subdomain y direction).
   integer(i_kind) grid_type_fv3_regional! type of fv3 model grid (grid orientation).
   real(r_kind) grid_ratio_nmmb ! ratio of analysis grid to nmmb model grid in nmmb model grid units.
   real(r_kind) grid_ratio_wrfmass ! ratio of analysis grid to wrf model grid in wrf mass grid units.
@@ -463,6 +465,7 @@ contains
     filled_grid = .false.
     half_grid = .false.
     grid_ratio_fv3_regional = one
+    fv3_io_layout_y = 1
     grid_type_fv3_regional = 0
     grid_ratio_nmmb = sqrt(two)
     grid_ratio_wrfmass = one

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -118,7 +118,7 @@
   use mod_strong, only: l_tlnmc,reg_tlnmc_type,nstrong,tlnmc_option,&
        period_max,period_width,init_strongvars,baldiag_full,baldiag_inc
   use gridmod, only: nlat,nlon,nsig,wrf_nmm_regional,nems_nmmb_regional,fv3_regional,cmaq_regional,&
-     nmmb_reference_grid,grid_ratio_nmmb,grid_ratio_wrfmass,grid_ratio_fv3_regional,&
+     nmmb_reference_grid,grid_ratio_nmmb,grid_ratio_wrfmass,grid_ratio_fv3_regional,fv3_io_layout_y,&
      filled_grid,half_grid,wrf_mass_regional,nsig1o,nnnn1o,update_regsfc,&
      diagnostic_reg,gencode,nlon_regional,nlat_regional,nvege_type,&
      twodvar_regional,regional,init_grid,init_reg_glob_ll,init_grid_vars,netcdf,&
@@ -468,7 +468,10 @@
 !  2021-01-05  x.zhang/lei  - add code for updating delz analysis in regional da
 !  09-07-2020 CAPS            Add options for directDA_radaruse_mod to use direct radar DA capabilities
 !  02-09-2021 CAPS(J. Park)   Add vad_near_analtime flag (obsqc) to assimilate newvad obs around analysis time only
-!
+!  01-07-2022 Hu        Add fv3_io_layout_y to let fv3lam interface read/write subdomain restart
+!                       files. The fv3_io_layout_y needs to match fv3lam model
+!                       option io_layout(2).
+!                       
 !EOP
 !-------------------------------------------------------------------------
 
@@ -754,6 +757,7 @@
 !                                = 'V', then analysis grid covers V grid domain
 !     grid_ratio_nmmb   - ratio of analysis grid to nmmb model grid in nmmb model grid units.
 !     grid_ratio_fv3_regional - ratio of analysis grid to fv3 grid in fv3 grid units.
+!     fv3_io_layout_y    - set to the same number as io_layout of fv3 regional model in y direction.
 !     grid_ratio_wrfmass - ratio of analysis grid to wrf mass grid in wrf grid units.
 !     grid_type_fv3_regional - type of fv3 model grid (grid orientation).
 !     twodvar_regional  - logical for regional 2d-var analysis
@@ -774,7 +778,7 @@
        diagnostic_reg,update_regsfc,netcdf,regional,wrf_nmm_regional,nems_nmmb_regional,fv3_regional,&
        wrf_mass_regional,twodvar_regional,filled_grid,half_grid,nvege_type,nlayers,cmaq_regional,&
        nmmb_reference_grid,grid_ratio_nmmb,grid_ratio_fv3_regional,grid_ratio_wrfmass,jcap_gfs,jcap_cut,&
-       wrf_mass_hybridcord,grid_type_fv3_regional
+       wrf_mass_hybridcord,grid_type_fv3_regional,fv3_io_layout_y
 
 ! BKGERR (background error related variables):
 !     vs       - scale factor for vertical correlation lengths for background error

--- a/ush/build.comgsi
+++ b/ush/build.comgsi
@@ -45,7 +45,11 @@ elif [[ -d /jetmon ]] ; then
     module load cmake/3.16.1
     module load intel/18.0.5.274
     module load impi/2018.4.274
-    module load netcdf/4.7.0 #don't load netcdf/4.7.4 from hpc-stack, GSI does not compile with it.
+    module load szip/2.1
+    module load hdf5parallel/1.10.6
+    module load netcdf-hdf5parallel/4.7.4
+    module load pnetcdf/1.11.2
+    module load nco/4.9.1
 
     module use /lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack
     module load hpc/1.1.0


### PR DESCRIPTION
This PR is to solve issue # 280. 

A new namelist fv3_io_layout_y is added. 

When fv3_io_layout_y=1, the GSI is identical to current function.
When fv3_io_layout_y=n, the GSI will expects multiple restart files covering subdomains.

The code is currently used in GSL NA 3km real-time runs.

In this PR, the build.comgsi is updated for JET application when parallel IO are needed for background and ensemble IO.

The calculate of GSD PBL is also updated for FV3LAM model. 

 