### PR TITLE
GitHub Issue NOAA-EMC/GSI#394.  Add -g and -traceback Intel compiler options back into utilities and ncdiag

### DIFF
--- a/src/GSD/gsdcloud/CMakeLists.txt
+++ b/src/GSD/gsdcloud/CMakeLists.txt
@@ -22,9 +22,9 @@ if(NOT CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Intel)$")
 endif()
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -convert big_endian")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -convert big_endian")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fconvert=big-endian")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -fbacktrace -fconvert=big-endian")
 endif()
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")

--- a/src/ncdiag/cmake/ncdiag_compiler_flags_Intel_Fortran.cmake
+++ b/src/ncdiag/cmake/ncdiag_compiler_flags_Intel_Fortran.cmake
@@ -2,7 +2,7 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -assume byterecl -convert big_endian -implicitnone")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -assume byterecl -convert big_endian -implicitnone")
 
 ####################################################################
 # RELEASE FLAGS

--- a/util/cmake/gsiutils_compiler_flags_Intel_Fortran.cmake
+++ b/util/cmake/gsiutils_compiler_flags_Intel_Fortran.cmake
@@ -2,7 +2,7 @@
 # FLAGS COMMON TO ALL BUILD TYPES
 ####################################################################
 
-set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS} -g -traceback -implicitnone")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -implicitnone")
 
 ####################################################################
 # RELEASE FLAGS


### PR DESCRIPTION
Following the CMake refactor, it was noted that `ncdiag` wasn't giving meaningful traceback information while debugging `nc_diag_cat.x` issues (please see issue [380](https://github.com/NOAA-EMC/GSI/issues/380#issuecomment-1133152957)). Compiling using VERBOSE=1 shows that only the GSI and EnKF are compiling using -g and -traceback compiler options, so both -g and -traceback have been added to the Intel compiler options.

Resolves #394 