### PR TITLE
GitHub Issue NOAA-EMC/GSI#419. correct minor code and link bugs

### DIFF
--- a/util/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90
+++ b/util/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90
@@ -99,7 +99,7 @@ program getsigensmeanp_smooth
   filenameout = trim(adjustl(datapath)) // trim(adjustl(filenameout))
   ! if a 5th arg present, it's a filename to write out ensemble spread
   ! (only used for ncio)
-  if (iargc() > 5) then
+  if (iargc() > 4) then
      call getarg(5,filenameoutsprd)
      write_spread_ncio = .true.
      if (mype == 0) print *,'computing ensemble spread'

--- a/util/netcdf_io/calc_analysis.fd/CMakeLists.txt
+++ b/util/netcdf_io/calc_analysis.fd/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(calc_analysis.x PRIVATE MPI::MPI_Fortran)
 target_link_libraries(calc_analysis.x PRIVATE bacio::bacio_4)
 target_link_libraries(calc_analysis.x PRIVATE nemsio::nemsio)
 target_link_libraries(calc_analysis.x PRIVATE ncio::ncio)
-target_link_libraries(calc_analysis.x PRIVATE w3emc::w3emc_d)
+target_link_libraries(calc_analysis.x PRIVATE w3emc::w3emc_4)
 
 # Install executable targets
 install(TARGETS calc_analysis.x RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This PR resolves two minor bugs in DA utility codes:

1. fix code bug in `util/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90`
2. fix link bug in `util/netcdf_io/calc_analysis.fd/CMakeLists.txt`

Details are found in issue #419 