### PR TITLE
update fix submodule to bring in gfs.v16.3.7 changes

### DIFF
--- a/modulefiles/gsi_hera.gnu.lua
+++ b/modulefiles/gsi_hera.gnu.lua
@@ -20,6 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 
 pushenv("MKLROOT", "/apps/oneapi/mkl/2022.0.2")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230112")
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230601")
 
 whatis("Description: GSI environment on Hera with GNU Compilers")

--- a/modulefiles/gsi_hera.gnu.lua
+++ b/modulefiles/gsi_hera.gnu.lua
@@ -20,6 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 
 pushenv("MKLROOT", "/apps/oneapi/mkl/2022.0.2")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20221128")
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230112")
 
 whatis("Description: GSI environment on Hera with GNU Compilers")

--- a/modulefiles/gsi_hera.intel.lua
+++ b/modulefiles/gsi_hera.intel.lua
@@ -26,6 +26,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20221128")
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230112")
 
 whatis("Description: GSI environment on Hera with Intel Compilers")

--- a/modulefiles/gsi_hera.intel.lua
+++ b/modulefiles/gsi_hera.intel.lua
@@ -26,6 +26,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230112")
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230601")
 
 whatis("Description: GSI environment on Hera with Intel Compilers")

--- a/modulefiles/gsi_jet.lua
+++ b/modulefiles/gsi_jet.lua
@@ -27,6 +27,6 @@ pushenv("CFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 pushenv("FFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/mnt/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/gsi/20221128")
+pushenv("GSI_BINARY_SOURCE_DIR", "/mnt/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/gsi/20230112")
 
 whatis("Description: GSI environment on Jet with Intel Compilers")

--- a/modulefiles/gsi_jet.lua
+++ b/modulefiles/gsi_jet.lua
@@ -27,6 +27,6 @@ pushenv("CFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 pushenv("FFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/mnt/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/gsi/20230112")
+pushenv("GSI_BINARY_SOURCE_DIR", "/mnt/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/gsi/20230601")
 
 whatis("Description: GSI environment on Jet with Intel Compilers")

--- a/modulefiles/gsi_orion.lua
+++ b/modulefiles/gsi_orion.lua
@@ -23,6 +23,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20221128")
+pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20230112")
 
 whatis("Description: GSI environment on Orion with Intel Compilers")

--- a/modulefiles/gsi_orion.lua
+++ b/modulefiles/gsi_orion.lua
@@ -23,6 +23,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20230112")
+pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20230601")
 
 whatis("Description: GSI environment on Orion with Intel Compilers")

--- a/modulefiles/gsi_s4.lua
+++ b/modulefiles/gsi_s4.lua
@@ -23,6 +23,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-march=ivybridge")
 pushenv("FFLAGS", "-march=ivybridge")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/data/prod/glopara/fix/gsi/20230112")
+pushenv("GSI_BINARY_SOURCE_DIR", "/data/prod/glopara/fix/gsi/20230601")
 
 whatis("Description: GSI environment on S4 with Intel Compilers")

--- a/modulefiles/gsi_s4.lua
+++ b/modulefiles/gsi_s4.lua
@@ -23,6 +23,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-march=ivybridge")
 pushenv("FFLAGS", "-march=ivybridge")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/data/prod/glopara/fix/gsi/20221128")
+pushenv("GSI_BINARY_SOURCE_DIR", "/data/prod/glopara/fix/gsi/20230112")
 
 whatis("Description: GSI environment on S4 with Intel Compilers")

--- a/modulefiles/gsi_wcoss2.lua
+++ b/modulefiles/gsi_wcoss2.lua
@@ -20,6 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 
 load("gsi_common")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20221128")
+pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20230112")
 
 whatis("Description: GSI environment on WCOSS2")

--- a/modulefiles/gsi_wcoss2.lua
+++ b/modulefiles/gsi_wcoss2.lua
@@ -20,6 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 
 load("gsi_common")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20230112")
+pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20230601")
 
 whatis("Description: GSI environment on WCOSS2")


### PR DESCRIPTION
**Description**
This PR is opened to address two items related to GFS v16.3.7.   This implementation modified GSI fix file `global_convinfo.txt`.    

1. EIB updated their staged GSI fix files to be consistent with GFS v16.3.7.  This PR updates the path to the EIB staged files, `GSI_BINARY_SOURCE_DIR` in GSI `modulefiles`.  
2. The updated `global_convinfo.txt` was committed to NOAA-EMC/GSI-fix at [6a42a29](https://github.com/NOAA-EMC/GSI-fix/commit/6a42a29dbbc9fca3453cc9e829601185555890b9).   The `fix` submodule in NOAA-EMC/GSI needs to be updated to point at this GSI-fix hash.   This PR updates the `fix` submodule hash.

fixes #580

**Type of change**
- [x] Maintenance

**How Has This Been Tested?**
`RussTreadon:feature/gsifix` was cloned on WCOSS2 (cactus).   File `global_convinfo.txt` was compared with ` /lfs/h1/ops/prod/packages/gfs.v16.3.7/fix/fix_gsi/global_convinfo.txt`.  The two files are identical.

`/ush/build.sh` was executed in the Cactus working copy of `feature/gsifix`.   The correct binary GSI fix files were copied from the updated EIB path.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes

**DUE DATE** for merger of this PR into `develop` is **7/5/2023** (six weeks after PR creation).