### PR TITLE
Fix to ensure the initialization step will be performed for uninitialized channels

### DIFF
--- a/src/gsi/radinfo.f90
+++ b/src/gsi/radinfo.f90
@@ -848,7 +848,8 @@ contains
                          varA(i,j)=varx(i)
                       end do
                       ostats(j)=ostatsx
-                      if ((any(varx>r10) .and. iuse_rad(j)>-2) .or. iuse_rad(j)==4) &
+                      if ((all(varx==zero) .and. iuse_rad(j)>-2) .or. iuse_rad(j)==4) cycle read3 
+                      if ((any(varx/=r10) .and. iuse_rad(j)>-2) .or. iuse_rad(j)==4) &
                          inew_rad(j)=.false.
                       cycle read3
                    end if

--- a/src/gsi/radinfo.f90
+++ b/src/gsi/radinfo.f90
@@ -608,7 +608,7 @@ contains
 ! !USES:
 
     use obsmod, only: iout_rad
-    use constants, only: zero,one,zero_quad
+    use constants, only: zero,one,zero_quad, r10
     use mpimod, only: mype
     use mpeu_util, only: perr,die
     implicit none
@@ -848,7 +848,7 @@ contains
                          varA(i,j)=varx(i)
                       end do
                       ostats(j)=ostatsx
-                      if ((any(varx/=zero) .and. iuse_rad(j)>-2) .or. iuse_rad(j)==4) & 
+                      if ((any(varx>r10) .and. iuse_rad(j)>-2) .or. iuse_rad(j)==4) &
                          inew_rad(j)=.false.
                       cycle read3
                    end if
@@ -1860,6 +1860,7 @@ contains
          end do 
       end do loop_a
 
+      write(6,*) 'INIT_PREDX: inst_sat  new_chan = ', trim(fdiag_rad), new_chan
       if (.not. update .and. new_chan==0) then 
          call close_radiag(fdiag_rad,lndiag)
          cycle loopf


### PR DESCRIPTION
### **Issue**
A very slow and less optimal initialization of radiance bias correction was observed in the gfsv16.3.0 parallel experiment (**v163**, **blue line**).  The first analysis is 2021101600, and the initial bias estimation occurs in 2021101606.   The issue described here did NOT occur in the low-resolution v16.x parallel experiments on HERA because older version of GSI was used in these experiments.

Example: AMSU-A NOAA-15 Channel 1
Vertical axis is the **Number of Observation** used (passed QC)  in the analysis.  
![NOAA-15](https://user-images.githubusercontent.com/36091766/179431112-7a6867e8-6ec9-453a-8939-befd8656bb00.png)
Vertical axis is **Bias**
![NOAA-15 Bias](https://user-images.githubusercontent.com/36091766/179440218-4c5e15d8-455c-4a45-9dc7-062a21f1a213.png)

The **v163 (blue line)** is observed from gfsv16.3.0 parallel experiment.  The **v163t (red line)** is an experimental run with the [fix](https://github.com/NOAA-EMC/GSI/pull/439/files) proposed in this PR.

### Please see Issue #438 for background, diagnostics, and the fix (more details).  

