### PR TITLE
GitHub Issue NOAA-EMC/GSI#339. The inclusion of the mixed surface type in situ observations and looser QC for in situ observations

### DIFF
--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -804,7 +804,7 @@ cat > gsiparm.anl << EOF
   $OBSQC
 /
 &OBS_INPUT
-  dmesh(1)=145.0,dmesh(2)=150.0,dmesh(3)=100.0,dmesh(4)=70.0,time_window_max=3.0,
+  dmesh(1)=145.0,dmesh(2)=150.0,dmesh(3)=100.0,dmesh(4)=25.0,time_window_max=3.0,
   $OBSINPUT
 /
 OBS_INPUT::

--- a/src/gsi/setupsst.f90
+++ b/src/gsi/setupsst.f90
@@ -61,6 +61,8 @@ subroutine setupsst(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
 !   2017-02-09  guo     - Remove m_alloc, n_alloc.
 !                       . Remove my_node with corrected typecast().
 !   2019-11-12  li      - add 4 nsst variables to netcdf sst diag file
+!   2022-04-04  li      - modify to use mixed surface in situ observations
+!                         if ( isli == 0 ) then =>  if ( owpct > 0.05_r_kind ) then
 !
 !   input argument list:
 !     lunin    - unit from which to read observations
@@ -309,7 +311,7 @@ subroutine setupsst(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
      if(.not.in_curbin) cycle
 
 ! Interpolate to get sst at obs location/time
-     if ( isli == 0 ) then
+     if ( owpct > 0.05_r_kind ) then
        nobs_qc = nobs_qc + 1
        call intrp2a11(dsfct(1,1,ntguessfc),dsfct_obx,dlat,dlon,mype)
      else


### PR DESCRIPTION
Background

The too warm NSST analysis over the Pamlico Sound area has been reported by MEG people, the diagnosis of the causes has been performed. Besides the correlation length and thinning mesh, the other two causes are:  (1) the in situ observations with mixed surface type are not used; (2) The threshold of the O - B QC test is too tight. The PR is to handle these two causes. 

See https://github.com/NOAA-EMC/GSI/issues/339

The cycling run, oprcst10 and oprcst2, have been done to test the changes and it shows expected results and the too warm Pamlico Sound issue is resolved. 

It is ready to merge to the master.