### PR TITLE
GitHub Issue NOAA-EMC/GSI#453. Correcting bug encountered in read_airs.f90 

### DIFF
--- a/src/gsi/read_airs.f90
+++ b/src/gsi/read_airs.f90
@@ -240,6 +240,7 @@ subroutine read_airs(mype,val_airs,ithin,isfcalc,rmesh,jsatid,gstime,&
 ! Initialize variables
   maxinfo    =  31
   disterrmax=zero
+  chsst=zero
   ntest=0
   if(dval_use) maxinfo = maxinfo+2
   nreal  = maxinfo+nstinfo
@@ -775,7 +776,7 @@ subroutine read_airs(mype,val_airs,ithin,isfcalc,rmesh,jsatid,gstime,&
         if( iskip >= satinfo_nchan )cycle read_loop
 
 !       Map obs to grids
-        if (chsst > tsavg) then
+        if ((airs).and.(chsst > tsavg)) then
            call finalcheck(dist1,crit1,itx,iuse)
         else
            call finalcheck(one,crit1,itx,iuse)


### PR DESCRIPTION
Currently, the debug tests don't assimilate Aqua AMSUA data, just Aqua AIRS.  A test was run that assimilated Aqua AMSUA data in debug mode.  This led to the failure of the test due to a floating invalid error.  Printing out values for chsst, NaNs were discovered for Aqua AMSUA.  Looking in the code, chsst isn't calculated for Aqua AMSUA, only Aqua AIRS.  To correct this issue, chsst was been initialized to zero and the logic on line 778 has been updated to only move forward for AIRS data.

The code has been compiled using Intel and GNU compilers, as well as being compiled in debug mode, and the regression tests have been submitted and have successfully passed.

 * src/gsi/read_airs.f90 - Applied safeguards to ensure that the chsst would be initialized to a value (zero) and that the logic that uses chsst is only applied for AIRS.

Closes #453 