### PR TITLE
Use prod ncio and ncdiag on wcoss2 (#554)

### DIFF
--- a/modulefiles/gsi_wcoss2.lua
+++ b/modulefiles/gsi_wcoss2.lua
@@ -19,15 +19,6 @@ load(pathJoin("python", python_ver))
 load(pathJoin("prod_util", prod_util_ver))
 
 load("gsi_common")
-unload("ncio")
-unload("ncdiag")
-
-pushenv("HPC_OPT", "/apps/ops/para/libs")
-prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/compiler/intel/19.1.3.304")
-prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.7")
-
-load("ncio/1.1.2")
-load("ncdiag/1.0.0")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20221128")
 


### PR DESCRIPTION
**Description**
The `ncio` and `ncdiag` modules have been promoted from para to prod on WCOSS2.   GSI issue #554 documents this change and highlights the need to update `modulefiles/gsi_wcoss2.lua`.   This PR is opened to replace the para load of these modules in `modulefiles/gsi_wcoss2.lua`  with the prod versions.

Fixes #554

**Type of change**
- [x] Maintenance (non-breaking change which fixes an issue)

**How Has This Been Tested?**
`feature/gsi_wcoss2` was built on Cactus and ctests run.   All ctests pass.   This is an expected result.   

This PR does not impact the build or execution of GSI and EnKF on other machines.
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Existing tests pass with my changes