### PR TITLE
remove or update non crtm/2.4.0 references (#550)

### DIFF
--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -18,7 +18,7 @@ spack:
   - nemsio@2.5.2
   - wrf-io@1.2.0
   - ncio@1.1.2
-  - crtm@2.3.0
+  - crtm@2.4.0
   - gsi-ncdiag@1.0.0
   view: true
   concretizer:

--- a/modulefiles/gsi_gaea
+++ b/modulefiles/gsi_gaea
@@ -52,9 +52,6 @@ module load sigio-intel-sandybridge/2.0.1
 module load sp-intel-sandybridge/2.0.2
 module load w3nco-intel-sandybridge/2.0.6
 module load w3emc-intel-sandybridge/2.2.0
-module load crtm-intel/2.2.4
-#setenv CRTM_INC /lustre/f1/pdata/ncep_shared/NCEPLIBS/lib/crtm/v2.2.4/intel/include/crtm_v2.2.4
-#setenv CRTM_LIB /lustre/f1/pdata/ncep_shared/NCEPLIBS/lib/crtm/v2.2.4/intel/libcrtm_v2.2.4.a 
 module load bacio-intel-sandybridge/2.0.2
 setenv CRAYOS_VERSION $::env(CRAYPE_VERSION)
 #setenv CRAYOS_VERSION ${CRAYPE_VERSION}

--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -58,7 +58,6 @@ case $machine in
     fi
     export ptmp="/glade/scratch/$LOGNAME/$ptmpName"
 
-    export fixcrtm="/glade/p/ral/jntp/tools/crtm/2.2.3/fix_update"
     export casesdir="/glade/p/ral/jntp/tools/CASES"
 
     export check_resource="no"
@@ -99,7 +98,6 @@ case $machine in
       fi
       export ptmp="${ptmp:-/work/noaa/stmp/$LOGNAME/$ptmpName}"
 
-      export fixcrtm=${CRTM_FIX:-/apps/contrib/NCEPLIBS/orion/fix/crtm_v2.3.0}
       export casesdir="/work/noaa/da/rtreadon/CASES/regtest"
 
       export check_resource="no"
@@ -124,7 +122,6 @@ case $machine in
 
     export ptmp="${ptmp:-/scratch1/NCEPDEV/stmp2/$LOGNAME/$ptmpName}"
 
-##  export fixcrtm="${CRTM_FIX:-/scratch1/NCEPDEV/da/Michael.Lueken/CRTM_REL-2.2.3/crtm_v2.2.3/fix_update}"
     export casesdir="/scratch1/NCEPDEV/da/Russ.Treadon/CASES/regtest"
 
     export check_resource="no"
@@ -160,7 +157,6 @@ case $machine in
     export ptmp=$basedir
     export ptmp=$basedir
     export noscrub=$basedir
-    export fixcrtm="/discover/nobackup/projects/gmao/share/gmao_ops/fvInput_4dvar/gsi/etc/fix_ncep20170329/REL-2.2.3-r60152_local-rev_1/CRTM_Coeffs/$endianness"
     export casesdir="/discover/nobackup/projects/gmao/obsdev/wrmccart/NCEP_regression/CASES"
     export check_resource="no"
     export accnt="g0613"


### PR DESCRIPTION
**Description**
PR #526 updated `develop` to `crtm/2.4.0`.   Some files remain in `develop` with references to previous versions of the crtm.   Branch [`feature/crtm240`](https://github.com/RussTreadon-NOAA/GSI/tree/feature/crtm240) was created to update the crtm references in these remaining files.   This PR is opened to update these remaining references to `crtm/2.4.0`.

Fixes #518
Fixes #550


**Type of change**
- [x] clean up (non-breaking change which fixes an issue)

Three files are changed
- `ci/spack.yaml` - crtm version number `2.3.0` is updated to `2.4.0`
- `modulefiles/gsi_gaea` - `crtm/2.2.4` references are removed.  `gsi_common.lua` loads `crtm/2.4.0`
- `regression/regression_var.sh` - `fixcrtm` references are removed.   The regression (ctest) scripts pick up crtm fix files via `CRTM_FIX`, not `fixcrtm`

**How Has This Been Tested?**
`feature/crtm240` has been built and ctests run on WCOSS2, Hera, and Orion.   Regression tests results are acceptable and documented in issue #550.
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code