### PR TITLE
GitHub Issue NOAA-EMC/GSI#363.  Convert the global 127-L BE vertical length scale unit for regional DA

### DIFF
--- a/src/gsi/balmod.f90
+++ b/src/gsi/balmod.f90
@@ -907,6 +907,8 @@ contains
 !   2005-03-28  wu - replace mlath with mlat
 !   2005-04-22  treadon - change berror file to 4-byte reals
 !   2005-06-06  wu - setup f1 for balance projection (st->t) when fstat=.true.
+!   2022-04-20  x.zhang - add switch (usenewgfsberror)for no need to convert 
+!                         the unit of clat for using global 127-L BE in regional DA
 !
 !   input argument list:
 !     mype     - mpi task id
@@ -924,6 +926,7 @@ contains
     use gridmod, only: nlon,nlat,lat2,lon2,istart,jstart,region_lat
     use m_berror_stats, only: berror_stats
     use constants, only: deg2rad,one
+    use m_berror_stats, only: usenewgfsberror
     implicit none
     
 !   Declare passed variables
@@ -946,9 +949,16 @@ contains
     allocate( clat_avn(mlat), clat_avn4(mlat) )
     read(lunin)clat_avn4
     close(lunin)
-    do i=1,mlat
-       clat_avn(i)=clat_avn4(i)*deg2rad
-    end do
+    if (usenewgfsberror) then
+!      'The unit of clat from global BE is radian, do not need to convert'
+       do i=1,mlat
+         clat_avn(i)=clat_avn4(i)
+       end do
+    else
+       do i=1,mlat
+         clat_avn(i)=clat_avn4(i)*deg2rad
+       end do
+    end if
     deallocate(clat_avn4)
     
 


### PR DESCRIPTION
This pull request is for the issue #363
convert the unit of VZ in GSI code: m_berror_stats_reg.f90 to ensure the global 127-L BE is properly used by regional DA. This is controlled by 'usenewgfsberror=.true.'. It won't affect any other BE files to be used for regional DA.

Steps to use global BE vertical length scale:

Read vz from BE file, unit is: 1/layer
Convert unit to 1/sigma : vz= vz_in_global_levs/dlsig(k)_glb
Interpolate global vz to RRFS sigma level
Normalization and convert to grid unit (1/layer):
vz= vz*dlsig(regional model)