### PR TITLE
Bugfix in EnKF assim of conventional q obs

### DIFF
--- a/src/enkf/readconvobs.f90
+++ b/src/enkf/readconvobs.f90
@@ -789,6 +789,9 @@ subroutine get_convobs_data_nc(obspath, datestring, nobs_max, nobs_maxdiag,   &
               x_obs(nob)   = x_obs(nob) /Forecast_Saturation_Spec_Hum(i)
               hx_mean(nob)     = hx_mean(nob) /Forecast_Saturation_Spec_Hum(i)
               hx_mean_nobc(nob) = hx_mean_nobc(nob) /Forecast_Saturation_Spec_Hum(i)
+              if (neigv>0) then
+              hx_modens(:,nob) = hx_modens(:,nob)/ Forecast_Saturation_Spec_Hum(i)
+              endif
            endif
 
            ! for wind, also read v-component


### PR DESCRIPTION
**Description**

Added code to divide hx_modens by qsat, for consistency with treatment of q as q/qsat. 

Fixes issue #544 

**Type of change**

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested?**

I created a test case, in which I assimilated a single sonde flight. Without this bugfix, assimilating conventional q obs from the sonde with the EnKF results in insignificant q increments. With the fix, the q increments match what I'd expect (based on approximating the increments offline, from the diag file and ensemble background). I also ran the enkf assimilation of all standard obs (sats and conventional), with and without the bugfix to test the magnitude of it's impact. The impact is substantial over land (where conventional obs are present). Details: 

https://drive.google.com/file/d/19TRrygaR5g2iJ2xMmthfHzxrCCf61TeR/view?usp=sharing
  
**Checklist**

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
The tests will not pass, since the output from assimilating conventional q has been changed.
- [ x] Any dependent changes have been merged and published