### PR TITLE
Bugfix/pseudo rh

### DIFF
--- a/regression/regression_namelists.sh
+++ b/regression/regression_namelists.sh
@@ -2155,7 +2155,7 @@ export gsi_namelist="
  &nam_enkf
   datestring=${global_adate},datapath='${DATA}/',
   analpertwtnh=${analpertwt},analpertwtsh=${analpertwt},analpertwttr=${analpertwt},
-  covinflatemax=1.e2,covinflatemin=1,pseudo_rh=.true.,iassim_order=0,
+  covinflatemax=1.e2,covinflatemin=1,pseudo_rh=.false.,iassim_order=0,
   corrlengthnh=${corrlength},corrlengthsh=${corrlength},corrlengthtr=${corrlength},
   lnsigcutoffnh=${lnsigcutoff},lnsigcutoffsh=${lnsigcutoff},lnsigcutofftr=${lnsigcutoff},
   lnsigcutoffpsnh=${lnsigcutoff},lnsigcutoffpssh=${lnsigcutoff},lnsigcutoffpstr=${lnsigcutoff},
@@ -2169,7 +2169,7 @@ export gsi_namelist="
   use_gfs_nemsio=${use_gfs_nemsio},use_gfs_ncio=${use_gfs_ncio},imp_physics=$imp_physics,lupp=$lupp,
   univaroz=.false.,adp_anglebc=.true.,angord=4,use_edges=.false.,emiss_bc=.true.,
   letkf_flag=${letkf_flag},nobsl_max=${nobsl_max},denkf=${denkf},getkf=${getkf}.,
-  nhr_anal=${IAUFHRS_ENKF},nhr_state=${IAUFHRS_ENKF},use_qsatensmean=.true.,
+  nhr_anal=${IAUFHRS_ENKF},nhr_state=${IAUFHRS_ENKF},
   lobsdiag_forenkf=$lobsdiag_forenkf,
   write_spread_diag=$write_spread_diag,
   modelspace_vloc=$modelspace_vloc,

--- a/src/enkf/controlvec.f90
+++ b/src/enkf/controlvec.f90
@@ -64,7 +64,6 @@ private
 public :: read_control, write_control, controlvec_cleanup, init_controlvec
 real(r_single), public, allocatable, dimension(:,:,:,:) :: grdin
 real(r_double), public, allocatable, dimension(:,:,:,:) :: qsat
-real(r_double), public, allocatable, dimension(:,:,:) :: qsatmean
 
 integer(i_kind), public :: nc2d, nc3d, ncdim
 character(len=max_varname_length), allocatable, dimension(:), public :: cvars3d
@@ -192,7 +191,6 @@ subroutine read_control()
 ! read ensemble members on IO tasks
 implicit none
 real(r_double)  :: t1,t2
-real(r_double), allocatable, dimension(:) :: qsat_tmp
 integer(i_kind) :: nb,nlev,ne
 integer(i_kind) :: q_ind
 integer(i_kind) :: ierr
@@ -373,7 +371,6 @@ if (allocated(clevels)) deallocate(clevels)
 if (allocated(index_pres)) deallocate(index_pres)
 if (allocated(grdin)) deallocate(grdin)
 if (allocated(qsat)) deallocate(qsat)
-if (allocated(qsatmean)) deallocate(qsatmean)
 call gridinfo_cleanup()
 end subroutine controlvec_cleanup
 

--- a/src/enkf/params.f90
+++ b/src/enkf/params.f90
@@ -681,10 +681,6 @@ if (nproc == 0) then
        letkf_flag) then
      print *,'warning: no time localization in LETKF!'
    endif
-   if ((write_ensmean .and. pseudo_rh) .and. .not. use_qsatensmean) then
-      print *,'write_ensmean=T requires use_qsatensmean=T when pseudo_rh=T'
-      call stop2(19)
-   endif
 
 
    print *, trim(adjustl(datapath))

--- a/src/enkf/params.f90
+++ b/src/enkf/params.f90
@@ -226,12 +226,6 @@ logical,public :: efsoi_cycling = .false.
 ! EFSOI calculation applications
 logical,public :: efsoi_flag = .false.
 
-! if true, use ensemble mean qsat in definition of
-! normalized humidity analysis variable (instead of
-! qsat for each member, which is the default behavior
-! when pseudo_rh=.true.  If pseudo_rh=.false, use_qsatensmean
-! is ignored.
-logical,public :: use_qsatensmean = .false.
 logical,public :: write_spread_diag = .false.
 ! if true, use jacobian from GSI stored in diag file to compute
 ! ensemble perturbations in observation space.
@@ -261,7 +255,7 @@ logical,public :: write_ensmean = .false.
 namelist /nam_enkf/datestring,datapath,iassim_order,nvars,&
                    covinflatemax,covinflatemin,deterministic,sortinc,&
                    mincorrlength_fact,corrlengthnh,corrlengthtr,corrlengthsh,&
-                   varqc,huber,nlons,nlats,smoothparm,use_qsatensmean,&
+                   varqc,huber,nlons,nlats,smoothparm,&
                    readin_localization, zhuberleft,zhuberright,&
                    obtimelnh,obtimeltr,obtimelsh,reducedgrid,&
                    lnsigcutoffnh,lnsigcutofftr,lnsigcutoffsh,&


### PR DESCRIPTION
**Description**

The EnKF uses the pseudo_RH=True option, which switches the humidity analysis variable to q/qsat (pseudo_RH=False would use q) 
The default (and in operations) settings also includes use use_qsatensmean=True, which uses q/ensmean(qsat) for each ensemble member.

If use_qsatensmean is true, in controlvec.f90 read_control (then write_control) the q for each ensemble member are divided (then multiplied) by the same number (ensemble mean qsat) at each location before (then after) the state update. This multipilcation/division of each ensemble member by the same number has no net effect, and use_qsatensmean = true reduces to being the same as use pseudo_rh = false (using q as the control variable). Experiments show identical output from both options. See example in slides: 

https://docs.google.com/presentation/d/1mLenEtuoN_9PI0--BEyIHN-E3rUW2WwcsHgzgqi2r0M/edit?usp=sharing

This PR then removes the use_qsatensmean option (including from the namelists). This required adding code to write out the ensemble mean for the pseudo_RH option without relying on the ensemble mean qsat. 

In the PR  I have the changed the pseudo_RH option to False in the regression test, which amounts to no science change. However, True would be better option and is what we thought we were doing up to now (more consistent with what is done in the Var solver, less heterogeneity in ensemble covariances with temperature). I suggest that we switch this going forward.

I ran both cases (but also decreased the obs error) in an EnKF experiment. There was no significant impact on skill. See slides linked above.

Note: @jswhit introduced the use_qsatensmean option to avoid problems with very small qsat at some locations. Could this become a problem again if we revert back to pseudo_RH=True.

Fixes #561  

**Type of change**

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

See experiments in slides above. 
All regerssion tests have passed on hera. 

  
**Checklist**

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] New and existing tests pass with my changes
- [x ] Any dependent changes have been merged and published

**DUE DATE for this PR is 9/8/2023.** If this PR is not merged into develop by this date, the PR will be closed and returned to the developer.