### PR TITLE
Release/gfsda.v16.3.0 (prune_4nco_globa.sh)

### DIFF
--- a/ush/prune_4nco_global.sh
+++ b/ush/prune_4nco_global.sh
@@ -144,7 +144,7 @@ done
 
 # Process ush directories and files
 cd $topdir/ush
-rlist="Get_Initial_Files comenkf comgsi gfs_truncate_enkf llsub para refactor_4nco_global run_arw rungsi sub"
+rlist="Get_Initial_Files comenkf_namelist_gfs.sh comenkf_namelist.sh comenkf_run_gfs.ksh comenkf_run_regional.ksh comgsi_namelist_chem.sh comgsi_namelist_gfs.sh comgsi_namelist.sh comgsi_run_chem.ksh comgsi_run_gfs.ksh comgsi_run_regional.ksh gfs_truncate_enkf.sh llsub_gsi_cmaq.sh para_config.gdas_analysis_high para_config.gfs_analysis refactor_4nco_global.sh run_arw_netcdf_hybens_testcase.sh rungsi62_prod.sh rungsi_globalprod.sh rungsi_nems_nmmb.sh rungsi_nmm_binary.sh rungsi_nmmprod.sh sub_discover sub_hera sub_jet sub_ncar sub_wcoss sub_wcoss_c sub_wcoss_d test_gdas_analysis_high.sh test_gfs_analysis.sh"
 for type in $rlist; do
     if [[ "$mode" = "prune" ]]; then
 	if [ -e $type ] ; then

--- a/ush/prune_4nco_global.sh
+++ b/ush/prune_4nco_global.sh
@@ -208,7 +208,7 @@ done
 
 # Process util directories and files
 cd $topdir/util
-rlist="AeroDA Analysis_Utilities Baseline Config Conventional_Monitor Correlated_Obs DTC EFSOI_Utilities Fit2Obs_Scorecard FOV_utilities GEN_BE_V2.0 GMI_BUFR_gen MODIS_AOD Minimization_Monitor/data_xtrct Minimization_Monitor/image_gen Minimization_Monitor/nwprod/nam_minmon Misc NCEP_bkerror NCEPgsi_Coupler NMC_Bkerror Ozone_Monitor/image_gen README Radar_Monitor Radiance_bias_correction_Utilities Radiance_Monitor/nwprod/nam_radmon Radiance_Utilities Single_Observation bufr_tools global_angupdate gsienvreport.sh python_utilities radar_process zero_biascoeff"
+rlist="AeroDA Analysis_Utilities Baseline Config Conventional_Monitor Correlated_Obs DTC EFSOI_Utilities Fit2Obs_Scorecard FOV_utilities GEN_BE_V2.0 GMI_BUFR_gen MODIS_AOD Minimization_Monitor/data_xtrct Minimization_Monitor/image_gen Minimization_Monitor/nwprod/gdas/driver Minimization_Monitor/nwprod/gfs/driver Minimization_Monitor/nwprod/nam_minmon Misc NCEP_bkerror NCEPgsi_Coupler NMC_Bkerror Ozone_Monitor/image_gen Ozone_Monitor/nwprod/gdas_oznmon/driver README Radar_Monitor Radiance_bias_correction_Utilities Radiance_Monitor/nwprod/gdas_radmon/driver Radiance_Monitor/nwprod/nam_radmon Radiance_Utilities Single_Observation bufr_tools global_angupdate gsienvreport.sh python_utilities radar_process zero_biascoeff"
 for type in $rlist; do
     if [[ "$mode" = "prune" ]]; then
 	if [ -e $type ]; then

--- a/ush/prune_4nco_global.sh
+++ b/ush/prune_4nco_global.sh
@@ -46,19 +46,21 @@ echo " "
 cd $topdir
 rlist="regression src/GSD unit-tests"
 for type in $rlist; do
-    if [ -e $type ]; then
-	git $string ${type}*
-	rc=$?
-	if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git $string ${type}"
-            exit
+    if [[ "$mode" = "prune" ]]; then
+	if [ -e $type ]; then
+	    git $string ${type}*
+	    rc=$?
+	    if [[ $rc -ne 0 ]]; then
+		echo "***ERROR* git $string ${type}"
+		exit
+	    fi
 	fi
-    fi
-    if [[ "$mode" = "restore" ]]; then
-	git checkout ${type}*
+    elif [[ "$mode" = "restore" ]]; then
+	git restore --staged ${type}*
+	git restore ${type}*
 	rc=$?
 	if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git checkout ${type}"
+            echo "***ERROR* git restore --staged ${type}"
             exit
 	fi
     fi
@@ -69,19 +71,21 @@ done
 cd $topdir/doc
 rlist="EnKF_user_guide GSI_user_guide README.discover Release_Notes.fv3gfs_da.v15.0.0.txt Release_Notes.gfsda.v16.0.0.txt"
 for type in $rlist; do
-    if [ -e $type ]; then
-	git $string ${type}*
-	rc=$?
-	if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git $string ${type}"
-            exit
+    if [[ "$mode" = "prune" ]]; then
+	if [ -e $type ]; then
+	    git $string ${type}*
+	    rc=$?
+	    if [[ $rc -ne 0 ]]; then
+		echo "***ERROR* git $string ${type}"
+		exit
+	    fi
 	fi
-    fi
-    if [[ "$mode" = "restore" ]]; then
-        git checkout ${type}*
+    elif [[ "$mode" = "restore" ]]; then
+        git restore --staged ${type}*
+        git restore ${type}*	
         rc=$?
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git checkout ${type}"
+            echo "***ERROR* git restore --staged ${type}"
             exit
         fi
     fi
@@ -92,19 +96,21 @@ done
 cd $topdir/jobs
 rlist="JGDAS_EFSOI"
 for type in $rlist; do
-    if [ -e $type ]; then
-	git $string ${type}*
-	rc=$?
-	if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git $string ${type}"
-            exit
+    if [[ "$mode" = "prune" ]]; then
+	if [ -e $type ]; then
+	    git $string ${type}*
+	    rc=$?
+	    if [[ $rc -ne 0 ]]; then
+		echo "***ERROR* git $string ${type}"
+		exit
+	    fi
 	fi
-    fi
-    if [[ "$mode" = "restore" ]]; then
-        git checkout ${type}*
+    elif [[ "$mode" = "restore" ]]; then
+        git restore --staged ${type}*
+        git restore ${type}*	
         rc=$?
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git checkout ${type}"
+            echo "***ERROR* git restore --staged ${type}"
             exit
         fi
     fi
@@ -115,19 +121,21 @@ done
 cd $topdir/scripts
 rlist="exurma2p5_gsianl.sh exgdas_efsoi"
 for type in $rlist; do
-    if [ -e $type ]; then
-	git $string ${type}*
-	rc=$?
-	if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git $string ${type}"
-            exit
+    if [[ "$mode" = "prune" ]]; then
+	if [ -e $type ]; then
+	    git $string ${type}*
+	    rc=$?
+	    if [[ $rc -ne 0 ]]; then
+		echo "***ERROR* git $string ${type}"
+		exit
+	    fi
 	fi
-    fi
-    if [[ "$mode" = "restore" ]]; then
-        git checkout ${type}*
+    elif [[ "$mode" = "restore" ]]; then
+        git restore --staged ${type}*
+        git restore ${type}*	
         rc=$?
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git checkout ${type}"
+            echo "***ERROR* git restore --staged ${type}"
             exit
         fi
     fi
@@ -138,19 +146,21 @@ done
 cd $topdir/ush
 rlist="Get_Initial_Files comenkf comgsi gfs_truncate_enkf llsub para refactor_4nco_global run_arw rungsi sub"
 for type in $rlist; do
-    if [ -e $type ] ; then
-	git $string ${type}*
-	rc=$?
-	if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git $string ${type}"
-            exit
+    if [[ "$mode" = "prune" ]]; then
+	if [ -e $type ] ; then
+	    git $string ${type}*
+	    rc=$?
+	    if [[ $rc -ne 0 ]]; then
+		echo "***ERROR* git $string ${type}"
+		exit
+	    fi
 	fi
-    fi
-    if [[ "$mode" = "restore" ]]; then
-        git checkout ${type}*
+    elif [[ "$mode" = "restore" ]]; then
+        git restore --staged ${type}*
+        git restore ${type}*	
         rc=$?
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git checkout ${type}"
+            echo "***ERROR* git restore --staged ${type}"
             exit
         fi
     fi
@@ -159,21 +169,23 @@ done
 
 # Process util directories and files
 cd $topdir/util
-rlist="Aero Analysis_Utilities Baseline Config Conventional_Monitor Correlated_Obs DTC EFSOI Fit2Obs_Scorecard FOV GEN_BE_V2.0 GMI_BUFR MODIS_AOD Minimization_Monitor/data_xtrct Minimization_Monitor/image_gen Minimization_Monitor/nwprod/nam_minmon Misc NCEP NMC_Bkerror Ozone_Monitor/image_gen README Radar_Monitor Radiance_bias_correction_Utilities Radiance_Monitor/nwprod/nam_radmon Radiance_Utilities Single_Observation bufr_tools global_angupdate gsienvreport.sh python_utilities radar_process zero_biascoeff"
+rlist="AeroDA Analysis_Utilities Baseline Config Conventional_Monitor Correlated_Obs DTC EFSOI_Utilities Fit2Obs_Scorecard FOV_utilities GEN_BE_V2.0 GMI_BUFR_gen MODIS_AOD Minimization_Monitor/data_xtrct Minimization_Monitor/image_gen Minimization_Monitor/nwprod/nam_minmon Misc NCEP_bkerror NCEPgsi_Coupler NMC_Bkerror Ozone_Monitor/image_gen README Radar_Monitor Radiance_bias_correction_Utilities Radiance_Monitor/nwprod/nam_radmon Radiance_Utilities Single_Observation bufr_tools global_angupdate gsienvreport.sh python_utilities radar_process zero_biascoeff"
 for type in $rlist; do
-    if [ -e $type ]; then
-	git $string ${type}*
-	rc=$?
-	if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git $string ${type}"
-            exit
+    if [[ "$mode" = "prune" ]]; then
+	if [ -e $type ]; then
+	    git $string ${type}*
+	    rc=$?
+	    if [[ $rc -ne 0 ]]; then
+		echo "***ERROR* git $string ${type}"
+		exit
+	    fi
 	fi
-    fi
-    if [[ "$mode" = "restore" ]]; then
-        git checkout ${type}*
+    elif [[ "$mode" = "restore" ]]; then
+        git restore --staged ${type}*
+        git restore ${type}*	
         rc=$?
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git checkout ${type}"
+            echo "***ERROR* git restore --staged ${type}"
             exit
         fi
     fi
@@ -184,19 +196,21 @@ done
 cd $topdir/util/EnKF
 rlist="arw python_utilities"
 for type in $rlist; do
-    if [ -e $type ]; then
-	git $string ${type}*
-	rc=$?
-	if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git $string ${type}"
-            exit
+    if [[ "$mode" = "prune" ]]; then    
+	if [ -e $type ]; then
+	    git $string ${type}*
+	    rc=$?
+	    if [[ $rc -ne 0 ]]; then
+		echo "***ERROR* git $string ${type}"
+		exit
+	    fi
 	fi
-    fi
-    if [[ "$mode" = "restore" ]]; then
-        git checkout ${type}*
+    elif [[ "$mode" = "restore" ]]; then
+        git restore --staged ${type}*
+	git restore ${type}*
         rc=$?
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git checkout ${type}"
+            echo "***ERROR* git restore --staged ${type}"
             exit
         fi
     fi
@@ -205,21 +219,23 @@ done
 
 # Process util/EnKF/gfs/src directories and files
 cd $topdir/util/EnKF/gfs/src
-rlist="adjustps misc preproc gribmean recenterncio_hybgain recenternemsiop_hybgain getnstensmeanp adderrspec getsfcnstensupdp"
+rlist="adjustps.fd misc preproc gribmean.fd recenterncio_hybgain.fd recenternemsiop_hybgain.fd getnstensmeanp.fd adderrspec.fd getsfcnstensupdp.fd"
 for type in $rlist; do
-    if [ -e $type ]; then
-	git $string ${type}*
-	rc=$?
-	if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git $string ${type}"
-            exit
+    if [[ "$mode" = "prune" ]]; then
+	if [ -e $type ]; then
+	    git $string ${type}*
+	    rc=$?
+	    if [[ $rc -ne 0 ]]; then
+		echo "***ERROR* git $string ${type}"
+		exit
+	    fi
 	fi
-    fi
-    if [[ "$mode" = "restore" ]]; then
-        git checkout ${type}*
+    elif [[ "$mode" = "restore" ]]; then
+        git restore --staged ${type}*
+        git restore ${type}*	
         rc=$?
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git checkout ${type}"
+            echo "***ERROR* git restore --staged ${type}"
             exit
         fi
     fi

--- a/ush/prune_4nco_global.sh
+++ b/ush/prune_4nco_global.sh
@@ -119,7 +119,7 @@ done
 
 # Process scripts directories and files
 cd $topdir/scripts
-rlist="exurma2p5_gsianl.sh exgdas_efsoi"
+rlist="exurma2p5_gsianl.sh exgdas_efsoi.sh exgdas_efsoi_update.sh"
 for type in $rlist; do
     if [[ "$mode" = "prune" ]]; then
 	if [ -e $type ]; then

--- a/ush/prune_4nco_global.sh
+++ b/ush/prune_4nco_global.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script removes or restores directories and/or files found in 
 # the rlist below from the current working directory.   This script
@@ -15,6 +15,8 @@
 #             removed directories and files
 #    
 
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
 set -ex
 
 mode=$1
@@ -23,7 +25,14 @@ mode=$1
 if [[ "$mode" = "prune" ]]; then
     string="rm -r"
 elif [[ "$mode" = "restore" ]]; then
-    string="reset HEAD"
+    git_ver=$(git version | cut -d" " -f3)
+    if [ $(version $git_ver) -lt $(version "2.23.0") ]; then
+	use_checkout="YES"
+	string="checkout"
+    else
+	use_checkout="NO"
+	string="restore"
+    fi
 else
     echo " "
     echo "***ERROR*** invalid mode= $mode"
@@ -51,16 +60,22 @@ for type in $rlist; do
 	    git $string ${type}*
 	    rc=$?
 	    if [[ $rc -ne 0 ]]; then
-		echo "***ERROR* git $string ${type}"
+		echo "***ERROR*** git $string ${type}"
 		exit
 	    fi
 	fi
     elif [[ "$mode" = "restore" ]]; then
-	git restore --staged ${type}*
-	git restore ${type}*
-	rc=$?
+	if [[ "$use_checkout" = "YES" ]]; then
+	    git reset HEAD ${type}*
+            git checkout ${type}*
+	    rc=$?
+	else
+	    git restore --staged ${type}*
+	    git restore ${type}*
+	    rc=$?
+	fi
 	if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git restore --staged ${type}"
+            echo "***ERROR*** restore failed for ${type}"
             exit
 	fi
     fi
@@ -76,16 +91,22 @@ for type in $rlist; do
 	    git $string ${type}*
 	    rc=$?
 	    if [[ $rc -ne 0 ]]; then
-		echo "***ERROR* git $string ${type}"
+		echo "***ERROR*** git $string ${type}"
 		exit
 	    fi
 	fi
     elif [[ "$mode" = "restore" ]]; then
-        git restore --staged ${type}*
-        git restore ${type}*	
-        rc=$?
+        if [[ "$use_checkout" = "YES" ]]; then
+            git reset HEAD ${type}*
+            git checkout ${type}*
+            rc=$?
+        else
+            git restore --staged ${type}*
+            git restore ${type}*
+            rc=$?
+        fi
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git restore --staged ${type}"
+            echo "***ERROR*** restore failed for ${type}"
             exit
         fi
     fi
@@ -101,16 +122,22 @@ for type in $rlist; do
 	    git $string ${type}*
 	    rc=$?
 	    if [[ $rc -ne 0 ]]; then
-		echo "***ERROR* git $string ${type}"
+		echo "***ERROR*** git $string ${type}"
 		exit
 	    fi
 	fi
     elif [[ "$mode" = "restore" ]]; then
-        git restore --staged ${type}*
-        git restore ${type}*	
-        rc=$?
+        if [[ "$use_checkout" = "YES" ]]; then
+            git reset HEAD ${type}*
+            git checkout ${type}*
+            rc=$?
+        else
+            git restore --staged ${type}*
+            git restore ${type}*
+            rc=$?
+        fi
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git restore --staged ${type}"
+            echo "***ERROR*** restore failed for ${type}"
             exit
         fi
     fi
@@ -126,16 +153,22 @@ for type in $rlist; do
 	    git $string ${type}*
 	    rc=$?
 	    if [[ $rc -ne 0 ]]; then
-		echo "***ERROR* git $string ${type}"
+		echo "***ERROR*** git $string ${type}"
 		exit
 	    fi
 	fi
     elif [[ "$mode" = "restore" ]]; then
-        git restore --staged ${type}*
-        git restore ${type}*	
-        rc=$?
+        if [[ "$use_checkout" = "YES" ]]; then
+            git reset HEAD ${type}*
+            git checkout ${type}*
+            rc=$?
+        else
+            git restore --staged ${type}*
+            git restore ${type}*
+            rc=$?
+        fi
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git restore --staged ${type}"
+            echo "***ERROR*** restore failed for ${type}"
             exit
         fi
     fi
@@ -147,20 +180,26 @@ cd $topdir/ush
 rlist="Get_Initial_Files comenkf_namelist_gfs.sh comenkf_namelist.sh comenkf_run_gfs.ksh comenkf_run_regional.ksh comgsi_namelist_chem.sh comgsi_namelist_gfs.sh comgsi_namelist.sh comgsi_run_chem.ksh comgsi_run_gfs.ksh comgsi_run_regional.ksh gfs_truncate_enkf.sh llsub_gsi_cmaq.sh para_config.gdas_analysis_high para_config.gfs_analysis refactor_4nco_global.sh run_arw_netcdf_hybens_testcase.sh rungsi62_prod.sh rungsi_globalprod.sh rungsi_nems_nmmb.sh rungsi_nmm_binary.sh rungsi_nmmprod.sh sub_discover sub_hera sub_jet sub_ncar sub_wcoss sub_wcoss_c sub_wcoss_d test_gdas_analysis_high.sh test_gfs_analysis.sh"
 for type in $rlist; do
     if [[ "$mode" = "prune" ]]; then
-	if [ -e $type ] ; then
+	if [ -e $type ]; then
 	    git $string ${type}*
 	    rc=$?
 	    if [[ $rc -ne 0 ]]; then
-		echo "***ERROR* git $string ${type}"
+		echo "***ERROR*** git $string ${type}"
 		exit
 	    fi
 	fi
     elif [[ "$mode" = "restore" ]]; then
-        git restore --staged ${type}*
-        git restore ${type}*	
-        rc=$?
+        if [[ "$use_checkout" = "YES" ]]; then
+            git reset HEAD ${type}*
+            git checkout ${type}*
+            rc=$?
+        else
+            git restore --staged ${type}*
+            git restore ${type}*
+            rc=$?
+        fi
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git restore --staged ${type}"
+            echo "***ERROR*** restore failed for ${type}"
             exit
         fi
     fi
@@ -176,16 +215,22 @@ for type in $rlist; do
 	    git $string ${type}*
 	    rc=$?
 	    if [[ $rc -ne 0 ]]; then
-		echo "***ERROR* git $string ${type}"
+		echo "***ERROR*** git $string ${type}"
 		exit
 	    fi
 	fi
     elif [[ "$mode" = "restore" ]]; then
-        git restore --staged ${type}*
-        git restore ${type}*	
-        rc=$?
+        if [[ "$use_checkout" = "YES" ]]; then
+            git reset HEAD ${type}*
+            git checkout ${type}*
+            rc=$?
+        else
+            git restore --staged ${type}*
+            git restore ${type}*
+            rc=$?
+        fi
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git restore --staged ${type}"
+            echo "***ERROR*** restore failed for ${type}"
             exit
         fi
     fi
@@ -201,16 +246,22 @@ for type in $rlist; do
 	    git $string ${type}*
 	    rc=$?
 	    if [[ $rc -ne 0 ]]; then
-		echo "***ERROR* git $string ${type}"
+		echo "***ERROR*** git $string ${type}"
 		exit
 	    fi
 	fi
     elif [[ "$mode" = "restore" ]]; then
-        git restore --staged ${type}*
-	git restore ${type}*
-        rc=$?
+        if [[ "$use_checkout" = "YES" ]]; then
+            git reset HEAD ${type}*
+            git checkout ${type}*
+            rc=$?
+        else
+            git restore --staged ${type}*
+            git restore ${type}*
+            rc=$?
+        fi
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git restore --staged ${type}"
+            echo "***ERROR*** restore failed for ${type}"
             exit
         fi
     fi
@@ -226,16 +277,22 @@ for type in $rlist; do
 	    git $string ${type}*
 	    rc=$?
 	    if [[ $rc -ne 0 ]]; then
-		echo "***ERROR* git $string ${type}"
+		echo "***ERROR*** git $string ${type}"
 		exit
 	    fi
 	fi
     elif [[ "$mode" = "restore" ]]; then
-        git restore --staged ${type}*
-        git restore ${type}*	
-        rc=$?
+        if [[ "$use_checkout" = "YES" ]]; then
+            git reset HEAD ${type}* 
+            git checkout ${type}*
+            rc=$?
+        else
+            git restore --staged ${type}*
+            git restore ${type}*
+            rc=$?
+        fi
         if [[ $rc -ne 0 ]]; then
-            echo "***ERROR* git restore --staged ${type}"
+            echo "***ERROR*** restore failed for ${type}"
             exit
         fi
     fi


### PR DESCRIPTION
The PR corrects errors in the `prune` function of `ush/prune_4nco_global.sh`.   Please see issue #465 for details.

Both the `prune` and `restore` functions have been tested in g-w `release/gfs.v16.3.0` using `sorc/build_gsi.sh` with the `export PRUNE_4NCO="YES"` line activated.   The `prune` function removes from the working copy of `sorc/gsi.fd` those files and directories which are not used by GFS v16.3.0.   The `restore` function restores pruned files and directories from the repository.

Neither the `prune` nor the `restore` functions alter GFS v16 DA analysis results.