### PR TITLE
GitHub Issue NOAA-EMC/GSI#442. Bug fix of reading in radar level2 bufr

### DIFF
--- a/src/gsi/read_l2bufr_mod.f90
+++ b/src/gsi/read_l2bufr_mod.f90
@@ -22,6 +22,8 @@ module read_l2bufr_mod
 !   2011-07-04  todling  - fixes to run either single or double precision
 !   2020-10-23  S.Liu    - fix reading l2rw_bufr issue
 !   2020-10-14  xu/sippel - Add options to superob the GRO
+!   2021-12-08  s.liu    - change max_num_radars from 150 to 250
+!   2021-12-10  s.liu    - fixes to find the index of radar station
 !
 ! subroutines included:
 !   sub initialize_superob_radar - initialize superob parameters to defaults
@@ -147,7 +149,7 @@ contains
 
     integer(i_kind),intent(in):: npe,mype
 
-    integer(i_kind),parameter:: max_num_radars=150
+    integer(i_kind),parameter:: max_num_radars=250
     integer(i_kind),parameter:: maxobs=2e8 
     integer(i_kind),parameter:: n_gates_max=4000
     real(r_kind),parameter:: four_thirds = 4.0_r_kind / 3.0_r_kind
@@ -247,7 +249,7 @@ contains
     character(len=256),allocatable,dimension(:):: rtable 
     character(4),allocatable,dimension(:):: rsite 
     integer(i_kind),allocatable,dimension(:):: ruse 
- 
+
     print_verbose=.false.
     if(verbose) print_verbose=.true.
     if (radar_sites) then 
@@ -371,7 +373,7 @@ contains
              end do 
              if (radar_true == 0) cycle 
           end if 
-          ibyte=index(cstn_id_table,stn_id)
+          ibyte=locindex(stn_id_table,max_num_radars,stn_id)
           if(ibyte==0) then
              num_radars=num_radars+1
              if(num_radars>max_num_radars) then
@@ -548,7 +550,7 @@ contains
 	     cycle
 	  end if
 	  stn_id=chdr 
-	  ibyte=index(cmaster_stn_table,stn_id)
+	  ibyte=locindex(master_stn_table,max_num_radars,stn_id)
           if (radar_sites) then 
              radar_true=0 
              do i=1,radar_count 
@@ -562,7 +564,7 @@ contains
 	     write(6,*) ' index error in radar_bufr_read_all -- program stops -- ',ibyte,stn_id
 	     call stop2(99)
 	  else
-	     krad=1+(ibyte-1)/4
+	     krad=ibyte
 	  end if
 
 	  call ufbint(inbufr,rwnd,3,n_gates_max,n_gates,'DIST125M DMVR DVSW')
@@ -1054,4 +1056,21 @@ SUBROUTINE invtllv(ALM,APH,TLMO,CTPH0,STPH0,TLM,TPH)
   TPH=ASIN(CTPH0*SPH+STPH0*CC)
   return
 END SUBROUTINE invtllv
+
+FUNCTION locindex(stnall,nstr,stn)
+  use kinds, only:  i_kind
+  implicit none
+  
+  integer(i_kind),intent(in):: nstr
+  character(4),intent(in):: stnall(nstr)
+  character(4),intent(in):: stn
+  integer(i_kind):: i,locindex
+  do i=1,nstr
+     locindex=index(stnall(i),stn)
+     if(locindex>0) then
+       locindex=i
+       exit
+     end if
+  end do
+END FUNCTION locindex
 end module read_l2bufr_mod


### PR DESCRIPTION
NAM-GSI abort in Aug 2019 and Nov 2021 due to failure of reading in level2 radar bufr with error message:

min,max num_radars= 14 25
index error in radar_bufr_read_all -- program stops -- 0 KPAH
STOP2 ABORTING EXECUTION w/code= 99

The bug was found in building radar master table and finding the radar name index. In a special case, radar PAHG is happen to next to radar KLZK. The master table will be ...KLZKPAHG..., GSI then consider KPAH (radar name) is already available in the master radar table. This is caused GSI abort.

The bug is fixed by using a new function "locindex" to replace "index" to avoid the error of searching radar station name.