### PR TITLE
GitHub Issue NOAA-EMC/GSI#335. Add several new functions from RAP/HRRR/RRFS application.

### DIFF
--- a/src/gsi/cplr_read_wrf_mass_guess.f90
+++ b/src/gsi/cplr_read_wrf_mass_guess.f90
@@ -73,6 +73,8 @@ contains
   !                               number concentration)
   !   2017-03-23  Hu     - add code to read hybrid vertical coodinate in WRF MASS
   !                          core
+  !   2022-03-15  Hu  change all th2 to t2m and convert 2m temperature 
+  !                        from potentionl to senseible temperature
   !
   !   input argument list:
   !     mype     - pe number
@@ -170,7 +172,7 @@ contains
     integer(i_kind) n_actual_clouds
   
     real(r_kind), pointer :: ges_ps_it (:,:  )=>NULL()
-    real(r_kind), pointer :: ges_th2_it(:,:  )=>NULL()
+    real(r_kind), pointer :: ges_t2m_it(:,:  )=>NULL()
     real(r_kind), pointer :: ges_q2_it (:,:  )=>NULL()
     real(r_kind), pointer :: ges_tsk_it(:,:  )=>NULL()
     real(r_kind), pointer :: ges_soilt1_it(:,:)=>NULL()
@@ -291,8 +293,8 @@ contains
           if (ier/=0) call die(trim(myname),'cannot get pointers for met-fields, ier =',ier)
   
           if (l_gsd_soilTQ_nudge .or.i_use_2mt4b>0) then
-             call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'th2m', ges_th2_it,istatus );ier=ier+istatus 
-             if (ier/=0) call die(trim(myname),'cannot get pointers for th2m, ier=',ier)
+             call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 't2m', ges_t2m_it,istatus );ier=ier+istatus 
+             if (ier/=0) call die(trim(myname),'cannot get pointers for t2m, ier=',ier)
           endif
 
           if (l_gsd_soilTQ_nudge) then
@@ -1188,9 +1190,13 @@ contains
                    ges_xlat(j,i,it)=real(all_loc(j,i,i_xlat),r_kind)/rad2deg_single
                 endif
                 if(l_gsd_soilTQ_nudge) then
-                   ges_th2_it(j,i)=real(all_loc(j,i,i_th2),r_kind)
                    ges_tsk_it(j,i)=real(all_loc(j,i,i_tsk),r_kind)
                    ges_soilt1_it(j,i)=real(all_loc(j,i,i_soilt1),r_kind)
+                endif
+                if(i_use_2mt4b > 0 ) then
+                   ges_t2m_it(j,i)=real(all_loc(j,i,i_th2),r_kind)
+  ! convert from potential to sensible temperature
+                   ges_t2m_it(j,i)=ges_t2m_it(j,i)*(ges_ps_it(j,i)/r100)**rd_over_cp_mass
                 endif
                 if(i_use_2mq4b>0) then
                   ges_q2_it(j,i)=real(all_loc(j,i,i_q2),r_kind)
@@ -1350,6 +1356,8 @@ contains
   !                            - add code for hydrometer variables needed for
   !                            direct reflectivity DA
   !                            - add CV transform option on hydrometer variables
+  !   2022-03-15  Hu  change all th2 to t2m and convert 2m temperature 
+  !                        from potentionl to senseible temperature
   !
   !   input argument list:
   !     mype     - pe number
@@ -1449,7 +1457,7 @@ contains
     real(r_kind)   :: ges_rho, tsn
 
     real(r_kind), pointer :: ges_ps_it (:,:  )=>NULL()
-    real(r_kind), pointer :: ges_th2_it(:,:  )=>NULL()
+    real(r_kind), pointer :: ges_t2m_it(:,:  )=>NULL()
     real(r_kind), pointer :: ges_q2_it (:,:  )=>NULL()
     real(r_kind), pointer :: ges_tsk_it(:,:  )=>NULL()
     real(r_kind), pointer :: ges_soilt1_it(:,:)=>NULL()
@@ -1933,8 +1941,8 @@ contains
              if (ier/=0) call die(trim(myname),'cannot get pointers for q2m, ier =',ier)
           endif
           if (i_use_2mt4b > 0) then
-             call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'th2m',ges_th2_it, istatus );ier=ier+istatus
-             if (ier/=0) call die(trim(myname),'cannot get pointers for th2m,ier =',ier)
+             call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 't2m',ges_t2m_it, istatus );ier=ier+istatus
+             if (ier/=0) call die(trim(myname),'cannot get pointers for t2m,ier =',ier)
           endif
           if (l_gsd_soilTQ_nudge) then
              call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'tskn',ges_tsk_it, istatus );ier=ier+istatus 
@@ -2251,7 +2259,9 @@ contains
                 sno(j,i,it)=real(all_loc(j,i,i_0+i_sno),r_kind)
                 sfc_rough(j,i,it)=rough_default
                 if(i_use_2mt4b > 0 ) then
-                   ges_th2_it(j,i)=real(all_loc(j,i,i_0+i_th2),r_kind)
+                   ges_t2m_it(j,i)=real(all_loc(j,i,i_0+i_th2),r_kind)
+  ! convert from potential to sensible temperature
+                   ges_t2m_it(j,i)=ges_t2m_it(j,i)*(ges_ps_it(j,i)/r100)**rd_over_cp_mass
                 endif
   ! for GSD soil nudging
                 if(l_gsd_soilTQ_nudge) then

--- a/src/gsi/cplr_wrwrfmassa.f90
+++ b/src/gsi/cplr_wrwrfmassa.f90
@@ -63,6 +63,8 @@ contains
   !                            direct reflectivity DA
   !                            - add CV transform option on hydrometer variables
   !                            for direct reflectivity DA
+  !   2022-03-15  Hu  change all th2 to t2m and convert 2m temperature 
+  !                        from sensible to potentionl temperature for writing
   !
   !
   !   input argument list:
@@ -89,7 +91,7 @@ contains
     use constants, only: soilmoistmin
     use gsi_io, only: lendian_in,verbose
     use rapidrefresh_cldsurf_mod, only: l_hydrometeor_bkio,l_gsd_soilTQ_nudge,&
-         i_use_2mq4b
+         i_use_2mq4b,i_use_2mt4b
     use wrf_mass_guess_mod, only: destroy_cld_grids
     use gsi_bundlemod, only: GSI_BundleGetPointer
     use gsi_metguess_mod, only: gsi_metguess_get,GSI_MetGuess_Bundle
@@ -156,7 +158,7 @@ contains
   
     real(r_kind), pointer :: ges_ps(:,:)=>NULL()
     real(r_kind), pointer :: ges_tsk(:,:)=>NULL()
-    real(r_kind), pointer :: ges_th2(:,:)=>NULL()
+    real(r_kind), pointer :: ges_t2m(:,:)=>NULL()
     real(r_kind), pointer :: ges_q2(:,:)=>NULL()
     real(r_kind), pointer :: ges_soilt1(:,:)=>NULL()
     real(r_kind), pointer :: ges_tslb_it(:,:,:)=>NULL()
@@ -751,8 +753,6 @@ contains
           end do
        end do
        ier=0
-       call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'th2m',  ges_th2, istatus );ier=ier+istatus
-       call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'q2m' ,  ges_q2,  istatus );ier=ier+istatus
        call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'tsoil', ges_soilt1, istatus );ier=ier+istatus
        call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'tskn' , ges_tsk , istatus );ier=ier+istatus
        if (ier/=0) then ! doesn't have to die - code can be generalized to bypass missing vars
@@ -764,12 +764,23 @@ contains
           do j=1,lat1
              jp1=j+1
              all_loc(j,i,i_tsk)=ges_tsk(jp1,ip1)
-             all_loc(j,i,i_th2)=ges_th2(jp1,ip1)
              all_loc(j,i,i_soilt1)=ges_soilt1(jp1,ip1)
           end do
        end do
     endif ! l_gsd_soilTQ_nudge
+    if(i_use_2mt4b > 0 ) then
+       call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 't2m',  ges_t2m, istatus );ier=ier+istatus
+       do i=1,lon1
+          ip1=i+1
+          do j=1,lat1
+  !  Convert 2m sensible T to potential T
+             jp1=j+1
+             all_loc(j,i,i_th2)=ges_t2m(jp1,ip1)*(r100/ges_ps(jp1,ip1))**rd_over_cp_mass
+          end do
+       end do
+    endif
     if (i_use_2mq4b > 0) then
+       call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'q2m' ,  ges_q2,  istatus );ier=ier+istatus
        do i=1,lon1
           ip1=i+1
           do j=1,lat1
@@ -1835,6 +1846,10 @@ contains
   !   2018-10-23   C.Liu   add w 
   !   2019-04-18  cTong  - add code of treatments for logarithmic q conversion
   !   2019-05-30  cTong  - add w analysis output 
+  !   2022-03-15  Hu  change all th2 to t2m and convert 2m temperature 
+  !                        from sensible to potentionl temperature for writing
+  !   2022-03-15  Hu  add a check to remove the negative moisture if rh>4%
+  !                   for the lowest 3 model level
   !
   !   input argument list:
   !     mype     - pe number
@@ -1882,6 +1897,7 @@ contains
   ! Declare local parameters
     character(len=*),parameter::myname='wrwrfmassa_netcdf'
     real(r_kind),parameter:: r225=225.0_r_kind
+    integer(i_kind), parameter :: nlvl_qcheck=3
     real(r_kind),parameter:: D608=0.608_r_kind
   
   ! Declare local variables
@@ -1890,8 +1906,10 @@ contains
     real(r_single),allocatable::all_loc(:,:,:)
     real(r_single),allocatable::strp(:)
     real(r_single),allocatable::landmask(:),snow(:),seaice(:),t1st2d(:),pt2t(:)
+    real(r_single),allocatable::qs1st2d(:,:),sfcprs(:)
+    real(r_kind),allocatable::tmp2da(:,:),tmp2db(:,:),tmp2dc(:,:)
     character(6) filename
-    integer(i_kind) i,j,k,kt,kq,ku,kv,it,i_psfc,i_t,i_q,i_u,i_v,i_w,i_dbz
+    integer(i_kind) i,j,k,kt,kq,ku,kv,it,i_psfc,i_t,i_q,i_u,i_v,i_w,i_dbz,ij
     integer(i_kind) i_qc,i_qi,i_qr,i_qs,i_qg,i_qnr,i_qni,i_qnc
     integer(i_kind) kqc,kqi,kqr,kqs,kqg,kqnr,kqni,kqnc,i_tt,ktt,kw,kdbz
     integer(i_kind) i_sst,i_skt,i_th2,i_q2,i_soilt1,i_tslb,i_smois,ktslb,ksmois
@@ -1911,7 +1929,7 @@ contains
   
     real(r_kind), pointer :: ges_ps(:,:  )=>NULL()
     real(r_kind), pointer :: ges_tsk(:,:)=>NULL()
-    real(r_kind), pointer :: ges_th2(:,:)=>NULL()
+    real(r_kind), pointer :: ges_t2m(:,:)=>NULL()
     real(r_kind), pointer :: ges_q2(:,:)=>NULL()
     real(r_kind), pointer :: ges_soilt1(:,:)=>NULL()
     real(r_kind), pointer :: ges_tslb_it(:,:,:)=>NULL()
@@ -2095,6 +2113,8 @@ contains
     if(mype==0) then
        allocate(landmask(im*jm),snow(im*jm),seaice(im*jm))
        allocate(t1st2d(im*jm),pt2t(im*jm))
+       allocate(qs1st2d(im*jm,nlvl_qcheck))
+       allocate(sfcprs(im*jm))
     endif
   
     if(mype == 0) write(6,*)' at 2 in wrwrfmassa'
@@ -2373,8 +2393,7 @@ contains
        call unfill_mass_grid2t(tempa,im,jm,temp1)
        write(lendian_out)temp1
        do i=1,im*jm
-          work_prsl = one_tenth*(aeta1_ll(1)*(temp1(i)/r100-pt_ll)+aeta2_ll(1)+pt_ll)
-          pt2t(i)   = (work_prsl/r100)**rd_over_cp_mass
+          sfcprs(i) = temp1(i)
        enddo
     end if
   
@@ -2399,11 +2418,29 @@ contains
           end do
           call unfill_mass_grid2t(tempa,im,jm,temp1)
           write(lendian_out)temp1
-          if(k==1) then
-             do i=1,im*jm
-                t1st2d(i)=temp1(i)*pt2t(i)  ! convert potential to sensible T
-             end do
-             pt2t=t1st2d   ! save a copy
+          if(k>=1 .and. k<=nlvl_qcheck) then
+          ! calculate moisture saturation at model level k 
+             allocate(tmp2da(im,jm),tmp2db(im,jm),tmp2dc(im,jm))
+             ij=0
+             do j=1,jm
+                do i=1,im
+                   ij=ij+1
+                   work_prsl = one_tenth*(aeta1_ll(k)*(sfcprs(ij)/r100-pt_ll)+aeta2_ll(k)+pt_ll)
+                   tmp2dc(i,j)=work_prsl                                       ! pressure
+                   tmp2db(i,j)=temp1(ij)*(work_prsl/r100)**rd_over_cp_mass     ! T in K
+                   if(k==1) t1st2d(ij)  = tmp2db(i,j)
+                enddo
+             enddo
+             call genqsat(tmp2da,tmp2db,tmp2dc,im,jm,1,.false.,0)
+             ij=0
+             do j=1,jm
+                do i=1,im
+                   ij=ij+1
+                   qs1st2d(ij,k)=tmp2da(i,j) ! moisture saturation 
+                enddo
+             enddo
+             deallocate(tmp2da,tmp2db,tmp2dc)
+             if(k==1) pt2t=t1st2d   ! save a copy
           endif
        end if
     end do
@@ -2421,7 +2458,11 @@ contains
           do i=1,iglobal
              tempa(i)=tempa(i)-tempb(i)
           end do
-          call unfill_mass_grid2t(tempa,im,jm,temp1)
+          if(k>=1 .and. k<=nlvl_qcheck) then
+             call unfill_mass_grid2t_drycheck(tempa,im,jm,temp1,qs1st2d(:,k))
+          else
+             call unfill_mass_grid2t(tempa,im,jm,temp1)
+          endif
           write(lendian_out)temp1
        end if
     end do
@@ -2528,14 +2569,15 @@ contains
     endif ! l_gsd_soilTQ_nudge
 
     if(i_use_2mt4b > 0 ) then
-       call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'th2m', ges_th2,istatus );ier=ier+istatus
+       call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 't2m', ges_t2m,istatus );ier=ier+istatus
        if (ier/=0) then ! doesn't have to die - code can be generalized to bypass
            write(6,*)'wrwrfmassa_netcdf: getpointer failed, cannot retrieve th2'
            call stop2(999)
        endif
+! convert to potential T
        do i=1,lon2
           do j=1,lat2
-             all_loc(j,i,i_th2)=ges_th2(j,i)
+             all_loc(j,i,i_th2)=ges_t2m(j,i)*(r100/ges_ps(j,i))**rd_over_cp_mass
           end do
        end do
     endif
@@ -2709,7 +2751,7 @@ contains
           end do
           write(6,*)' at 10.13 in wrwrfmassa,max,min(tempa)=', &
                              maxval(tempa),minval(tempa)
-          call unfill_mass_grid2t(tempa,im,jm,temp1)
+          call unfill_mass_grid2t_drycheck(tempa,im,jm,temp1,qs1st2d(:,1))
           write(6,*)' at 10.14 in wrwrfmassa,max,min(temp1)=', &
                              maxval(temp1),minval(temp1)
           write(lendian_out)temp1
@@ -3015,6 +3057,8 @@ contains
        deallocate(seaice)
        deallocate(t1st2d)
        deallocate(pt2t)
+       deallocate(qs1st2d)
+       deallocate(sfcprs)
     endif
     
   end subroutine wrwrfmassa_netcdf_wrf

--- a/src/gsi/gsd_update_mod.f90
+++ b/src/gsi/gsd_update_mod.f90
@@ -11,11 +11,13 @@ module gsd_update_mod
 !   2015-01-12  Hu  fix the bug in coast proximity calculation in subdomain
 !   2015-01-14  Hu  do T soil nudging over snow
 !   2015-01-15  Hu  move the land/sea mask check to fine grid update step
+!   2022-03-15  Hu  change all th2 to t2m to indicate that 2m temperature 
+!                   is sensible instead of potentionl temperature
 !
 ! subroutines included:
 !   sub gsd_update_soil_tq  - change surface and soil based on analysis increment
 !   sub gsd_limit_ocean_q   - limits to analysis increments over oceans 
-!   sub gsd_update_th2      - adjust 2-m t based on analysis increment
+!   sub gsd_update_t2m      - adjust 2-m t based on analysis increment
 !   sub gsd_update_q2       - adjust 2-m q based on analysis increment
 !
 ! Variable Definitions:
@@ -30,7 +32,7 @@ module gsd_update_mod
 ! set subroutines to public
   public :: gsd_update_soil_tq
   public :: gsd_limit_ocean_q
-  public :: gsd_update_th2
+  public :: gsd_update_t2m
   public :: gsd_update_q2
   public :: gsd_gen_coast_prox
 ! set passed variables to public
@@ -487,10 +489,10 @@ subroutine gsd_limit_ocean_q(qinc,it)
   deallocate(rhgues)
 end subroutine gsd_limit_ocean_q 
 
-subroutine gsd_update_th2(tinc,it)
+subroutine gsd_update_t2m(tinc,it)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
-! subprogram:    gsd_update_th2    adjust 2-m t based on analysis increment
+! subprogram:    gsd_update_t2m    adjust 2-m t based on analysis increment
 !   prgmmr: Hu          org: GSD                date: 2011-10-04
 !
 ! abstract:  This routine does the following things:
@@ -514,9 +516,9 @@ subroutine gsd_update_th2(tinc,it)
 !$$$
   use kinds, only: r_kind,i_kind
   use jfunc, only:  tsensible
-  use constants, only: zero,one,fv,rd_over_cp_mass,one_tenth
-  use gridmod, only: lat2,lon2,aeta1_ll,pt_ll,aeta2_ll
-! use guess_grids, only: nfldsig
+  use constants, only: zero,one,fv,one_tenth
+  use gridmod, only: lat2,lon2
+  use constants, only: half
 
   implicit none
 
@@ -527,17 +529,17 @@ subroutine gsd_update_th2(tinc,it)
   real(r_kind),parameter:: r10=10.0_r_kind
   real(r_kind),parameter:: r100=100.0_r_kind
   integer(i_kind) i,j,ier,ihaveq
-  real(r_kind) :: dth2, work_prsl,work_prslk
+  real(r_kind) :: dth2
 
   real(r_kind),dimension(:,:  ),pointer:: ges_ps =>NULL()
-  real(r_kind),dimension(:,:  ),pointer:: ges_th2=>NULL()
+  real(r_kind),dimension(:,:  ),pointer:: ges_t2m=>NULL()
   real(r_kind),dimension(:,:,:),pointer:: ges_q  =>NULL()
 
 !*******************************************************************************
 !
 ! 2-m temperature
 !  do it=1,nfldsig
-     call gsi_bundlegetpointer(gsi_metguess_bundle(it),'th2m',ges_th2,ier)
+     call gsi_bundlegetpointer(gsi_metguess_bundle(it),'t2m',ges_t2m,ier)
      if(ier/=0) return
      call gsi_bundlegetpointer(gsi_metguess_bundle(it),'ps',ges_ps,ier)
      if(ier/=0) return
@@ -552,17 +554,14 @@ subroutine gsd_update_th2(tinc,it)
               if(ihaveq/=0) cycle
               dth2=tinc(i,j)/(one+fv*ges_q(i,j,1))
            endif
-!          Convert sensible temperature to potential temperature
-           work_prsl  = one_tenth*(aeta1_ll(1)*(r10*ges_ps(i,j)-pt_ll)+ &
-                                   aeta2_ll(1) + pt_ll)
-           work_prslk = (work_prsl/r100)**rd_over_cp_mass
-           ges_th2(i,j) = ges_th2(i,j) + dth2/work_prslk
+
+           ges_t2m(i,j) = ges_t2m(i,j) + dth2
         end do
      end do
 !  end do
 
   return
-end subroutine gsd_update_th2
+end subroutine gsd_update_t2m
 
 subroutine gsd_update_q2(qinc,it)
 !$$$  subprogram documentation block

--- a/src/gsi/gsi_rfv3io_mod.f90
+++ b/src/gsi/gsi_rfv3io_mod.f90
@@ -14,10 +14,12 @@ module gsi_rfv3io_mod
 !   2019        ting    - modifications for use for ensemble IO and cold start files 
 !   2019-03-13  CAPS(C. Tong) - Port direct radar DA capabilities.
 !   2021-11-01  lei     - modify for fv3-lam parallel IO
-!   2022-01-07  Hu      - add code to readi/write subdomain restart files.
+!   2022-01-07  Hu      - add code to read/write subdomain restart files.
 !                         This function is needed when fv3 model sets
 !                         io_layout(2)>1
 !   2022-02-15 Lu @ Wang - add time label it for FGAT. POC: xuguang.wang@ou.edu
+!   2022-03-15  Hu      - add code to read/write 2m T and Q for they will be
+!                         used as background for surface observation operator
 ! subroutines included:
 !   sub gsi_rfv3io_get_grid_specs
 !   sub read_fv3_files 
@@ -30,6 +32,7 @@ module gsi_rfv3io_mod
 !   sub gsi_fv3ncdf_writeps
 !   sub gsi_fv3ncdf_write
 !   sub gsi_fv3ncdf_write_v1
+!   sub gsi_fv3ncdf2d_write
 !   sub check
 !
 ! variable definitions:
@@ -47,6 +50,7 @@ module gsi_rfv3io_mod
   use general_sub2grid_mod, only: sub2grid_info
   use gridmod,  only: fv3_io_layout_y
   use guess_grids, only: nfldsig,ntguessig,ifilesig
+  use rapidrefresh_cldsurf_mod, only: i_use_2mq4b,i_use_2mt4b
   implicit none
   public type_fv3regfilenameg
   public bg_fv3regfilenameg
@@ -111,7 +115,7 @@ module gsi_rfv3io_mod
   public :: mype_u,mype_v,mype_t,mype_q,mype_p,mype_oz,mype_ql
   public :: mype_qi,mype_qr,mype_qs,mype_qg,mype_qnr,mype_w
   public :: k_slmsk,k_tsea,k_vfrac,k_vtype,k_stype,k_zorl,k_smc,k_stc
-  public :: k_snwdph,k_f10m,mype_2d,n2d,k_orog,k_psfc
+  public :: k_snwdph,k_f10m,mype_2d,n2d,k_orog,k_psfc,k_t2m,k_q2m
   public :: ijns,ijns2d,displss,displss2d,ijnz,displsz_g
   public :: fv3lam_io_dynmetvars3d_nouv,fv3lam_io_tracermetvars3d_nouv
   public :: fv3lam_io_dynmetvars2d_nouv,fv3lam_io_tracermetvars2d_nouv
@@ -120,7 +124,7 @@ module gsi_rfv3io_mod
   integer(i_kind) mype_qi,mype_qr,mype_qs,mype_qg,mype_qnr,mype_w
 
   integer(i_kind) k_slmsk,k_tsea,k_vfrac,k_vtype,k_stype,k_zorl,k_smc,k_stc
-  integer(i_kind) k_snwdph,k_f10m,mype_2d,n2d,k_orog,k_psfc
+  integer(i_kind) k_snwdph,k_f10m,mype_2d,n2d,k_orog,k_psfc,k_t2m,k_q2m
   parameter(                   &  
     k_f10m =1,                  &   !fact10
     k_stype=2,                  &   !soil_type
@@ -132,8 +136,10 @@ module gsi_rfv3io_mod
     k_stc  =8,                  &   !soil_temp
     k_smc  =9,                  &   !soil_moi
     k_slmsk=10,                 &   !isli
-    k_orog =11,                 & !terrain
-    n2d=11                   )
+    k_t2m =11,                 & ! 2 m T
+    k_q2m  =12,                 & ! 2 m Q
+    k_orog =13,                 & !terrain
+    n2d=13                   )
   logical :: grid_reverse_flag
   character(len=max_varname_length),allocatable,dimension(:) :: fv3lam_io_dynmetvars3d_nouv 
                                     ! copy of cvars3d excluding uv 3-d fields   
@@ -759,6 +765,8 @@ subroutine read_fv3_netcdf_guess(fv3filenamegin)
     real(r_kind),dimension(:,:,:),pointer::ges_tv=>NULL()
     real(r_kind),dimension(:,:,:),pointer::ges_tsen_readin=>NULL()
     real(r_kind),pointer,dimension(:,:,:):: ges_delp  =>NULL()
+    real(r_kind),dimension(:,:),pointer::ges_t2m=>NULL()
+    real(r_kind),dimension(:,:),pointer::ges_q2m=>NULL()
 
     real(r_kind),dimension(:,:,:),pointer::ges_ql=>NULL()
     real(r_kind),dimension(:,:,:),pointer::ges_qi=>NULL()
@@ -906,6 +914,8 @@ subroutine read_fv3_netcdf_guess(fv3filenamegin)
             ntracerio2d=ntracerio2d+1
           else if(trim(vartem)=='z') then
              write(6,*)'the metvarname ',trim(vartem),' will be dealt separately'
+          else if(trim(vartem)=='t2m') then
+          else if(trim(vartem)=='q2m') then
           else 
             write(6,*)'the metvarname2 ',trim(vartem),' has not been considered yet, stop'
             call stop2(333)
@@ -922,7 +932,8 @@ subroutine read_fv3_netcdf_guess(fv3filenamegin)
       jtracer=0
       do i=1,size(name_metvars2d)
         vartem=trim(name_metvars2d(i))
-        if(.not.( (trim(vartem)=='ps'.and.fv3sar_bg_opt==0).or.(trim(vartem)=="z")))  then !z is treated separately
+        if(.not.( (trim(vartem)=='ps'.and.fv3sar_bg_opt==0).or.(trim(vartem)=="z") &
+                  .or.(trim(vartem)=="t2m").or.(trim(vartem)=="q2m")))  then !z is treated separately
           if (ifindstrloc(vardynvars,trim(vartem)) > 0) then
             jdynvar=jdynvar+1
             fv3lam_io_dynmetvars2d_nouv(jdynvar)=trim(vartem)
@@ -1015,13 +1026,6 @@ subroutine read_fv3_netcdf_guess(fv3filenamegin)
 
       deallocate(lnames,names,uvlnames,uvnames)
 
-    
-
-
-
-      
-
-
       do it=1,nfldsig
          ier=0
          call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'ps' ,ges_ps ,istatus );ier=ier+istatus
@@ -1042,8 +1046,15 @@ subroutine read_fv3_netcdf_guess(fv3filenamegin)
             call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'qnr',ges_qnr ,istatus );ier=ier+istatus
             call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'w' , ges_w ,istatus );ier=ier+istatus
          end if
-   
          if (ier/=0) call die(trim(myname),'cannot get pointers for fv3 met-fields, ier =',ier)
+   
+         if(i_use_2mq4b > 0 .and. i_use_2mt4b > 0 ) then
+            call GSI_BundleGetPointer(GSI_MetGuess_Bundle(it),'q2m',ges_q2m,istatus ); ier=ier+istatus
+            if (ier/=0) call die(trim(myname),'cannot get pointers for q2m, ier=',ier)
+            call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it),'t2m',ges_t2m,istatus );ier=ier+istatus
+            if (ier/=0) call die(trim(myname),'cannot get pointers for t2m,ier=',ier)
+         endif
+
          if( fv3sar_bg_opt == 0) then 
             call gsi_fv3ncdf_readuv(grd_fv3lam_uv,ges_u,ges_v,fv3filenamegin(it))
          else
@@ -1100,8 +1111,13 @@ subroutine read_fv3_netcdf_guess(fv3filenamegin)
           
          endif
    
-         call gsi_fv3ncdf2d_read(fv3filenamegin(it),it,ges_z)
+         call gsi_fv3ncdf2d_read(fv3filenamegin(it),it,ges_z,ges_t2m,ges_q2m)
    
+         if(i_use_2mq4b > 0 .and. i_use_2mt4b > 0 ) then
+! Convert 2m guess mixing ratio to specific humidity
+            ges_q2m = ges_q2m/(one+ges_q2m)
+         endif
+
          if (l_use_dbz_directDA ) then
            if( fv3sar_bg_opt == 0) then
              ges_iqr=ges_qr
@@ -1116,10 +1132,9 @@ subroutine read_fv3_netcdf_guess(fv3filenamegin)
          end if
       end do
 
-
 end subroutine read_fv3_netcdf_guess
 
-subroutine gsi_fv3ncdf2d_read(fv3filenamegin,it,ges_z)
+subroutine gsi_fv3ncdf2d_read(fv3filenamegin,it,ges_z,ges_t2m,ges_q2m)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    gsi_fv3ncdf2d_read       
@@ -1155,6 +1170,8 @@ subroutine gsi_fv3ncdf2d_read(fv3filenamegin,it,ges_z)
 
     integer(i_kind),intent(in) :: it   
     real(r_kind),intent(in),dimension(:,:),pointer::ges_z
+    real(r_kind),intent(in),dimension(:,:),pointer::ges_t2m
+    real(r_kind),intent(in),dimension(:,:),pointer::ges_q2m
     type (type_fv3regfilenameg),intent(in) :: fv3filenamegin
     character(len=max_varname_length) :: name
     integer(i_kind),allocatable,dimension(:):: dim_id,dim
@@ -1233,6 +1250,10 @@ subroutine gsi_fv3ncdf2d_read(fv3filenamegin,it,ges_z)
              k=k_smc
           else if( trim(name)=='SLMSK'.or.trim(name)=='slmsk' ) then
              k=k_slmsk
+          else if( trim(name)=='T2M'.or.trim(name)=='t2m' ) then
+             k=k_t2m
+          else if( trim(name)=='Q2M'.or.trim(name)=='q2m' ) then
+             k=k_q2m
           else
              cycle 
           endif
@@ -1400,6 +1421,10 @@ subroutine gsi_fv3ncdf2d_read(fv3filenamegin,it,ges_z)
     soil_moi(:,:,it)=sfcn2d(:,:,k_smc)
     ges_z(:,:)=sfcn2d(:,:,k_orog)/grav
     isli(:,:,it)=nint(sfcn2d(:,:,k_slmsk))
+    if(i_use_2mq4b > 0 .and. i_use_2mt4b > 0 ) then
+       ges_t2m(:,:)=sfcn2d(:,:,k_t2m)
+       ges_q2m(:,:)=sfcn2d(:,:,k_q2m)
+    endif
     deallocate (sfcn2d,a)
     return
 end subroutine gsi_fv3ncdf2d_read
@@ -2073,6 +2098,7 @@ subroutine wrfv3_netcdf(fv3filenamegin)
     use directDA_radaruse_mod, only: l_use_dbz_directDA
     use directDA_radaruse_mod, only: l_cvpnr, cvpnr_pval
     use gridmod,  only: eta1_ll,eta2_ll
+    use constants, only: one
 
 
     implicit none
@@ -2086,6 +2112,8 @@ subroutine wrfv3_netcdf(fv3filenamegin)
     real(r_kind),pointer,dimension(:,:,:):: ges_u   =>NULL()
     real(r_kind),pointer,dimension(:,:,:):: ges_v   =>NULL()
     real(r_kind),pointer,dimension(:,:,:):: ges_q   =>NULL()
+    real(r_kind),pointer,dimension(:,:  ):: ges_t2m =>NULL()
+    real(r_kind),pointer,dimension(:,:  ):: ges_q2m  =>NULL()
    
     integer(i_kind) i,k
 
@@ -2121,6 +2149,11 @@ subroutine wrfv3_netcdf(fv3filenamegin)
        call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'qnr',ges_qnr,istatus);ier=ier+istatus
        call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'w' , ges_w ,istatus);ier=ier+istatus
     end if
+    if(i_use_2mq4b > 0 .and. i_use_2mt4b > 0 ) then
+       call GSI_BundleGetPointer (GSI_MetGuess_Bundle(it),'q2m',ges_q2m,istatus); ier=ier+istatus
+       call GSI_BundleGetPointer (GSI_MetGuess_Bundle(it),'t2m',ges_t2m,istatus );ier=ier+istatus
+    endif
+
     if(l_reg_update_hydro_delz) then
       allocate(ges_delzinc(lat2,lon2,nsig))
       do k=1,nsig
@@ -2177,8 +2210,12 @@ subroutine wrfv3_netcdf(fv3filenamegin)
 !   write out
     if (ier/=0) call die('get ges','cannot get pointers for fv3 met-fields, ier =',ier)
 
-    add_saved=.true.
+    if(i_use_2mq4b > 0 .and. i_use_2mt4b > 0 ) then
+! Convert 2m guess specific humidity to mixing ratio
+      ges_q2m = ges_q2m/(one-ges_q2m)
+    endif
 
+    add_saved=.true.
 !   write out
     if(fv3sar_bg_opt == 0) then
       call gsi_fv3ncdf_write(grd_fv3lam_dynvar_ionouv,gsibundle_fv3lam_dynvar_nouv,&
@@ -2195,6 +2232,12 @@ subroutine wrfv3_netcdf(fv3filenamegin)
                                 add_saved,fv3filenamegin%tracers,fv3filenamegin)
       call gsi_fv3ncdf_writeuv_v1(grd_fv3lam_uv,ges_u,ges_v,add_saved,fv3filenamegin)
     endif
+
+    if(i_use_2mq4b > 0 .and. i_use_2mt4b > 0 ) then
+      call gsi_fv3ncdf_write_sfc(fv3filenamegin,'t2m',ges_t2m,add_saved)
+      call gsi_fv3ncdf_write_sfc(fv3filenamegin,'q2m',ges_q2m,add_saved)
+    endif
+
     if(allocated(g_prsi)) deallocate(g_prsi)
 
     deallocate(ny_layout_len)
@@ -2621,6 +2664,136 @@ subroutine gsi_fv3ncdf_writeuv_v1(grd_uv,ges_u,ges_v,add_saved,fv3filenamegin)
 
 end subroutine gsi_fv3ncdf_writeuv_v1
 
+subroutine gsi_fv3ncdf_write_sfc(fv3filenamegin,varname,var,add_saved)
+!$$$  subprogram documentation block
+!                .      .    .                                        .
+! subprogram:    gsi_fv3ncdf_write_sfc
+!   pgrmmr: wu
+!
+! abstract:
+!
+! program history log:
+! 2022-02-25  Hu  write surface fields  
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+    use mpimod, only: ierror,mpi_comm_world,mpi_rtype,mype
+    use gridmod, only: lat1,lon1,lat2,lon2,nlat,nlon
+    use gridmod, only: ijn,displs_g,itotsub,iglobal
+    use gridmod,  only: nlon_regional,nlat_regional
+    use mod_fv3_lola, only: fv3_ll_to_h,fv3_h_to_ll
+    use general_commvars_mod, only: ltosi,ltosj
+    use netcdf, only: nf90_open,nf90_close
+    use netcdf, only: nf90_write,nf90_inq_varid
+    use netcdf, only: nf90_put_var,nf90_get_var
+    use gridmod, only: strip
+    implicit none
+
+    real(r_kind)   ,intent(in   ) :: var(lat2,lon2)
+    logical        ,intent(in   ) :: add_saved
+    character(*)   ,intent(in   ) :: varname
+    type (type_fv3regfilenameg),intent (in) :: fv3filenamegin
+
+    integer(i_kind) :: VarId,gfile_loc
+    integer(i_kind) i,mm1
+    real(r_kind),allocatable,dimension(:):: work
+    real(r_kind),allocatable,dimension(:,:):: work_sub,work_a
+    real(r_kind),allocatable,dimension(:,:):: work_b
+    real(r_kind),allocatable,dimension(:,:):: workb2,worka2
+    character(len=80)   :: filename
+
+! for io_layout > 1
+    real(r_kind),allocatable,dimension(:,:):: work_b_layout
+    integer(i_kind) :: nio
+    integer(i_kind),allocatable :: gfile_loc_layout(:)
+    character(len=180)  :: filename_layout
+
+    filename=trim(fv3filenamegin%sfcdata)
+
+    mm1=mype+1
+    allocate(work(max(iglobal,itotsub)),work_sub(lat1,lon1))
+    call strip(var,work_sub)
+    call mpi_gatherv(work_sub,ijn(mm1),mpi_rtype, &
+          work,ijn,displs_g,mpi_rtype,0,mpi_comm_world,ierror)
+    deallocate(work_sub)
+
+    if(mype==0) then
+       allocate( work_a(nlat,nlon))
+       do i=1,iglobal
+          work_a(ltosi(i),ltosj(i))=work(i)
+       end do
+       allocate( work_b(nlon_regional,nlat_regional))
+
+
+       if(fv3_io_layout_y > 1) then
+         allocate(gfile_loc_layout(0:fv3_io_layout_y-1))
+         do nio=0,fv3_io_layout_y-1
+            write(filename_layout,'(a,a,I4.4)') trim(filename),'.',nio
+            call check(nf90_open(trim(filename_layout),nf90_write,gfile_loc_layout(nio)) )
+         enddo
+         gfile_loc=gfile_loc_layout(0)
+       else
+         call check( nf90_open(trim(filename),nf90_write,gfile_loc) )
+       endif
+       call check( nf90_inq_varid(gfile_loc,trim(varname),VarId) )
+
+       if(add_saved)then
+          allocate( workb2(nlon_regional,nlat_regional))
+          allocate( worka2(nlat,nlon))
+!!!!!!!! read in guess !!!!!!!!!!!!!!
+
+          if(fv3_io_layout_y > 1) then
+             do nio=0,fv3_io_layout_y-1
+                allocate(work_b_layout(nlon_regional,ny_layout_len(nio)))
+                call check(nf90_get_var(gfile_loc_layout(nio),VarId,work_b_layout) )
+                work_b(:,ny_layout_b(nio):ny_layout_e(nio))=work_b_layout
+                deallocate(work_b_layout)
+              enddo
+          else
+             call check( nf90_get_var(gfile_loc,VarId,work_b) )
+          endif
+          call fv3_h_to_ll(work_b,worka2,nlon_regional,nlat_regional,nlon,nlat,grid_reverse_flag)
+!!!!!!! analysis_inc work_a
+          work_a(:,:)=work_a(:,:)-worka2(:,:)
+          call fv3_ll_to_h(work_a,workb2,nlon,nlat,nlon_regional,nlat_regional,grid_reverse_flag)
+             work_b(:,:)=work_b(:,:)+workb2(:,:)
+          deallocate(worka2,workb2)
+       else
+          call fv3_ll_to_h(work_a,work_b,nlon,nlat,nlon_regional,nlat_regional,grid_reverse_flag)
+       endif
+
+       if(fv3_io_layout_y > 1) then
+         do nio=0,fv3_io_layout_y-1
+            allocate(work_b_layout(nlon_regional,ny_layout_len(nio)))
+            work_b_layout=work_b(:,ny_layout_b(nio):ny_layout_e(nio))
+            call check( nf90_put_var(gfile_loc_layout(nio),VarId,work_b_layout) )
+            deallocate(work_b_layout)
+         enddo
+       else
+          call check( nf90_put_var(gfile_loc,VarId,work_b) )
+       endif
+
+       if(fv3_io_layout_y > 1) then
+         do nio=0,fv3_io_layout_y-1
+           call check(nf90_close(gfile_loc_layout(nio)))
+         enddo
+         deallocate(gfile_loc_layout)
+       else
+         call check(nf90_close(gfile_loc))
+       endif
+       deallocate(work_b,work_a)
+    end if !mype_io
+
+    deallocate(work)
+
+end subroutine gsi_fv3ncdf_write_sfc
 
 subroutine gsi_fv3ncdf_write(grd_ionouv,cstate_nouv,add_saved,filenamein,fv3filenamegin)
 !$$$  subprogram documentation block

--- a/src/gsi/setupt.f90
+++ b/src/gsi/setupt.f90
@@ -226,6 +226,8 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 !                         information in diagonostic file, which is used
 !                         in offline observation quality control program (AutoObsQC) 
 !                         for 3D-RTMA (if l_obsprvdiag is true).
+!   2022-03-15  Hu  change all th2 to t2m to indicate that 2m temperature 
+!                   is sensible instead of potentionl temperature
 !
 ! !REMARKS:
 !   language: f90
@@ -334,7 +336,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind),allocatable,dimension(:,:,:,:) :: ges_tv
   real(r_kind),allocatable,dimension(:,:,:,:) :: ges_q
   real(r_kind),allocatable,dimension(:,:,:  ) :: ges_q2
-  real(r_kind),allocatable,dimension(:,:,:  ) :: ges_th2
+  real(r_kind),allocatable,dimension(:,:,:  ) :: ges_t2m
 
   logical:: l_pbl_pseudo_itype
   integer(i_kind):: ich0
@@ -742,10 +744,8 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            if(i_coastline==1 .or. i_coastline==3) then
 
 !          Interpolate guess th 2m to observation location and time
-              call tintrp2a11_csln(ges_th2,tges2m,tges2m_water,dlat,dlon,dtime,hrdifsig,&
+              call tintrp2a11_csln(ges_t2m,tges2m,tges2m_water,dlat,dlon,dtime,hrdifsig,&
                 mype,nfldsig)
-              tges2m=tges2m*(r10*psges/r1000)**rd_over_cp_mass  ! convert to sensible T         
-              tges2m_water=tges2m_water*(r10*psges/r1000)**rd_over_cp_mass  ! convert to sensible T         
               if(iqtflg)then
                  call tintrp2a11_csln(ges_q2,qges2m,qges2m_water,dlat,dlon,dtime,hrdifsig,&
                      mype,nfldsig)
@@ -755,9 +755,8 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               if( abs(tob-tges2m) > abs(tob-tges2m_water)) tges2m=tges2m_water
            else
 !          Interpolate guess th 2m to observation location and time
-              call tintrp2a11(ges_th2,tges2m,dlat,dlon,dtime,hrdifsig,&
+              call tintrp2a11(ges_t2m,tges2m,dlat,dlon,dtime,hrdifsig,&
                 mype,nfldsig)
-              tges2m=tges2m*(r10*psges/r1000)**rd_over_cp_mass  ! convert to sensible T         
               if(iqtflg)then
                  call tintrp2a11(ges_q2,qges2m,dlat,dlon,dtime,hrdifsig,&
                      mype,nfldsig)
@@ -1413,19 +1412,19 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
          call stop2(999)
      endif
      if(i_use_2mt4b>0) then
-!    get th2m ...
-        varname='th2m'
+!    get t2m ...
+        varname='t2m'
         call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank2,istatus)
         if (istatus==0) then
-            if(allocated(ges_th2))then
+            if(allocated(ges_t2m))then
                write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
                call stop2(999)
             endif
-            allocate(ges_th2(size(rank2,1),size(rank2,2),nfldsig))
-            ges_th2(:,:,1)=rank2
+            allocate(ges_t2m(size(rank2,1),size(rank2,2),nfldsig))
+            ges_t2m(:,:,1)=rank2
             do ifld=2,nfldsig
                call gsi_bundlegetpointer(gsi_metguess_bundle(ifld),trim(varname),rank2,istatus)
-               ges_th2(:,:,ifld)=rank2
+               ges_t2m(:,:,ifld)=rank2
             enddo
         else
             write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
@@ -1835,7 +1834,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     if(allocated(ges_u )) deallocate(ges_u )
     if(allocated(ges_ps)) deallocate(ges_ps)
     if(allocated(ges_q2)) deallocate(ges_q2)
-    if(allocated(ges_th2)) deallocate(ges_th2)
+    if(allocated(ges_t2m)) deallocate(ges_t2m)
   end subroutine final_vars_
 
 end subroutine setupt

--- a/src/gsi/update_guess.f90
+++ b/src/gsi/update_guess.f90
@@ -136,7 +136,7 @@ subroutine update_guess(sval,sbias)
   use rapidrefresh_cldsurf_mod, only: l_gsd_limit_ocean_q,l_gsd_soilTQ_nudge
   use rapidrefresh_cldsurf_mod, only: i_use_2mq4b,i_use_2mt4b
   use gsd_update_mod, only: gsd_limit_ocean_q,gsd_update_soil_tq,&
-       gsd_update_th2,gsd_update_q2
+       gsd_update_t2m,gsd_update_q2
   use qcmod, only: pvis,pcldch,vis_thres,cldch_thres 
   use obsmod, only: l_wcp_cwm
   use directDA_radaruse_mod, only: l_use_cvpqx, l_use_dbz_directDA
@@ -460,8 +460,8 @@ subroutine update_guess(sval,sbias)
               tinc_1st(i,j)=p_tv(i,j,1)
            end do
         end do
-        call  gsd_update_th2(tinc_1st,it)
-     endif ! l_gsd_th2_adjust
+        call  gsd_update_t2m(tinc_1st,it)
+     endif ! l_gsd_t2m_adjust
      if (i_use_2mq4b > 0 .and. is_q>0) then
         do j=1,lon2
            do i=1,lat2


### PR DESCRIPTION
This PR address issue #335:

1) Add function to read and write 2m T and Q from fv3lam background
   and used 2m T and Q as background to calculate innovation for
   2m T/Q surface observations.

2) Change the variable name for 2m T from th2 to t2m to indicate
   It is a sensible temperature now. It was a potential temperature.
   The converting between potential and sensible is in
   background IO (from ARW)

3) Add function to remove the negative moisture analysis
   if background is not too dry (RH > 4%) for
   the lowest three model levels. This function is in the code to
   write analysis results for ARW and only used in RAP/HRRR.

Note:
The anavinfo for RAP/HRRR need to be changed:
change:
  th2m      1      -1         2-m_T                th2m
to
  t2m       1      -1         2-m_T                t2m

Also, the results of the analysis for ARW background (RAP/HRRR) is changed.
