### PR TITLE
Fix a bug mpi_allreduce failed process 2D arrays

### DIFF
--- a/util/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90
+++ b/util/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90
@@ -342,7 +342,9 @@ program getsigensmeanp_smooth
         call nemsio_readrecv(gfile,'hgt','sfc',1,rwork_hgt,iret=iret)
 
         rwork_avg = zero
-        call mpi_allreduce(rwork_mem,rwork_avg,nsize,mpi_real,mpi_sum,new_comm,iret)
+        do n = 1,nrec
+            call mpi_allreduce(rwork_mem(:,n),rwork_avg(:,n),npts,mpi_real,mpi_sum,new_comm,iret)
+        end do
         rwork_avg = rwork_avg * rnanals
 
         if ( mype == 0 ) then


### PR DESCRIPTION
The bug will cause rwork_avg=ZERO after call mpi_allreduce on WCOSS2,
    after  changing it to process 1D array, it works well

 On branch hotfix/gefs_v12
	modified:   util/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90

Refs: #289