### PR TITLE
Update calc_analysis.fd/CMakeLists.txt to use w3emc_4 (#478)

### DIFF
--- a/util/netcdf_io/calc_analysis.fd/CMakeLists.txt
+++ b/util/netcdf_io/calc_analysis.fd/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(calc_analysis.x PRIVATE MPI::MPI_Fortran)
 target_link_libraries(calc_analysis.x PRIVATE bacio::bacio_4)
 target_link_libraries(calc_analysis.x PRIVATE nemsio::nemsio)
 target_link_libraries(calc_analysis.x PRIVATE ncio::ncio)
-target_link_libraries(calc_analysis.x PRIVATE w3emc::w3emc_d)
+target_link_libraries(calc_analysis.x PRIVATE w3emc::w3emc_4)
 
 # Install executable targets
 install(TARGETS calc_analysis.x RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Correct bug in the release/gfsda.v16.3.0 build of `calc_analysis.x`.    Please see #478 for details.
