### PR TITLE
GitHub Issue NOAA-EMC/GSI#388. Verification of readin_localization=.true. for regional GSI.

### DIFF
--- a/src/gsi/hybrid_ensemble_isotropic.F90
+++ b/src/gsi/hybrid_ensemble_isotropic.F90
@@ -4175,7 +4175,7 @@ subroutine convert_km_to_grid_units(s_ens_h_gu_x,s_ens_h_gu_y,nz)
   implicit none
 
   integer(i_kind) ,intent(in   ) ::nz
-  real(r_kind),intent(  out) ::s_ens_h_gu_x(nz),s_ens_h_gu_y(nz)
+  real(r_kind),intent(  out) ::s_ens_h_gu_x(nz*n_ens),s_ens_h_gu_y(nz*n_ens)
   logical :: print_verbose
   real(r_kind) dxmax,dymax
   integer(i_kind) k,n,nk


### PR DESCRIPTION
A quick fix for an "exceeding array bound" error when regional GSI in debug mode ran with readin_localizaiion=.true..
See issue : https://github.com/NOAA-EMC/GSI/issues/388. 
The new code shows identical results when built with debug mode or optimization mode.
And, both of them are also identical with previous GSI built with optimization mode, which is expected when the involved array is stored continuously in the memory. 
The identical results are concluded according to their output in the gsi stdout, especially for their Final/Initial cost/gradient as shown below
![image](https://user-images.githubusercontent.com/15043351/170513116-a6b0efc5-6f8c-46ce-b8a6-308255d7a36c.png)
 