### PR TITLE
Update to bufr/11.7.0, add safeguard to avoid out of bounds reference…

### DIFF
--- a/modulefiles/gsi_common.lua
+++ b/modulefiles/gsi_common.lua
@@ -4,7 +4,7 @@ Load common modules to build GSI on all machines
 
 local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 
-local bufr_ver=os.getenv("bufr_ver") or "11.5.0"
+local bufr_ver=os.getenv("bufr_ver") or "11.7.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.9.1"
 local sp_ver=os.getenv("sp_ver") or "2.3.3"

--- a/modulefiles/gsi_wcoss2.lua
+++ b/modulefiles/gsi_wcoss2.lua
@@ -1,10 +1,10 @@
 help([[
 ]])
 
-local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.2.0"
+local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
 local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
-local craype_ver=os.getenv("craype_ver") or "2.7.13"
-local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.12"
+local craype_ver=os.getenv("craype_ver") or "2.7.8"
+local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
 local cmake_ver= os.getenv("cmake_ver") or "3.20.2"
 local python_ver=os.getenv("python_ver") or "3.8.6"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.0.10"

--- a/modulefiles/gsi_wcoss2.lua
+++ b/modulefiles/gsi_wcoss2.lua
@@ -1,10 +1,10 @@
 help([[
 ]])
 
-local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
+local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.2.0"
 local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
-local craype_ver=os.getenv("craype_ver") or "2.7.8"
-local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
+local craype_ver=os.getenv("craype_ver") or "2.7.13"
+local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.12"
 local cmake_ver= os.getenv("cmake_ver") or "3.20.2"
 local python_ver=os.getenv("python_ver") or "3.8.6"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.0.10"

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -3057,7 +3057,11 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
  
         do k=1,ndata
            ikx=nint(cdata_out(10,k))
-           itype=ictype(ikx)
+           if (ikx>0) then
+              itype=ictype(ikx)
+           else
+              itype=0
+           endif
            if( itype ==230 .or. itype ==231 .or. itype ==233) then
               prest=r10*exp(cdata_out(4,k))
               if (prest <100.0_r_kind) cycle

--- a/util/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90
+++ b/util/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90
@@ -100,7 +100,7 @@ program getsigensmeanp_smooth
   ! if a 5th arg present, it's a filename to write out ensemble spread
   ! (only used for ncio)
   write_spread_ncio = .false.
-  if (iargc() > 5) then
+  if (iargc() > 4) then
      call getarg(5,filenameoutsprd)
      write_spread_ncio = .true.
      if (mype == 0) print *,'computing ensemble spread'


### PR DESCRIPTION
This PR is opened to request the addition of two updates to `release/gfsda.v16.3.0`.  These changes are in response to
- a request from NCO to update to `bufr/11.7.0`
- identification of a case in which the `-check all` build of `gsi.x` seg faults

Please see issue #474 for details.

Neither of these changes alter `gsi.x` analysis results in testing to date.
