### PR TITLE
Release/gfsda.v16.3.0 warnings

### DIFF
--- a/src/gsi/stub_wrf_binary_interface.f90
+++ b/src/gsi/stub_wrf_binary_interface.f90
@@ -29,18 +29,26 @@ contains
 
   subroutine convert_binary_nmm_dummy(this,update_pint,ctph0,stph0,tlm0)
     use kinds, only: r_kind
+    use constants, only: zero 
     implicit none
     class(get_wrf_binary_interface_class), intent(inout) :: this
     logical     ,intent(inout) :: update_pint
     real(r_kind),intent(  out) :: ctph0,stph0,tlm0
+    ctph0 = zero
+    stph0 = zero
+    tlm0 = zero
   end subroutine convert_binary_nmm_dummy
 
   subroutine convert_nems_nmmb_dummy(this,update_pint,ctph0,stph0,tlm0)
     use kinds, only: r_kind
+    use constants, only: zero 
     implicit none
     class(get_wrf_binary_interface_class), intent(inout) :: this
     logical     ,intent(inout) :: update_pint
     real(r_kind),intent(  out) :: ctph0,stph0,tlm0
+    ctph0 = zero
+    stph0 = zero
+    tlm0 = zero
   end subroutine convert_nems_nmmb_dummy
 
 end module get_wrf_binary_interface_mod

--- a/src/gsi/stub_wrf_netcdf_interface.f90
+++ b/src/gsi/stub_wrf_netcdf_interface.f90
@@ -30,12 +30,15 @@ contains
   
   subroutine convert_netcdf_nmm_dummy(this,update_pint,ctph0,stph0,tlm0,guess)
     use kinds, only: r_single,i_kind,r_kind
+    use constants, only: zero 
     implicit none
     class(convert_netcdf_class) ,intent(inout) :: this
     logical     ,intent(in   ) :: guess
     logical     ,intent(inout) :: update_pint
     real(r_kind),intent(  out) :: ctph0,stph0,tlm0
-  
+    ctph0 = zero 
+    stph0 = zero 
+    tlm0 = zero 
   end subroutine convert_netcdf_nmm_dummy
   
   subroutine update_netcdf_mass_dummy(this)

--- a/util/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/maingrads_lev.f90
+++ b/util/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/maingrads_lev.f90
@@ -23,7 +23,7 @@
 
          integer ifileo
          character(ifileo)              :: fileo
-         integer                        :: nobs,nreal,nlev,igrads,isubtype
+         integer                        :: nobs,nreal,nlev,igrads,isubtype,iscater
          real(4),dimension(nlev)        :: plev
          character(10)                  :: levcard
          real*4                         :: hint

--- a/util/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/maingrads_sfctime.f90
+++ b/util/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/maingrads_sfctime.f90
@@ -20,10 +20,11 @@ program maingrads_sfctime
                     nlev,plev,iscater,igrads,isubtype,subtype,list,run)
 
          use generic_list
-         character(ifileo)       :: fileo
          integer                 :: ifileo,nobs,nreal,nlev 
+         character(ifileo)       :: fileo
          real(4),dimension(nlev) :: plev
-         integer                 :: iscater,igrdas,isubtype
+!        integer                 :: iscater,igrdas,isubtype
+         integer                 :: iscater,igrads,isubtype
          character(3)            :: subtype
          type(list_node_t),pointer   :: list
          character(3)            :: run

--- a/util/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/maingrads_sig.f90
+++ b/util/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/maingrads_sig.f90
@@ -23,7 +23,7 @@ program maingrads_sig
 
          integer ifileo
          character(ifileo)              :: fileo
-         integer                        :: nobs,nreal,nlev,igrads,isubtype
+         integer                        :: nobs,nreal,nlev,igrads,isubtype,iscater
          real(4),dimension(nlev)        :: plev
          character(3)                   :: subtype
          type(list_node_t), pointer     :: list


### PR DESCRIPTION
Per NCO's request for gfs.v16.3.0 code delivery, we were asked to fix a few warning messages from the compilation of the GSI code.  The warnings are listed as the following:

```
/gsi.fd/util/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/maingrads_lev.f90(20): warning #6717: This name has not been given an explicit type.   [ISCATER]
/gsi.fd/util/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/maingrads_sfctime.f90(23): warning #6717: This name has not been given an explicit type.   [IFILEO]
/gsi.fd/util/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/maingrads_sfctime.f90(20): warning #6717: This name has not been given an explicit type.   [IGRADS]
/gsi.fd/util/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/maingrads_sig.f90(20): warning #6717: This name has not been given an explicit type.   [ISCATER]

/gsi.fd/src/gsi/stub_wrf_binary_interface.f90(38): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [CTPH0]
/gsi.fd/src/gsi/stub_wrf_binary_interface.f90(30): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [CTPH0]
/gsi.fd/src/gsi/stub_wrf_binary_interface.f90(38): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [STPH0]
/gsi.fd/src/gsi/stub_wrf_binary_interface.f90(30): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [STPH0]
/gsi.fd/src/gsi/stub_wrf_binary_interface.f90(38): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [TLM0]
/gsi.fd/src/gsi/stub_wrf_binary_interface.f90(30): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [TLM0]
/gsi.fd/src/gsi/stub_wrf_netcdf_interface.f90(31): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [CTPH0]
/gsi.fd/src/gsi/stub_wrf_netcdf_interface.f90(31): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [STPH0]
/gsi.fd/src/gsi/stub_wrf_netcdf_interface.f90(31): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [TLM0]

```

There are two sets of warnings.  The first set comes from WRF binary and netcdf intricate.  Three variables: ctph0, stph0, and tlm0,  were not initialized.  
The solution is to give them zeros as initial value.

The second set of warning comes from the conventional data monitoring code.  Some of the variables were not declared properly.  
The solution is to declare the variables before they are used.

The warnings went away after the proposed fixes.