### PR TITLE
GitHub Issue NOAA-EMC/GSI#413. Correct incorrect variables in LUA modulefiles.

### DIFF
--- a/modulefiles/gsi_hera.gnu.lua
+++ b/modulefiles/gsi_hera.gnu.lua
@@ -4,8 +4,8 @@ help([[
 prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
 
 local hpc_ver=os.getenv("hpc_ver") or "1.1.0"
-local hpc_intel_ver=os.getenv("hpc_gnu_ver") or "9.2.0"
-local impi_ver=os.getenv("hpc_mpich_ver") or "3.3.2"
+local hpc_gnu_ver=os.getenv("hpc_gnu_ver") or "9.2.0"
+local hpc_mpich_ver=os.getenv("hpc_mpich_ver") or "3.3.2"
 local cmake_ver=os.getenv("cmake_ver") or "3.20.1"
 local prod_util_ver=os.getenv("prod_util_ver") or "1.2.2"
 

--- a/modulefiles/gsi_hera.intel.lua
+++ b/modulefiles/gsi_hera.intel.lua
@@ -5,7 +5,7 @@ prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/mo
 
 local hpc_ver=os.getenv("hpc_ver") or "1.1.0"
 local hpc_intel_ver=os.getenv("hpc_intel_ver") or "18.0.5.274"
-local impi_ver=os.getenv("hpc_impi_ver") or "2018.0.4"
+local hpc_impi_ver=os.getenv("hpc_impi_ver") or "2018.0.4"
 local cmake_ver=os.getenv("cmake_ver") or "3.20.1"
 local anaconda_ver=os.getenv("anaconda_ver") or "2.3.0"
 local prod_util_ver=os.getenv("prod_util_ver") or "1.2.2"

--- a/modulefiles/gsi_orion.lua
+++ b/modulefiles/gsi_orion.lua
@@ -5,7 +5,7 @@ prepend_path("MODULEPATH", "/apps/contrib/NCEP/libs/hpc-stack/modulefiles/stack"
 
 local hpc_ver=os.getenv("hpc_ver") or "1.1.0"
 local hpc_intel_ver=os.getenv("hpc_intel_ver") or "2018.4"
-local impi_ver=os.getenv("hpc_impi_ver") or "2018.4"
+local hpc_impi_ver=os.getenv("hpc_impi_ver") or "2018.4"
 local cmake_ver=os.getenv("cmake_ver") or "3.22.1"
 local python_ver=os.getenv("python_ver") or "3.7.5"
 local prod_util_ver=os.getenv("prod_util_ver") or "1.2.2"

--- a/modulefiles/gsi_s4.lua
+++ b/modulefiles/gsi_s4.lua
@@ -3,7 +3,7 @@ help([[
 
 local hpc_ver=os.getenv("hpc_ver") or "1.1.0"
 local hpc_intel_ver=os.getenv("hpc_intel_ver") or "18.0.4"
-local impi_ver=os.getenv("hpc_impi_ver") or "18.0.4"
+local hpc_impi_ver=os.getenv("hpc_impi_ver") or "18.0.4"
 local miniconda_ver=os.getenv("miniconda_ver") or "3.8-s4"
 local prod_util_ver=os.getenv("prod_util_ver") or "1.2.2"
 

--- a/modulefiles/gsi_wcoss_dell_p3.lua
+++ b/modulefiles/gsi_wcoss_dell_p3.lua
@@ -2,8 +2,8 @@ help([[
 ]])
 
 local hpc_ver=os.getenv("hpc_ver") or "1.1.0"
-local hpc_intel_ver=os.getenv("hpc_ips_ver") or "18.0.1.163"
-local impi_ver=os.getenv("hpc_impi_ver") or "18.0.1"
+local hpc_ips_ver=os.getenv("hpc_ips_ver") or "18.0.1.163"
+local hpc_impi_ver=os.getenv("hpc_impi_ver") or "18.0.1"
 local cmake_ver=os.getenv("cmake_ver") or "3.20.0"
 local lsf_ver=os.getenv("lsf_ver") or "10.1"
 local jasper_ver=os.getenv("jasper_ver") or "2.0.22"


### PR DESCRIPTION
* `gsi_hera.gnu.lua` - replaced:
```
local hpc_intel_ver=os.getenv("hpc_gnu_ver") or "9.2.0"
local impi_ver=os.getenv("hpc_mpich_ver") or "3.3.2"
```
with:
```
local hpc_gnu_ver=os.getenv("hpc_gnu_ver") or "9.2.0"
local hpc_mpich_ver=os.getenv("hpc_mpich_ver") or "3.3.2"
```
* `gsi_hera.intel.lua` - replaced:

`local impi_ver=os.getenv("hpc_impi_ver") or "2018.0.4"`
with:
`local hpc_impi_ver=os.getenv("hpc_impi_ver") or "2018.0.4"`

* `gsi_orion.lua` - replaced:

`local impi_ver=os.getenv("hpc_impi_ver") or "2018.4"`
with:
`local hpc_impi_ver=os.getenv("hpc_impi_ver") or "2018.4"`

* `gsi_s4.lua` - replaced:

`local impi_ver=os.getenv("hpc_impi_ver") or "18.0.4"`
with:
`local hpc_impi_ver=os.getenv("hpc_impi_ver") or "18.0.4"`

* `gsi_wcoss_dell_p3.lua` - replaced:
```
local hpc_intel_ver=os.getenv("hpc_ips_ver") or "18.0.1.163"
local impi_ver=os.getenv("hpc_impi_ver") or "18.0.1"
```
with:
```
local hpc_ips_ver=os.getenv("hpc_ips_ver") or "18.0.1.163"
local hpc_impi_ver=os.getenv("hpc_impi_ver") or "18.0.1"
```

Fixes #413 