### PR TITLE
GitHub Issue NOAA-EMC/GSI#423.  Replace ncio/1.0.0 with ncio/1.1.2.

### DIFF
--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -15,7 +15,7 @@ spack:
   - sfcio@1.4.1
   - nemsio@2.5.2
   - wrf-io@1.2.0
-  - ncio@1.0.0
+  - ncio@1.1.2
   - crtm@2.3.0
   - gsi-ncdiag@1.0.0
   view: true

--- a/modulefiles/gsi_common.lua
+++ b/modulefiles/gsi_common.lua
@@ -13,7 +13,7 @@ local sigio_ver=os.getenv("sigio_ver") or "2.3.2"
 local sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
 local nemsio_ver=os.getenv("nemsio_ver") or "2.5.2"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
-local ncio_ver=os.getenv("ncio_ver") or "1.0.0"
+local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
 local crtm_ver=os.getenv("crtm_ver") or "2.3.0"
 
 load(pathJoin("netcdf", netcdf_ver))

--- a/modulefiles/gsi_wcoss2.lua
+++ b/modulefiles/gsi_wcoss2.lua
@@ -19,5 +19,12 @@ load(pathJoin("python", python_ver))
 load(pathJoin("prod_util", prod_util_ver))
 
 load("gsi_common")
+unload("ncio")
+
+pushenv("HPC_OPT", "/apps/ops/para/libs")
+prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/compiler/intel/19.1.3.304")
+prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.7")
+
+load("ncio/1.1.2")
 
 whatis("Description: GSI environment on WCOSS2")


### PR DESCRIPTION
Replace ncio/1.0.0 with ncio/1.1.2 in modulefiles/gsi_common.lua and add commands to load ncio/1.1.2 from para for WCOSS2 in gsi_wcoss2.lua.  Updated ncio version in ci/spack.yaml from 1.0.0 to 1.1.2.

Closes #423 