### PR TITLE
Deprecate gerrit and use github for fix files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "fix"]
+  path = fix
+  url = https://github.com/NOAA-EMC/GSI-fix
+  branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,4 @@
 [submodule "fix"]
   path = fix
   url = https://github.com/NOAA-EMC/GSI-fix
-  #branch = develop
-  branch = feature/cmake
+  branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "fix"]
   path = fix
   url = https://github.com/NOAA-EMC/GSI-fix
-  branch = develop
+  #branch = develop
+  branch = feature/cmake

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "fix"]
-	path = fix
-	url = gerrit:GSI-fix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,10 @@ message(STATUS "BUILD_REG_TESTING ...... ${BUILD_REG_TESTING}")
 # Build components
 add_subdirectory(src)
 
-# Download and copy binary fix files
-add_subdirectory(fix)
+# Download and copy binary fix files if submodule has been cloned
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/fix/CMakeLists.txt)
+  add_subdirectory(fix)
+endif()
 
 if(BUILD_REG_TESTING)
   add_subdirectory(regression)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ message(STATUS "BUILD_REG_TESTING ...... ${BUILD_REG_TESTING}")
 # Build components
 add_subdirectory(src)
 
+# Download and copy binary fix files
+add_subdirectory(fix)
+
 if(BUILD_REG_TESTING)
   add_subdirectory(regression)
 endif()

--- a/modulefiles/gsi_hera.gnu.lua
+++ b/modulefiles/gsi_hera.gnu.lua
@@ -20,4 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 
 pushenv("MKLROOT", "/apps/oneapi/mkl/2022.0.2")
 
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20221128")
+
 whatis("Description: GSI environment on Hera with GNU Compilers")

--- a/modulefiles/gsi_hera.intel.lua
+++ b/modulefiles/gsi_hera.intel.lua
@@ -26,4 +26,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20221128")
+
 whatis("Description: GSI environment on Hera with Intel Compilers")

--- a/modulefiles/gsi_jet.lua
+++ b/modulefiles/gsi_jet.lua
@@ -21,4 +21,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 pushenv("FFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 
+pushenv("GSI_BINARY_SOURCE_DIR", "/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/gsi/20221128")
+
 whatis("Description: GSI environment on Jet with Intel Compilers")

--- a/modulefiles/gsi_orion.lua
+++ b/modulefiles/gsi_orion.lua
@@ -23,4 +23,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
+pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20221128")
+
 whatis("Description: GSI environment on Orion with Intel Compilers")

--- a/modulefiles/gsi_s4.lua
+++ b/modulefiles/gsi_s4.lua
@@ -23,4 +23,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-march=ivybridge")
 pushenv("FFLAGS", "-march=ivybridge")
 
+pushenv("GSI_BINARY_SOURCE_DIR", "/data/prod/glopara/fix/gsi/20221128")
+
 whatis("Description: GSI environment on S4 with Intel Compilers")

--- a/modulefiles/gsi_wcoss2.lua
+++ b/modulefiles/gsi_wcoss2.lua
@@ -29,4 +29,6 @@ prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/mpi/intel/19.1.3.304
 load("ncio/1.1.2")
 load("ncdiag/1.0.0")
 
+pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20221128")
+
 whatis("Description: GSI environment on WCOSS2")

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -21,10 +21,12 @@ REGRESSION_TESTS=${REGRESSION_TESTS:-"YES"} # Build regression test suite
 source $DIR_ROOT/ush/detect_machine.sh
 
 # Load modules
+set +x
 source $DIR_ROOT/ush/module-setup.sh
 module use $DIR_ROOT/modulefiles
 module load gsi_$MACHINE_ID
 module list
+set -x
 
 # Set CONTROLPATH variable to user develop installation
 CONTROLPATH="$DIR_ROOT/../develop/install/bin"
@@ -46,10 +48,8 @@ CMAKE_OPTS+=" -DGSI_MODE=$GSI_MODE -DENKF_MODE=${ENKF_MODE}"
 mkdir -p $BUILD_DIR && cd $BUILD_DIR
 
 # Configure, build, install
-set -x
 cmake $CMAKE_OPTS $DIR_ROOT
 make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-}
 make install
-set +x
 
 exit


### PR DESCRIPTION
**Description**

This PR:
- deprecates `gerrit::GSI-fix` in favor of `github::GSI-fix`
- Updates modulefiles on select platforms to define a variable `GSI_BINARY_SOURCE_DIR` to a path that currently hosts staged GSI binary fix data.

There is a companion [PR#4](https://github.com/NOAA-EMC/GSI-fix/pull/4) in [NOAA-EMC/GSI-fix](https://github.com/NOAA-EMC/GSI-fix) that allows optionally downloading and then copying the binary fix files to the fix directory. This PR depends on that PR.  Once that PR is merged, the git submodule pointer in this PR should then be updated before merging.

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

This work is part of #505 

**Type of change**
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

**How Has This Been Tested?**

- [X] Clone tests on Orion using staged data on Orion before and after gerrit yeilds in identical fix directory. 

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published