### PR TITLE
Regression test updates:  global_4dvar bug fix, oom fix, enhance error checking

### DIFF
--- a/regression/global_4dvar.sh
+++ b/regression/global_4dvar.sh
@@ -98,7 +98,7 @@ SINGLEOB=""
 #   bftab_sst= bufr table for sst ONLY needed for sst retrieval (retrieval=.true.)
 #   aeroinfo = text file with information about assimilation of aerosol data
 
-anavinfo=$fixgsi/global_anavinfo.l${LEVS}.txt
+anavinfo=$fixgsi/global_anavinfo_qlqi.l${LEVS}.txt
 berror=$fixgsi/Big_Endian/global_berror.l${LEVS}y${NLAT}.f77
 locinfo=$fixgsi/global_hybens_info.l${LEVS}.txt
 satinfo=$fixgsi/global_satinfo.txt
@@ -311,9 +311,9 @@ $gsi_namelist
 EOF
 cp gsiparm.anl gsiparm.anl.obsvr
 
-echo "run gsi now"
+echo "run gsi observer"
 eval "$APRUN $tmpdir/gsi.x < gsiparm.anl > stdout.obsvr 2>&1"
-rc=$?
+ra=$?
 
 # Run gsi identity model 4dvar under Parallel Operating Environment (poe) on NCEP IBM
 rm -f siganl sfcanl.gsi satbias_out fort.2*
@@ -331,8 +331,8 @@ cat <<EOF > gsiparm.anl
 $gsi_namelist
 EOF
 
-echo "run gsi now"
+echo "run gsi 4dvar"
 eval "$APRUN $tmpdir/gsi.x < gsiparm.anl > stdout 2>&1"
-rc=$?
-
+rb=$?
+rc=$((ra+rb))
 exit $rc

--- a/regression/regression_driver.sh
+++ b/regression/regression_driver.sh
@@ -47,7 +47,6 @@ for jn in `seq ${RSTART} ${REND}`; do
    $scripts/regression_wait.sh ${job[$jn]} ${rcname} $check_resource
    rc=$?
    if [ $rc -ne 0 ]; then
-     rm -f ${rcname}
      exit 1
    fi
    done

--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -150,8 +150,8 @@ case $regtest in
             topts[1]="0:15:00" ; popts[1]="20/1/"  ; ropts[1]="/1"
             topts[2]="0:15:00" ; popts[2]="20/2/"  ; ropts[2]="/1"
         elif [[ "$machine" = "Orion" ]]; then
-            topts[1]="0:15:00" ; popts[1]="4/4/"  ; ropts[1]="/1"
-            topts[2]="0:15:00" ; popts[2]="6/6/"  ; ropts[2]="/1"
+            topts[1]="0:15:00" ; popts[1]="20/1/"  ; ropts[1]="/1"
+            topts[2]="0:15:00" ; popts[2]="20/2/"  ; ropts[2]="/1"
         elif [[ "$machine" = "Jet" ]]; then
             topts[1]="0:15:00" ; popts[1]="4/4/"  ; ropts[1]="/1"
             topts[2]="0:15:00" ; popts[2]="6/6/"  ; ropts[2]="/1"

--- a/regression/regression_test.sh
+++ b/regression/regression_test.sh
@@ -576,11 +576,20 @@ mkdir -p $vfydir
 
 $ncp $output                        $vfydir/
 
+# Final check for any failed tests
+count=$(grep -i "fail" $output |wc -l)
+if [ $count -gt 0 ]; then
+    (( failed_test = $failed_test + $count ))
+fi
+
+# Remove job log files is no failures detected
 cd $scripts
-rm -f ${exp1}.out
-rm -f ${exp2}.out
-rm -f ${exp3}.out
-rm -f ${exp2_scale}.out
+if [ $count -eq 0 ]; then
+    rm -f ${exp1}.out
+    rm -f ${exp2}.out
+    rm -f ${exp3}.out
+    rm -f ${exp2_scale}.out
+fi
 
 if [[ "$clean" = ".true." ]]; then
    rm -rf $savdir

--- a/regression/regression_test_enkf.sh
+++ b/regression/regression_test_enkf.sh
@@ -284,12 +284,11 @@ while [[ $imem -le $nmem ]]; do
    member="_mem"`printf %03i $imem`
    ncdump incr$member.${exp1} > incr$member.${exp1}.out
    ncdump incr$member.${exp2} > incr$member.${exp2}.out
-   if ! diff incr$member.${exp1}.out incr$member.${exp2}.out
-then
-   echo 'incr'$member'.'${exp1}' incr'$member'.'${exp2}' are NOT identical'
-else
+   if [[ ! diff incr$member.${exp1}.out incr$member.${exp2}.out ]]; then
+       echo 'incr'$member'.'${exp1}' incr'$member'.'${exp2}' are NOT identical'
+   else
        rm -f incr$member.${exp1}.out incr$member.${exp2}.out
-fi
+   fi
    (( imem = $imem + 1 ))
 done
 echo
@@ -385,13 +384,12 @@ else
       member="_mem"`printf %03i $imem`
       ncdump incr$member.${exp1} > incr$member.${exp1}.out
       ncdump incr$member.${exp3} > incr$member.${exp3}.out
-      if ! diff incr$member.${exp1}.out incr$member.${exp3}.out
-      then
-      echo 'incr'$member'.'${exp1}' incr'$member'.'${exp3}' are NOT identical'
+      if [[ ! diff incr$member.${exp1}.out incr$member.${exp3}.out ]]; then
+          echo 'incr'$member'.'${exp1}' incr'$member'.'${exp3}' are NOT identical'
       else
           rm -f incr$member.${exp1}.out incr$member.${exp3}.out
       fi
-   (( imem = $imem + 1 ))
+      (( imem = $imem + 1 ))
    done
    echo
 } >> $output

--- a/regression/regression_test_enkf.sh
+++ b/regression/regression_test_enkf.sh
@@ -284,7 +284,7 @@ while [[ $imem -le $nmem ]]; do
    member="_mem"`printf %03i $imem`
    ncdump incr$member.${exp1} > incr$member.${exp1}.out
    ncdump incr$member.${exp2} > incr$member.${exp2}.out
-   if [[ ! diff incr$member.${exp1}.out incr$member.${exp2}.out ]]; then
+   if [ ! diff incr$member.${exp1}.out incr$member.${exp2}.out ]; then
        echo 'incr'$member'.'${exp1}' incr'$member'.'${exp2}' are NOT identical'
    else
        rm -f incr$member.${exp1}.out incr$member.${exp2}.out
@@ -384,7 +384,7 @@ else
       member="_mem"`printf %03i $imem`
       ncdump incr$member.${exp1} > incr$member.${exp1}.out
       ncdump incr$member.${exp3} > incr$member.${exp3}.out
-      if [[ ! diff incr$member.${exp1}.out incr$member.${exp3}.out ]]; then
+      if [ ! diff incr$member.${exp1}.out incr$member.${exp3}.out ]; then
           echo 'incr'$member'.'${exp1}' incr'$member'.'${exp3}' are NOT identical'
       else
           rm -f incr$member.${exp1}.out incr$member.${exp3}.out


### PR DESCRIPTION
**Description**
Regression tests using `develop` found that ctest `global_4dvar` seg faulted during the lanczos solver execution of `gsi.x`.   This was traced to the wrong `anavinfo` file being used in the test.    During this investigation other issues were found with the regression tests.   

The Orion job configuration for `rrfs_3denvar_glbens` was insufficient.  The job aborted with an OOM error.   The Hera job configuration requested more resources.   The Orion configuration was updated to be consistent with Hera.

Error checking was enhanced in the regression test scripts.  Log files are now retained if a ctest fails.   

Fixes #531  

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested?**
The full suite of 9 ctests will be run run on Hera, Orion, and WCOSS2.   Test results will be documented in this PR.
  

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes