### PR TITLE
Improve gsi.x error messages as requested by NCO bugzilla for GFS v16.3

### DIFF
--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -562,9 +562,6 @@ $NLN $SFCGES sfcf06
 $NLN $SFCG09 sfcf09
 
 # Link hourly backgrounds (if present)
-if [ -f $ATMG04 -a -f $ATMG05 -a -f $ATMG07 -a -f $ATMG08 ]; then
-   nhr_obsbin=1
-fi
 
 [[ -f $ATMG04 ]] && $NLN $ATMG04 sigf04
 [[ -f $ATMG05 ]] && $NLN $ATMG05 sigf05
@@ -587,6 +584,7 @@ if [ $DOHYBVAR = "YES" ]; then
    fhrs="06"
    if [ $l4densvar = ".true." ]; then
       fhrs="03 04 05 06 07 08 09"
+      nhr_obsbin=1
    fi
 
    for imem in $(seq 1 $NMEM_ENKF); do

--- a/src/gsi/cplr_gfs_ensmod.f90
+++ b/src/gsi/cplr_gfs_ensmod.f90
@@ -914,6 +914,7 @@ subroutine parallel_read_gfsnc_state_(en_full,m_cvars2d,m_cvars3d,nlon,nlat,nsig
    character(len=*), intent(in   ) :: filename
 
    ! Declare local variables
+   logical :: file_exist
    integer(i_kind) i,ii,j,jj,k,lonb,latb,levs,kr,ierror
    integer(i_kind) k2,k3,k3u,k3v,k3t,k3q,k3cw,k3oz,kf
    integer(i_kind) k3ql,k3qi,k3qr,k3qs,k3qg
@@ -927,11 +928,19 @@ subroutine parallel_read_gfsnc_state_(en_full,m_cvars2d,m_cvars3d,nlon,nlat,nsig
    type(Dataset) :: atmges
    type(Dimension) :: ncdim
 
+!  Check to see if requested file exists
+   inquire(file=filename,exist=file_exist)
+   if (.not.file_exist) then
+      write(6,*)' PARALLEL_READ_GFSNC_STATE:  ***FATAL ERROR*** ',trim(filename),' NOT AVAILABLE: PROGRAM STOPS'
+      call die(myname_, ': ***FATAL ERROR*** insufficient ens fcst for hybrid',999)
+   endif
 
+!  If file exists, open and process
    atmges = open_dataset(filename,errcode=ierror)
    if (ierror /=0) then
-      write(6,*)' PARALLEL_READ_GFSNC_STATE:  ***FATAL ERROR*** ',trim(filename),' NOT AVAILABLE: PROGRAM STOPS'
-      call stop2(999)
+      write(6,*)' PARALLEL_READ_GFSNC_STATE:  ***FATAL ERROR*** problem reading ',&
+           trim(filename),' ierror= ',ierror,' PROGRAM STOPS'
+      call die(myname_, ': ***FATAL ERROR*** problem reading ens fcst',999)
    endif
    ! get dimension sizes
    ncdim = get_dim(atmges, 'grid_xt'); lonb = ncdim%len


### PR DESCRIPTION
NCO GFS v16.3 testing identified issues with the error messages generated by gsi.x when an expected background file is missing.   Issue #491 documents changes made to `exglobal_atmos_analysis.sh` and `src/gsi/cplr_gfs_ensmod.f90` to address NCO bugzilla [#1196](http://www2.spa.ncep.noaa.gov/bugzilla/show_bug.cgi?id=1196).

Fixes #491