### PR TITLE
bump bufr version to 11.7.0

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -8,7 +8,7 @@ defaults:
     shell: bash -leo pipefail {0}
 
 env:
-  cache_key: gcc3  # The number (#) following the cache_key "gcc" is to flush Action cache.
+  cache_key: gcc4  # The number (#) following the cache_key "gcc" is to flush Action cache.
   CC: gcc-10
   FC: gfortran-10
   CXX: g++-10

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -9,7 +9,7 @@ defaults:
 
 # Set I_MPI_CC/F90 so Intel MPI wrapper uses icc/ifort instead of gcc/gfortran
 env:
-  cache_key: intel3  # The number (#) following the cache_key "intel" is to flush Action cache.
+  cache_key: intel4  # The number (#) following the cache_key "intel" is to flush Action cache.
   CC: icc
   FC: ifort
   CXX: icpc

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -6,7 +6,7 @@ spack:
   specs:
   - netcdf-c@4.7.4
   - netcdf-fortran@4.5.3
-  - bufr@11.5.0
+  - bufr@11.7.0
   - bacio@2.4.1
   - w3emc@2.9.2
   - sp@2.3.3

--- a/modulefiles/gsi_common.lua
+++ b/modulefiles/gsi_common.lua
@@ -4,7 +4,7 @@ Load common modules to build GSI on all machines
 
 local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 
-local bufr_ver=os.getenv("bufr_ver") or "11.5.0"
+local bufr_ver=os.getenv("bufr_ver") or "11.7.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.9.1"
 local sp_ver=os.getenv("sp_ver") or "2.3.3"


### PR DESCRIPTION
This PR bumps the version of the bufr library to 11.7.0.
Updates the modulefiles as well as the CI environment.

Fixes #470 