### PR TITLE
GitHub Issue NOAA-EMC/GSI#266.  remove global_cycle from DA jobs and scripts

### DIFF
--- a/jobs/JGDAS_ATMOS_ANALYSIS_DIAG
+++ b/jobs/JGDAS_ATMOS_ANALYSIS_DIAG
@@ -110,15 +110,6 @@ if [ $DOHYBVAR = "YES" ]; then
 fi
 
 
-
-# Update surface fields with global_cycle
-export DOGCYCLE=${DOGCYCLE:-"YES"}
-
-
-# Generate Gaussian surface analysis
-export DOGAUSFCANL=${DOGAUSFCANL:-"YES"}
-
-
 ###############################################################
 # Run relevant script
 env

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS
@@ -131,14 +131,6 @@ export TCVITL="${COMOUT}/${OPREFIX}syndata.tcvitals.tm00"
 [[ $DONST = "YES" ]] && export NSSTBF="${COMIN_OBS}/${OPREFIX}nsstbufr"
 
 
-# Update surface fields with global_cycle
-export DOGCYCLE=${DOGCYCLE:-"YES"}
-
-
-# Generate Gaussian surface analysis
-export DOGAUSFCANL=${DOGAUSFCANL:-"YES"}
-
-
 # Copy fix file for obsproc
 if [ $RUN = "gfs" ]; then
     mkdir -p $ROTDIR/fix

--- a/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
+++ b/jobs/JGLOBAL_ATMOS_ANALYSIS_CALC
@@ -121,11 +121,6 @@ if [ $DOHYBVAR = "YES" ]; then
 fi
 
 
-
-# Update surface fields with global_cycle
-export DOGCYCLE=${DOGCYCLE:-"YES"}
-
-
 # Generate Gaussian surface analysis
 export DOGAUSFCANL=${DOGAUSFCANL:-"YES"}
 


### PR DESCRIPTION
The PR removes global_cycle from DA jobs and scripts.   global_cycle is part of the global workflow, not NOAA-EMC/GSI.   As such, this PR does not alter the behavior of applications specific to NOAA-EMC/GSI.   