### PR TITLE
modulefiles update for GNU compilers

### DIFF
--- a/modulefiles/gsi_cheyenne.gnu.lua
+++ b/modulefiles/gsi_cheyenne.gnu.lua
@@ -4,26 +4,27 @@ help([[
 load("cmake/3.22.0")
 load("python/3.7.9")
 load("ncarenv/1.3")
-load("gnu/10.1.0")
-load("mpt/2.22")
+load("gnu/11.2.0")
+load("mpt/2.25")
 load("ncarcompilers/0.5.0")
+unload("intel")
 unload("netcdf")
 
-prepend_path("MODULEPATH", "/glade/work/epicufsrt/GMTB/tools/gnu/10.1.0/hpc-stack-v1.2.0/modulefiles/stack")
+prepend_path("MODULEPATH", "/glade/work/epicufsrt/contrib/hpc-stack/gnu11.2.0/modulefiles/stack")
 
 load("hpc/1.2.0")
-load("hpc-gnu/10.1.0")
-load("hpc-mpt/2.22")
+load("hpc-gnu/11.2.0")
+load("hpc-mpt/2.25")
 
 -- Preload w3nco to work around nemsio "find_dependency(w3nco)" hpc-stack bug
 load("w3nco/2.4.1")
 
 load("gsi_common")
 
-local prod_util_ver=os.getenv("prod_util_ver") or "1.2.2"
-load(pathJoin("prod_util", prod_util_ver))
+load(pathJoin("prod_util", os.getenv("prod_util_ver") or "1.2.2"))
+load(pathJoin("openblas", os.getenv("openblas_ver") or "0.3.23"))
 
-pushenv("MKLROOT", "/glade/u/apps/opt/intel/2022.1/mkl/latest")
+pushenv("GSI_BINARY_SOURCE_DIR", "/glade/work/epicufsrt/contrib/GSI_fix/fix")
 
 pushenv("CC",  "mpicc")
 pushenv("FC",  "mpif90")

--- a/modulefiles/gsi_common.lua
+++ b/modulefiles/gsi_common.lua
@@ -6,16 +6,16 @@ local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 
 local bufr_ver=os.getenv("bufr_ver") or "11.7.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
-local w3emc_ver=os.getenv("w3emc_ver") or "2.9.1"
+local w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 local sp_ver=os.getenv("sp_ver") or "2.3.3"
 local ip_ver=os.getenv("ip_ver") or "3.3.3"
 local sigio_ver=os.getenv("sigio_ver") or "2.3.2"
 local sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
-local nemsio_ver=os.getenv("nemsio_ver") or "2.5.2"
+local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
 local crtm_ver=os.getenv("crtm_ver") or "2.4.0"
-local ncdiag_ver=os.getenv("ncdiag_ver") or "1.0.0"
+local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.0"
 
 load(pathJoin("netcdf", netcdf_ver))
 

--- a/modulefiles/gsi_hera.gnu.lua
+++ b/modulefiles/gsi_hera.gnu.lua
@@ -1,15 +1,18 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack")
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/gnu-9.2/modulefiles/stack")
 
 local hpc_ver=os.getenv("hpc_ver") or "1.1.0"
-local hpc_gnu_ver=os.getenv("hpc_gnu_ver") or "9.2.0"
+local gnu_ver=os.getenv("gnu_ver") or "9.2.0"
+local hpc_gnu_ver=os.getenv("hpc_gnu_ver") or "9.2"
 local hpc_mpich_ver=os.getenv("hpc_mpich_ver") or "3.3.2"
 local cmake_ver=os.getenv("cmake_ver") or "3.20.1"
 local prod_util_ver=os.getenv("prod_util_ver") or "1.2.2"
+local openblas_ver=os.getenv("openblas_ver") or "0.3.23"
 
 load(pathJoin("hpc", hpc_ver))
+load(pathJoin("gnu", gnu_ver))
 load(pathJoin("hpc-gnu", hpc_gnu_ver))
 load(pathJoin("hpc-mpich", hpc_mpich_ver))
 load(pathJoin("cmake", cmake_ver))
@@ -17,8 +20,7 @@ load(pathJoin("cmake", cmake_ver))
 load("gsi_common")
 
 load(pathJoin("prod_util", prod_util_ver))
-
-pushenv("MKLROOT", "/apps/oneapi/mkl/2022.0.2")
+load(pathJoin("openblas", openblas_ver))
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230601")
 


### PR DESCRIPTION
**Description**

This is an update for modulefiles with GNU compilers on Hera and Cheyenne.
It includes loading an additional library/module "openblas" built with GNU that replaces the MKL libraries used in intel builds.

GSI fix files are also staged on Cheyenne in EPIC-controlled space. 

Files changed:
```
gsi_hera.gnu.lua
gsi_cheyenne.gnu.lua
gsi_common.lua
```

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
- [x] Hera - Compile, build executables
- [x] Hera - Regression testing 
- [x] Cheyenne - Compile, build executables
- [ ] Cheyenne - Regression testing (no regression test data available yet) 
 
 
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published


**DUE DATE for this PR is 7/19/2023**. If this PR is not merged into `develop` by this date, the PR will be closed and returned to the developer.