### PR TITLE
GitHub Issue NOAA-EMC/GSI#402. Add necessary entries to build_4nco_global.sh to build required utilities.

### DIFF
--- a/ush/build_4nco_global.sh
+++ b/ush/build_4nco_global.sh
@@ -17,7 +17,7 @@ export INSTALL_PREFIX="$DIR_ROOT/install_4nco"
 export GSI_MODE="GFS"
 export ENKF_MODE="GFS"
 export REGRESSION_TESTS="NO"
-export UTIL_OPTS="-DBUILD_UTIL_ENKF_GFS=ON"
+export UTIL_OPTS="-DBUILD_UTIL_ENKF_GFS=ON -DBUILD_UTIL_MON=ON -DBUILD_UTIL_NCIO=ON"
 
 # Prune the directory structure per NCO liking
 $DIR_ROOT/ush/prune_4nco_global.sh prune


### PR DESCRIPTION
It has been noted that `ush/build_4nco_global.sh` doesn't build all of the necessary utilities for the GFS. Updating `ush/build_4nco_global.sh` to include `-DBUILD_UTIL_MON=ON -DBUILD_UTIL_NCIO=ON` to ensure that all utilities are properly built.

Closes #402 