### PR TITLE
GitHub Issue NOAA-EMC/GSI#383 Update hpc-stack in Cheyenne modulefiles for GNU and Intel compilers.

### DIFF
--- a/modulefiles/gsi_cheyenne.gnu.lua
+++ b/modulefiles/gsi_cheyenne.gnu.lua
@@ -9,18 +9,21 @@ load("mpt/2.22")
 load("ncarcompilers/0.5.0")
 unload("netcdf")
 
-prepend_path("MODULEPATH", "/glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.2.0/modulefiles/stack")
+prepend_path("MODULEPATH", "/glade/work/epicufsrt/GMTB/tools/gnu/10.1.0/hpc-stack-v1.2.0/modulefiles/stack")
 
 load("hpc/1.2.0")
 load("hpc-gnu/10.1.0")
 load("hpc-mpt/2.22")
+
+-- Preload w3nco to work around nemsio "find_dependency(w3nco)" hpc-stack bug
+load("w3nco/2.4.1")
 
 load("gsi_common")
 
 local prod_util_ver=os.getenv("prod_util_ver") or "1.2.2"
 load(pathJoin("prod_util", prod_util_ver))
 
-pushenv("MKLROOT", "/glade/u/apps/opt/intel/2021.2/mkl/latest")
+pushenv("MKLROOT", "/glade/u/apps/opt/intel/2022.1/mkl/latest")
 
 pushenv("CC",  "mpicc")
 pushenv("FC",  "mpif90")

--- a/modulefiles/gsi_cheyenne.intel.lua
+++ b/modulefiles/gsi_cheyenne.intel.lua
@@ -4,16 +4,16 @@ help([[
 load("cmake/3.22.0")
 load("python/3.7.9")
 load("ncarenv/1.3")
-load("intel/2021.2")
-load("mpt/2.22")
+load("intel/2022.1")
+load("mpt/2.25")
 load("ncarcompilers/0.5.0")
 
-prepend_path("MODULEPATH", "/glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.2.0/modulefiles/stack")
+prepend_path("MODULEPATH", "/glade/work/epicufsrt/GMTB/tools/intel/2022.1/hpc-stack-v1.2.0_6eb6/modulefiles/stack")
 
 load("hpc/1.2.0")
-load("hpc-intel/2021.2")
-load("hpc-mpt/2.22")
-load("mkl/2021.2")
+load("hpc-intel/2022.1")
+load("hpc-mpt/2.25")
+load("mkl/2022.1")
 
 load("gsi_common")
 


### PR DESCRIPTION
This PR closes #383 by updating modulefiles for Cheyenne Intel and GNU builds.  The version of hpc-stack was updated to a newer one maintained by EPIC.  Additionally, the version of the compiler and MPT MPI was updated for Intel.

A small workaround was necessary for the GNU module file to avoid a `find_dependency(w3nco)` [issue](https://github.com/NOAA-EMC/hpc-stack/issues/451) with the GNU version of hpc-stack.

The builds were tested successfully on Cheyenne:

Intel: `ush/build.sh`
GNU: `bash -c "COMPILER=gnu ush/build.sh"`

Regression tests were not run because they are not supported on Cheyenne.