### PR TITLE
GitHub Issue NOAA-EMC/GSI#538 Add options to tune weights of mixed ensemble for FV3-LAM EnVar

### DIFF
--- a/src/gsi/cplr_get_fv3_regional_ensperts.f90
+++ b/src/gsi/cplr_get_fv3_regional_ensperts.f90
@@ -52,7 +52,7 @@ contains
      use constants, only: zero,one,half,zero_single,rd_over_cp,one_tenth
      use mpimod, only: mpi_comm_world,ierror,mype,npe
      use hybrid_ensemble_parameters, only: n_ens,grd_ens,parallelization_over_ensmembers
-     use hybrid_ensemble_parameters, only: l_both_fv3sar_gfs_ens, n_ens_gfs,n_ens_fv3sar
+     use hybrid_ensemble_parameters, only: l_both_fv3sar_gfs_ens,n_ens_gfs,n_ens_fv3sar,weight_ens_fv3sar
      use hybrid_ensemble_parameters, only: ntlevs_ens,ensemble_path
      use control_vectors, only: cvars2d,cvars3d,nc2d,nc3d
      use gsi_bundlemod, only: gsi_bundlecreate
@@ -674,7 +674,7 @@ contains
  !
  !
  ! CONVERT ENSEMBLE MEMBERS TO ENSEMBLE PERTURBATIONS
-        sig_norm=sqrt(one/max(one,n_ens_fv3sar-one))
+        sig_norm=sqrt(weight_ens_fv3sar/max(one,n_ens_fv3sar-one))
  
         do n=imem_start,n_ens
            do i=1,nelen

--- a/src/gsi/get_gefs_for_regional.f90
+++ b/src/gsi/get_gefs_for_regional.f90
@@ -41,7 +41,7 @@ subroutine get_gefs_for_regional
                      fv3_regional
   use hybrid_ensemble_parameters, only: region_lat_ens,region_lon_ens
   use hybrid_ensemble_parameters, only: en_perts,ps_bar,nelen
-  use hybrid_ensemble_parameters, only: n_ens_gfs,grd_ens,grd_a1,grd_e1,p_e2a,uv_hyb_ens,dual_res
+  use hybrid_ensemble_parameters, only: n_ens_gfs,weight_ens_gfs,grd_ens,grd_a1,grd_e1,p_e2a,uv_hyb_ens,dual_res
   use hybrid_ensemble_parameters, only: full_ensemble,q_hyb_ens,l_ens_in_diff_time,write_ens_sprd
   use hybrid_ensemble_parameters, only: ntlevs_ens,ensemble_path,jcap_ens
   use control_vectors, only: cvars2d,cvars3d,nc2d,nc3d
@@ -1311,7 +1311,7 @@ subroutine get_gefs_for_regional
 ! 2*J_b = x^T * (beta1*B + beta2*P_ens)^(-1) * x
 ! where  P_ens is the ensemble covariance which is the sum of outer products of the
 ! ensemble perturbations (unnormalized) divided by n_ens-1  (or n_ens, depending on who you read).
-     sig_norm=sqrt(one/max(one,n_ens_temp-one))
+     sig_norm=sqrt(weight_ens_gfs/max(one,n_ens_temp-one))
 
 !     if(n_ens_temp==n_ens.and.n==n_ens+1) sig_norm=one
 !                                                  if(n==1 .or. n==2 .or. n==50) then

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -154,7 +154,7 @@
                          i_ensloccov4tim,i_ensloccov4var,i_ensloccov4scl,l_timloc_opt,&
                          vdl_scale,vloc_varlist,&
                          global_spectral_filter_sd,assign_vdl_nml,parallelization_over_ensmembers
-  use hybrid_ensemble_parameters,only : l_both_fv3sar_gfs_ens,n_ens_gfs,n_ens_fv3sar
+  use hybrid_ensemble_parameters,only : l_both_fv3sar_gfs_ens,n_ens_gfs,n_ens_fv3sar,weight_ens_gfs,weight_ens_fv3sar
   use rapidrefresh_cldsurf_mod, only: init_rapidrefresh_cldsurf, &
                             dfi_radar_latent_heat_time_period,metar_impact_radius,&
                             metar_impact_radius_lowcloud,l_gsd_terrain_match_surftobs, &
@@ -1408,7 +1408,8 @@
 !                 s_ens_h  = v1L1  v2L1  v3L1  v1L2 v2L2
 !                 Then localization lengths will be assigned as above.
 !
-  namelist/hybrid_ensemble/l_hyb_ens,uv_hyb_ens,q_hyb_ens,aniso_a_en,generate_ens,n_ens,l_both_fv3sar_gfs_ens,n_ens_gfs,n_ens_fv3sar,nlon_ens,nlat_ens,jcap_ens,&
+  namelist/hybrid_ensemble/l_hyb_ens,uv_hyb_ens,q_hyb_ens,aniso_a_en,generate_ens,n_ens,&
+                l_both_fv3sar_gfs_ens,n_ens_gfs,n_ens_fv3sar,weight_ens_gfs,weight_ens_fv3sar,nlon_ens,nlat_ens,jcap_ens,&
                 pseudo_hybens,merge_two_grid_ensperts,regional_ensemble_option,fv3sar_bg_opt,fv3sar_ensemble_opt,full_ensemble,pwgtflg,&
                 jcap_ens_test,beta_s0,beta_e0,s_ens_h,s_ens_v,readin_localization,eqspace_ensgrid,readin_beta,&
                 grid_ratio_ens, &
@@ -1821,7 +1822,8 @@
     else 
        write(6,*)'n_ens_gfs and n_ens_fv3sar won"t be used if not regional_ensemble_option==5' 
     endif
-    
+    weight_ens_gfs=one
+    weight_ens_fv3sar=one
   endif
   if(ltlint) then
      if(vqc .or. njqc .or. nvqc)then

--- a/src/gsi/hybrid_ensemble_parameters.f90
+++ b/src/gsi/hybrid_ensemble_parameters.f90
@@ -287,6 +287,7 @@ module hybrid_ensemble_parameters
   public :: generate_ens,n_ens,nlon_ens,nlat_ens,jcap_ens,jcap_ens_test,l_hyb_ens,&
        s_ens_h,oz_univ_static,vvlocal
   public :: n_ens_gfs,n_ens_fv3sar
+  public :: weight_ens_gfs,weight_ens_fv3sar
   public :: uv_hyb_ens,q_hyb_ens,s_ens_v,beta_s0,beta_e0,aniso_a_en,s_ens_hv,s_ens_vv
   public :: readin_beta,beta_s,beta_e
   public :: readin_localization
@@ -361,6 +362,7 @@ module hybrid_ensemble_parameters
   integer(i_kind) i_en_perts_io
   integer(i_kind) n_ens,nlon_ens,nlat_ens,jcap_ens,jcap_ens_test
   integer(i_kind) n_ens_gfs,n_ens_fv3sar
+  real(r_kind) weight_ens_gfs,weight_ens_fv3sar
   real(r_kind) beta_s0,beta_e0,grid_ratio_ens
   integer(i_kind),parameter::max_naensloc=20
   integer(i_kind),parameter::max_nvars=100
@@ -497,6 +499,8 @@ subroutine init_hybrid_ensemble_parameters
   l_both_fv3sar_gfs_ens=.false.
   n_ens_gfs=0 
   n_ens_fv3sar=0
+  weight_ens_gfs=one
+  weight_ens_fv3sar=one
   vdl_scale = 0
   vloc_varlist = 'aaa'
   global_spectral_filter_sd=.false.


### PR DESCRIPTION
This PR adds options (weight_ens_gfs and weight_ens_fv3sar) to tune weights of mixed ensemble for FV3-LAM EnVar (https://github.com/NOAA-EMC/GSI/issues/538). Regression tests for global 3dvar/4denvar/4dvar are not completed yet, but for other tests, issues are not found except for "failed the scalability test" and "exceeded maximum allowable hardware memory limit" on Orion.

Fixes #538