### PR TITLE
GitHub Issue NOAA-EMC/GSI#303. Modifications of two GSI scripts to the filename being consistent with the change in ufs_utils

### DIFF
--- a/scripts/exgdas_enkf_sfc.sh
+++ b/scripts/exgdas_enkf_sfc.sh
@@ -128,11 +128,9 @@ else
 fi
 
 if [ $DONST = "YES" ]; then
-    export NST_ANL=".true."
-    export GSI_FILE=${GSI_FILE:-$COMIN/${APREFIX}dtfanl.nc}
+    export NST_FILE=${NST_FILE:-$COMIN/${APREFIX}dtfanl.nc}
 else
-    export NST_ANL=".false."
-    export GSI_FILE="NULL"
+    export NST_FILE="NULL"
 fi
 
 export APRUNCY=${APRUN_CYCLE:-$APRUN_ESFC}

--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -1004,11 +1004,9 @@ if [ $DOGCYCLE = "YES" ]; then
     fi
 
     if [ $DONST = "YES" ]; then
-        export NST_ANL=".true."
-        export GSI_FILE=${GSI_FILE:-$COMOUT/${APREFIX}dtfanl.nc}
+        export NST_FILE=${NST_FILE:-$COMOUT/${APREFIX}dtfanl.nc}
     else
-        export NST_ANL=".false."
-        export GSI_FILE="NULL"
+        export NST_FILE="NULL"
     fi
 
     if [ $DOIAU = "YES" ]; then


### PR DESCRIPTION
The GSI scripts, exglobal_atmos_analysis.sh and exgdas_enkf_sfc.sh, are modified to make the GSI generated NSST foundation temperature file. as an input to global_cycle, have the same name in ufs_utils. See GSI Issue: https://github.com/NOAA-EMC/GSI/issues/303.

This change is limited to these two GSI scripts only, no code change. It is in the frame of workflow, no need to run regression test. 

It is treated as a hotfix. 

The change has been done in feature/gsinsst_scripts_only branch. It is ready to be committed to master. 