### PR TITLE
Fix fortran standard non-conforming code for rerank interface

### DIFF
--- a/src/gsi/m_rerank.f90
+++ b/src/gsi/m_rerank.f90
@@ -3,6 +3,7 @@ module m_rerank
 ! 01Aug2011 - Lueken  - changed F90 to f90 (no machine logic
 ! 28Apr2011 - Todling - overload to handle single precision
   use kinds, only : r_double,r_single,i_kind
+  use iso_c_binding
   implicit none
   private
   public :: rerank
@@ -31,17 +32,7 @@ CONTAINS
     real(r_single),dimension(:,:),target,intent(in):: i2
     real(r_single),pointer,dimension(:):: i1
 
-    interface
-       function rerank_hack_2in1r4_(ln,i2) result(i1)
-       use kinds, only: r_single,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: ln
-       real(r_single),dimension(:,:),target,intent(in):: i2
-       real(r_single),pointer,dimension(:):: i1
-       end function rerank_hack_2in1r4_
-    end interface
-
-    i1 => rerank_hack_2in1r4_(size(i2),i2)
+    call c_f_pointer(c_loc(i2), i1, [size(i2)])
   end function rerank_2in1r4_
 
   function rerank_2in1r8_(i2) result(i1)
@@ -49,17 +40,7 @@ CONTAINS
     real(r_double),dimension(:,:),target,intent(in):: i2
     real(r_double),pointer,dimension(:):: i1
 
-    interface
-       function rerank_hack_2in1r8_(ln,i2) result(i1)
-       use kinds, only: r_double,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: ln
-       real(r_double),dimension(:,:),target,intent(in):: i2
-       real(r_double),pointer,dimension(:):: i1
-       end function rerank_hack_2in1r8_
-    end interface
-
-    i1 => rerank_hack_2in1r8_(size(i2),i2)
+    call c_f_pointer(c_loc(i2), i1, [size(i2)])
   end function rerank_2in1r8_
 
   function rerank_3in1r4_(i3) result(i1)
@@ -67,17 +48,7 @@ CONTAINS
     real(r_single),dimension(:,:,:),target,intent(in):: i3
     real(r_single),pointer,dimension(:):: i1
 
-    interface
-       function rerank_hack_2in1r4_(ln,i3) result(i1)
-       use kinds, only: r_single,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: ln
-       real(r_single),dimension(:,:,:),target,intent(in):: i3
-       real(r_single),pointer,dimension(:):: i1
-       end function rerank_hack_2in1r4_
-    end interface
-
-    i1 => rerank_hack_2in1r4_(size(i3),i3)
+    call c_f_pointer(c_loc(i3), i1, [size(i3)])
   end function rerank_3in1r4_
 
   function rerank_3in1r8_(i3) result(i1)
@@ -85,17 +56,7 @@ CONTAINS
     real(r_double),dimension(:,:,:),target,intent(in):: i3
     real(r_double),pointer,dimension(:):: i1
 
-    interface
-       function rerank_hack_2in1r8_(ln,i3) result(i1)
-       use kinds, only: r_double,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: ln
-       real(r_double),dimension(:,:,:),target,intent(in):: i3
-       real(r_double),pointer,dimension(:):: i1
-       end function rerank_hack_2in1r8_
-    end interface
-
-    i1 => rerank_hack_2in1r8_(size(i3),i3)
+    call c_f_pointer(c_loc(i3), i1, [size(i3)])
   end function rerank_3in1r8_
 !----
   function rerank_4in1r4_(i4) result(i1)
@@ -103,17 +64,7 @@ CONTAINS
     real(r_single),dimension(:,:,:,:),target,intent(in):: i4
     real(r_single),pointer,dimension(:):: i1
 
-    interface
-       function rerank_hack_2in1r4_(ln,i4) result(i1)
-       use kinds, only: r_single,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: ln
-       real(r_single),dimension(:,:,:,:),target,intent(in):: i4
-       real(r_single),pointer,dimension(:):: i1
-       end function rerank_hack_2in1r4_
-    end interface
-
-    i1 => rerank_hack_2in1r4_(size(i4),i4)
+    call c_f_pointer(c_loc(i4), i1, [size(i4)])
   end function rerank_4in1r4_
 
   function rerank_4in1r8_(i4) result(i1)
@@ -121,17 +72,7 @@ CONTAINS
     real(r_double),dimension(:,:,:,:),target,intent(in):: i4
     real(r_double),pointer,dimension(:):: i1
 
-    interface
-       function rerank_hack_2in1r8_(ln,i4) result(i1)
-       use kinds, only: r_double,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: ln
-       real(r_double),dimension(:,:,:,:),target,intent(in):: i4
-       real(r_double),pointer,dimension(:):: i1
-       end function rerank_hack_2in1r8_
-    end interface
-
-    i1 => rerank_hack_2in1r8_(size(i4),i4)
+    call c_f_pointer(c_loc(i4), i1, [size(i4)])
   end function rerank_4in1r8_
 !----
   function rerank_1in2r4_(i1,mold,shape) result(i2)
@@ -141,19 +82,9 @@ CONTAINS
     integer(i_kind),dimension(:),intent(in):: shape
     real(r_single),pointer,dimension(:,:):: i2
 
-    interface
-       function rerank_hack_1in2r4_(l1,l2,i1) result(i2)
-       use kinds, only: r_single,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: l1,l2
-       real(r_single),dimension(l1,l2),target,intent(in):: i1
-       real(r_single),pointer,dimension(:,:):: i2
-       end function rerank_hack_1in2r4_
-    end interface
-
     character(len=*),parameter:: myname_='rerank_1in2_single_'
     call assert_eq_(size(shape),2,myname_,'size(shape)==2')
-    i2 => rerank_hack_1in2r4_(shape(1),shape(2),i1)
+    call c_f_pointer(c_loc(i1), i2, [shape(1), shape(2)])
   end function rerank_1in2r4_
 
   function rerank_1in2r8_(i1,mold,shape) result(i2)
@@ -163,19 +94,9 @@ CONTAINS
     integer(i_kind),dimension(:),intent(in):: shape
     real(r_double),pointer,dimension(:,:):: i2
 
-    interface
-       function rerank_hack_1in2r8_(l1,l2,i1) result(i2)
-       use kinds, only: r_double,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: l1,l2
-       real(r_double),dimension(l1,l2),target,intent(in):: i1
-       real(r_double),pointer,dimension(:,:):: i2
-       end function rerank_hack_1in2r8_
-    end interface
-
     character(len=*),parameter:: myname_='rerank_1in2_double_'
     call assert_eq_(size(shape),2,myname_,'size(shape)==2')
-    i2 => rerank_hack_1in2r8_(shape(1),shape(2),i1)
+    call c_f_pointer(c_loc(i1), i2, [shape(1), shape(2)])
   end function rerank_1in2r8_
 
   function rerank_1in3r4_(i1,mold,shape) result(i3)
@@ -185,19 +106,9 @@ CONTAINS
     integer(i_kind),dimension(:),intent(in):: shape
     real(r_single),pointer,dimension(:,:,:):: i3
 
-    interface
-       function rerank_hack_1in3r4_(l1,l2,l3,i1) result(i3)
-       use kinds, only: r_single,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: l1,l2,l3
-       real(r_single),dimension(l1,l2,l3),target,intent(in):: i1
-       real(r_single),pointer,dimension(:,:,:):: i3
-       end function rerank_hack_1in3r4_
-    end interface
-
     character(len=*),parameter:: myname_='rerank_1in3_single_'
     call assert_eq_(size(shape),3,myname_,'size(shape)==3')
-    i3 => rerank_hack_1in3r4_(shape(1),shape(2),shape(3),i1)
+    call c_f_pointer(c_loc(i1), i3, [shape(1), shape(2), shape(3)])
   end function rerank_1in3r4_
 
   function rerank_1in3r8_(i1,mold,shape) result(i3)
@@ -207,19 +118,9 @@ CONTAINS
     integer(i_kind),dimension(:),intent(in):: shape
     real(r_double),pointer,dimension(:,:,:):: i3
 
-    interface
-       function rerank_hack_1in3r8_(l1,l2,l3,i1) result(i3)
-       use kinds, only: r_double,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: l1,l2,l3
-       real(r_double),dimension(l1,l2,l3),target,intent(in):: i1
-       real(r_double),pointer,dimension(:,:,:):: i3
-       end function rerank_hack_1in3r8_
-    end interface
-
     character(len=*),parameter:: myname_='rerank_1in3_double_'
     call assert_eq_(size(shape),3,myname_,'size(shape)==3')
-    i3 => rerank_hack_1in3r8_(shape(1),shape(2),shape(3),i1)
+    call c_f_pointer(c_loc(i1), i3, [shape(1), shape(2), shape(3)])
   end function rerank_1in3r8_
 !>>>
   function rerank_1in4r4_(i1,mold,shape) result(i4)
@@ -229,19 +130,9 @@ CONTAINS
     integer(i_kind),dimension(:),intent(in):: shape
     real(r_single),pointer,dimension(:,:,:,:):: i4
 
-    interface
-       function rerank_hack_1in4r4_(l1,l2,l3,l4,i1) result(i4)
-       use kinds, only: r_single,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: l1,l2,l3,l4
-       real(r_single),dimension(l1,l2,l3,l4),target,intent(in):: i1
-       real(r_single),pointer,dimension(:,:,:,:):: i4
-       end function rerank_hack_1in4r4_
-    end interface
-
     character(len=*),parameter:: myname_='rerank_1in4_single_'
     call assert_eq_(size(shape),4,myname_,'size(shape)==4')
-    i4 => rerank_hack_1in4r4_(shape(1),shape(2),shape(3),shape(4),i1)
+    call c_f_pointer(c_loc(i1), i4, [shape(1), shape(2), shape(3), shape(4)])
   end function rerank_1in4r4_
 
   function rerank_1in4r8_(i1,mold,shape) result(i4)
@@ -251,19 +142,9 @@ CONTAINS
     integer(i_kind),dimension(:),intent(in):: shape
     real(r_double),pointer,dimension(:,:,:,:):: i4
 
-    interface
-       function rerank_hack_1in4r8_(l1,l2,l3,l4,i1) result(i4)
-       use kinds, only: r_double,i_kind
-       implicit none
-       integer(i_kind),intent(in) :: l1,l2,l3,l4
-       real(r_double),dimension(l1,l2,l3,l4),target,intent(in):: i1
-       real(r_double),pointer,dimension(:,:,:,:):: i4
-       end function rerank_hack_1in4r8_
-    end interface
-
     character(len=*),parameter:: myname_='rerank_1in4_double_'
     call assert_eq_(size(shape),4,myname_,'size(shape)==4')
-    i4 => rerank_hack_1in4r8_(shape(1),shape(2),shape(3),shape(4),i1)
+    call c_f_pointer(c_loc(i1), i4, [shape(1), shape(2), shape(3), shape(4)])
   end function rerank_1in4r8_
 !>>>
   subroutine assert_eq_(lsize,lrank,who,what)
@@ -279,76 +160,3 @@ CONTAINS
   end subroutine assert_eq_
 
 end module m_rerank
-
-! These must live outside module to trick compiler
-function rerank_hack_2in1r8_(ln,i2) result(i1)
-  use kinds, only: r_double,i_kind
-  implicit none
-  integer(i_kind),intent(in) :: ln
-  real(r_double),dimension(ln),target,intent(in):: i2
-  real(r_double),pointer,dimension(:):: i1
-  i1 => i2
-end function rerank_hack_2in1r8_
-
-function rerank_hack_2in1r4_(ln,i2) result(i1)
-  use kinds, only: r_single,i_kind
-  implicit none
-  integer(i_kind),intent(in) :: ln
-  real(r_single),dimension(ln),target,intent(in):: i2
-  real(r_single),pointer,dimension(:):: i1
-  i1 => i2
-end function rerank_hack_2in1r4_
-
-function rerank_hack_1in2r8_(l1,l2,i1) result(i2)
-  use kinds, only: r_double,i_kind
-  implicit none
-  integer(i_kind),intent(in) :: l1,l2
-  real(r_double),dimension(l1,l2),target,intent(in):: i1
-  real(r_double),pointer,dimension(:,:):: i2
-  i2 => i1
-end function rerank_hack_1in2r8_
-
-function rerank_hack_1in2r4_(l1,l2,i1) result(i2)
-  use kinds, only: r_single,i_kind
-  implicit none
-  integer(i_kind),intent(in) :: l1,l2
-  real(r_single),dimension(l1,l2),target,intent(in):: i1
-  real(r_single),pointer,dimension(:,:):: i2
-  i2 => i1
-end function rerank_hack_1in2r4_
-
-function rerank_hack_1in3r8_(l1,l2,l3,i1) result(i3)
-  use kinds, only: r_double,i_kind
-  implicit none
-  integer(i_kind),intent(in) :: l1,l2,l3
-  real(r_double),dimension(l1,l2,l3),target,intent(in):: i1
-  real(r_double),pointer,dimension(:,:,:):: i3
-  i3 => i1
-end function rerank_hack_1in3r8_
-
-function rerank_hack_1in3r4_(l1,l2,l3,i1) result(i3)
-  use kinds, only: r_single,i_kind
-  implicit none
-  integer(i_kind),intent(in) :: l1,l2,l3
-  real(r_single),dimension(l1,l2,l3),target,intent(in):: i1
-  real(r_single),pointer,dimension(:,:,:):: i3
-  i3 => i1
-end function rerank_hack_1in3r4_
-
-function rerank_hack_1in4r8_(l1,l2,l3,l4,i1) result(i4)
-  use kinds, only: r_double,i_kind
-  implicit none
-  integer(i_kind),intent(in) :: l1,l2,l3,l4
-  real(r_double),dimension(l1,l2,l3,l4),target,intent(in):: i1
-  real(r_double),pointer,dimension(:,:,:,:):: i4
-  i4 => i1
-end function rerank_hack_1in4r8_
-
-function rerank_hack_1in4r4_(l1,l2,l3,l4,i1) result(i4)
-  use kinds, only: r_single,i_kind
-  implicit none
-  integer(i_kind),intent(in) :: l1,l2,l3,l4
-  real(r_single),dimension(l1,l2,l3,l4),target,intent(in):: i1
-  real(r_single),pointer,dimension(:,:,:,:):: i4
-  i4 => i1
-end function rerank_hack_1in4r4_


### PR DESCRIPTION
According to Fortran 2018 standard Section 15.4.3.2 point 7, if an explicit specific interface for an external procedure is specified by and interface body or a procedure declaration statement, the characteristics shall be consistent with those specified in the procedure definition.

`m_rerank.f90` is standard non-conforming and one small reproducer is in https://github.com/llvm/llvm-project/issues/57620#issuecomment-1275525166. The test results show both `gfortran` and `ifort` do not the expected behaviors, which is to rerank the array pointer. One possible fix is in https://github.com/llvm/llvm-project/issues/57620#issuecomment-1277138294 and `gfortran`, `ifort` and LLVM Flang support it.