### PR TITLE
Fix inconsistency between penalty statistics (qcpen vs cpen) for winds

### DIFF
--- a/src/gsi/setupw.f90
+++ b/src/gsi/setupw.f90
@@ -1254,7 +1254,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         call vqc_setup(vals,ratio_errors,error,cvar,&
                       cg_t,ibb,ikk,var_jb,rat_err2v,wgt,valqcv)
         rwgt = rwgt+0.5_r_kind*wgt/wgtlim
-        valqc=valqcu+valqcv
+        valqc=half*(valqcu+valqcv)
 
 !       Accumulate statistics for obs belonging to this task
         if (muse(i)) then


### PR DESCRIPTION
We are running gfs.v16.3.0 parallel (experiment) on WCOSS-2 and comparing the results with the current operational run using gfs.v16.2.0 (control).  We found something in the satellite AMV wind statistics:

Here is the example:
```
Experiment
<  o-g 01      uv asm 245 0270 count          0      24102      44724          0          0       8360       5218      12427      17027          0          0     111858
<  o-g 01      uv asm 245 0270  bias  0.000E+00 -0.237E+00 -0.201E+00  0.000E+00  0.000E+00  0.271E+00  0.606E-01 -0.296E+00  0.141E+00  0.000E+00  0.000E+00 -0.120E+00
<  o-g 01      uv asm 245 0270   rms  0.000E+00  0.168E+01  0.168E+01  0.000E+00  0.000E+00  0.406E+01  0.425E+01  0.401E+01  0.402E+01  0.000E+00  0.000E+00  0.284E+01
<  o-g 01      uv asm 245 0270  cpen  0.000E+00  0.157E-01  0.157E-01  0.000E+00  0.000E+00  0.329E-01  0.311E-01  0.261E-01  0.263E-01  0.000E+00  0.000E+00  0.205E-01
<  o-g 01      uv asm 245 0270 qcpen  0.000E+00  0.314E-01  0.314E-01  0.000E+00  0.000E+00  0.658E-01  0.622E-01  0.523E-01  0.525E-01  0.000E+00  0.000E+00  0.409E-01
```
```
Control
>  o-g 01      uv asm 245 0270 count          0      24103      44725          0          0       8355       5153      12448      17045          0          0     111829
>  o-g 01      uv asm 245 0270  bias  0.000E+00 -0.263E+00 -0.250E+00  0.000E+00  0.000E+00  0.276E+00  0.210E-02 -0.385E+00  0.623E-01  0.000E+00  0.000E+00 -0.169E+00
>  o-g 01      uv asm 245 0270   rms  0.000E+00  0.169E+01  0.170E+01  0.000E+00  0.000E+00  0.401E+01  0.416E+01  0.391E+01  0.395E+01  0.000E+00  0.000E+00  0.280E+01
>  o-g 01      uv asm 245 0270  cpen  0.000E+00  0.159E-01  0.159E-01  0.000E+00  0.000E+00  0.321E-01  0.299E-01  0.249E-01  0.253E-01  0.000E+00  0.000E+00  0.202E-01
>  o-g 01      uv asm 245 0270 qcpen  0.000E+00  0.159E-01  0.159E-01  0.000E+00  0.000E+00  0.321E-01  0.299E-01  0.249E-01  0.253E-01  0.000E+00  0.000E+00  0.202E-01
```
Brett (from UW-Madison, and now is working for us) found that the qcpen and cpen values are always identical to the current operational run. However, the qcpen values are about twice larger than the cpen values.  

The cause of discrepancy between the cpen and qcpen in winds come [PR #242](https://github.com/NOAA-EMC/GSI/pull/242).
In PR 242, there were bug fixes in varQC for winds, but there is no change in which wind observations use the varQC.

The following changes proposed by @jderber-NOAA should make cpen and qcpen consistent:

change the line in setupw.f90

valqc=valqcu+valqcv

to

valqc=half*(valqcu+valqcv)

the nonlinear and linear qc will be consistent.
