### PR TITLE
Remove extra fields from conventional diagnostic file

### DIFF
--- a/src/gsi/setupps.f90
+++ b/src/gsi/setupps.f90
@@ -913,8 +913,6 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
            call nc_diag_metadata("Observation",                   sngl(pob)        )
            call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   sngl(pob-pges)   )
            call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl(pob-pgesorig))
-           call nc_diag_metadata("Forecast_adjusted",             sngl(pges)       )
-           call nc_diag_metadata("Forecast_unadjusted",           sngl(pgesorig)   )
  
           if (lobsdiagsave) then
 
@@ -946,8 +944,6 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
              call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
              call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
            endif
-
-           call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(exp(prsltmp)*r1000))
 
   end subroutine contents_netcdf_diag_
 

--- a/src/gsi/setupq.f90
+++ b/src/gsi/setupq.f90
@@ -1292,8 +1292,6 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("Observation",                   sngl(data(iqob,i)))
            call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   sngl(ddiff)       )
            call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl(qob-qges)    )
-           call nc_diag_metadata("Forecast_adjusted",             sngl(data(iqob,i)-ddiff))
-           call nc_diag_metadata("Forecast_unadjusted",           sngl(qges))
            call nc_diag_metadata("Forecast_Saturation_Spec_Hum",  sngl(qsges)       )
            if (lobsdiagsave) then
               do jj=1,miter
@@ -1323,8 +1321,6 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
              call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
              call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
            endif
-
-           call nc_diag_data2d("atmosphere_pressure_coordinate",exp(prsltmp)*r1000)
 
   end subroutine contents_netcdf_diag_
 
@@ -1360,8 +1356,6 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("Observation",                   sngl(data(iqob,i)))
            call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   sngl(ddiff)       )
            call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl(ddiff)       )
-           call nc_diag_metadata("Forecast_adjusted",             sngl(data(iqob,i)-ddiff))
-           call nc_diag_metadata("Forecast_unadjusted",           sngl(data(iqob,i)-ddiff))
            call nc_diag_metadata("Forecast_Saturation_Spec_Hum",  sngl(qsges)       )
 !----
            if (lobsdiagsave) then
@@ -1393,8 +1387,6 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
              call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
              call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
            endif
-
-           call nc_diag_data2d("atmosphere_pressure_coordinate",exp(prsltmp)*r1000)
 
   end subroutine contents_netcdf_diagp_
 

--- a/src/gsi/setupt.f90
+++ b/src/gsi/setupt.f90
@@ -1696,8 +1696,6 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     call nc_diag_metadata("Observation",             sngl(data(itob,i))     )
     call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   sngl(ddiff)      )
     call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl(tob-tges)   )
-    call nc_diag_metadata("Forecast_unadjusted",     sngl(tges))
-    call nc_diag_metadata("Forecast_adjusted",       sngl(data(itob,i)-ddiff))
 
     if (aircraft_t_bc_pof .or. aircraft_t_bc .or. aircraft_t_bc_ext) then
        call nc_diag_metadata("Data_Pof",             sngl(data(ipof,i))     )
@@ -1750,9 +1748,6 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
     endif
 
-    ! need additional arrays for GeoVaLs for T2
-    call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(exp(prsltmp)*r1000))
-
   end subroutine contents_netcdf_diag_
 
   subroutine contents_netcdf_diagp_(odiag)
@@ -1789,8 +1784,6 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     call nc_diag_metadata("Observation",             sngl(data(itob,i))     )
     call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   sngl(ddiff)      )
     call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl(ddiff)      )
-    call nc_diag_metadata("Forecast_unadjusted",     sngl(data(itob,i)-ddiff))
-    call nc_diag_metadata("Forecast_adjusted",       sngl(data(itob,i)-ddiff))
 
 !----
     if (lobsdiagsave) then
@@ -1821,9 +1814,6 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
        call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
     endif
-
-    ! need additional arrays for GeoVaLs for T2
-    call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(exp(prsltmp)*r1000))
 
   end subroutine contents_netcdf_diagp_
 

--- a/src/gsi/setupw.f90
+++ b/src/gsi/setupw.f90
@@ -1837,14 +1837,10 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_metadata("u_Observation",                              sngl(uob_e)           )
               call nc_diag_metadata("u_Obs_Minus_Forecast_adjusted",              sngl(dudiff_e)        )
               call nc_diag_metadata("u_Obs_Minus_Forecast_unadjusted",            sngl(uob_e-uges_e)    )
-              call nc_diag_metadata("u_Forecast_adjusted",                        sngl(uob_e-dudiff_e))
-              call nc_diag_metadata("u_Forecast_unadjusted",                      sngl(uges_e))
 
               call nc_diag_metadata("v_Observation",                              sngl(vob_e)           )
               call nc_diag_metadata("v_Obs_Minus_Forecast_adjusted",              sngl(dvdiff_e)        )
               call nc_diag_metadata("v_Obs_Minus_Forecast_unadjusted",            sngl(vob_e-vges_e)    )
-              call nc_diag_metadata("v_Forecast_adjusted",                        sngl(vob_e-dvdiff_e))
-              call nc_diag_metadata("v_Forecast_unadjusted",                      sngl(vges_e))
            endif
 
            if (lobsdiagsave) then
@@ -1883,8 +1879,6 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_data2d("v_Observation_Operator_Jacobian_endind", dhx_dx_v%end_ind)
               call nc_diag_data2d("v_Observation_Operator_Jacobian_val", real(dhx_dx_v%val,r_single))
            endif
-
-           call nc_diag_data2d("atmosphere_pressure_coordinate", exp(prsltmp)*r1000)
 
   end subroutine contents_netcdf_diag_
 


### PR DESCRIPTION
This PR removes the following fields from conventional data diagnostic files:
- `Forecast_adjusted`
- `Forecast_unadjusted`
- `atmosphere_pressure_coordinate`

These fields no longer need to be included in the conventional data diagnostic file.  

This PR applies the `setup*` changes in PR #490 to `develop`.   PR #490 applies the same changes to `release/gfsda.v16.3.0`.

Fixes #496.  