### PR TITLE
GitHub Issue NOAA-EMC/GSI#380.  Exclude NOAA15/16 AMSU-A from antenna correction

### DIFF
--- a/src/gsi/read_bufrtovs.f90
+++ b/src/gsi/read_bufrtovs.f90
@@ -742,8 +742,12 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
 
               if (llll == 1) then
                  call ufbrep(lnbufr,data1b8,1,nchanl,iret,'TMBR')
-                 if ( amsua .or. amsub .or. mhs )then
-                    ! convert antenna temperature to brightness temperature
+                 if ( (amsua .or. amsub .or. mhs) .and. &
+                      .not.(jsatid == 'n15' .or. jsatid == 'n16') )then
+                    ! convert antenna temperature to brightness temperature,
+                    ! unless the satellite is n15 or n16, because tranamsua
+                    ! does this conversion because the coefficient files exist
+                    ! for it to use
                     data1b8x=data1b8
                     data1b4=data1b8
                     !call apply_antcorr(accoeff_sets(spc_coeff_versions),ifov,data1b4)


### PR DESCRIPTION
This change is needed in order to not apply antenna correction to these observations twice. The [tranamsua](https://github.com/NOAA-EMC/satingest/blob/develop/sorc/bufr_tranamsua.fd/tranamsua.f) code is doing this transformation already.