### PR TITLE
Refine PM2.5 DA for the RRFS_SD model 

### DIFF
--- a/src/gsi/chemmod.f90
+++ b/src/gsi/chemmod.f90
@@ -40,21 +40,23 @@ module chemmod
   public :: naero_cmaq_fv3,aeronames_cmaq_fv3,imodes_cmaq_fv3
 
 ! fv3smoke
-  public :: naero_smoke_fv3,aeronames_smoke_fv3,pm2_5_innov_threshold 
+  public :: naero_smoke_fv3,aeronames_smoke_fv3
+  public :: pm2_5_innov_threshold,pm2_5_urban_innov_threshold,pm2_5_bg_threshold 
+  public :: pm10_innov_threshold,pm10_urban_innov_threshold,pm10_bg_threshold,pm10_obs_threshold,pm10_da_scheme
 
   public :: naero_gocart_wrf,aeronames_gocart_wrf
 
   public :: pm2_5_guess,init_pm2_5_guess,&
        aerotot_guess,init_aerotot_guess
   public :: init_chem
-  public :: berror_chem,berror_fv3_cmaq_regional,oneobtest_chem,maginnov_chem,magoberr_chem,oneob_type_chem,conconeobs
+  public :: berror_chem,berror_fv3_cmaq_regional,berror_fv3_sd_regional,oneobtest_chem,maginnov_chem,magoberr_chem,oneob_type_chem,conconeobs
   public :: oblat_chem,oblon_chem,obpres_chem,diag_incr,oneobschem
   public :: site_scale,nsites
   public :: tunable_error
   public :: in_fname,out_fname,incr_fname,maxstr
   public :: code_pm25_ncbufr,code_pm25_anowbufr
   public :: code_pm10_ncbufr,code_pm10_anowbufr
-
+  public :: anowbufr_ext
   public :: l_aoderr_table
 
   public :: laeroana_gocart,laeroana_fv3cmaq,laeroana_fv3smoke,crtm_aerosol_model,crtm_aerosolcoeff_format,crtm_aerosolcoeff_file, &
@@ -76,10 +78,11 @@ module chemmod
   logical :: luse_deepblue
   character(len=max_varname_length) :: crtm_aerosol_model,crtm_aerosolcoeff_format,crtm_aerosolcoeff_file
   integer(i_kind) :: aod_qa_limit  ! qa >=  aod_qa_limit will be retained
-  integer(i_kind) :: icvt_cmaq_fv3
+  integer(i_kind) :: icvt_cmaq_fv3,pm10_da_scheme
   real(r_kind)    :: raod_radius_mean_scale,raod_radius_std_scale
   real(r_kind)    :: ppmv_conv = 96.06_r_kind/28.964_r_kind*1.0e+3_r_kind
-  real(r_kind)    :: pm2_5_innov_threshold 
+  real(r_kind)    :: pm2_5_innov_threshold,pm2_5_urban_innov_threshold,pm2_5_bg_threshold
+  real(r_kind)    :: pm10_innov_threshold,pm10_urban_innov_threshold,pm10_bg_threshold,pm10_obs_threshold
 
   logical :: wrf_pm2_5
 
@@ -90,7 +93,9 @@ module chemmod
 
   logical :: aero_ratios
 
-  logical :: oneobtest_chem,diag_incr,berror_chem,berror_fv3_cmaq_regional
+  logical :: oneobtest_chem,diag_incr,berror_chem
+  logical :: berror_fv3_cmaq_regional,berror_fv3_sd_regional
+  logical :: anowbufr_ext
   character(len=max_varname_length) :: oneob_type_chem
   integer(i_kind), parameter :: maxstr=256
   real(r_kind) :: maginnov_chem,magoberr_chem,conconeobs,&
@@ -103,7 +108,7 @@ module chemmod
   real(r_kind),parameter :: pm2_5_teom_max=900.0_r_kind !ug/m3
 !some parameters need to be put here since convinfo file won't
 !accomodate, stands for maximum realistic value of surface pm2.5
-  real(r_kind),parameter :: pm10_teom_max=150.0_r_kind !ug/m3
+  real(r_kind),parameter :: pm10_teom_max=3000.0_r_kind !ug/m3
 
 
   real(r_kind),parameter :: elev_missing=-9999.0_r_kind
@@ -157,10 +162,10 @@ module chemmod
         'AOLGAJ', 'AISO1J', 'AISO2J', 'AISO3J',   'ATRP1J', 'ATRP2J',&
         'ASQTJ',  'AOLGBJ', 'AORGCJ']
 ! fv3smoke
-  integer(i_kind), parameter ::  naero_smoke_fv3=2 
+  integer(i_kind), parameter ::  naero_smoke_fv3=3 
 
   character(len=max_varname_length), dimension(naero_smoke_fv3), parameter :: &
-        aeronames_smoke_fv3=[character(len=max_varname_length) ::  'smoke','dust' ]
+        aeronames_smoke_fv3=[character(len=max_varname_length) ::  'smoke','dust','coarsepm']
 
 ! FV3CMAQ
   integer(i_kind), parameter :: naero_cmaq_fv3=70 !  !number of cmaq aerosol species aero6
@@ -287,7 +292,9 @@ contains
     
     berror_chem=.false.
     berror_fv3_cmaq_regional=.false.  ! Set .true. to use berror for fv3_cmaq_regional, whose cv has 10 characters
+    berror_fv3_sd_regional=.false.    ! Set .true. to use berror for rrfs_sd model, whose cv has 10 characters
     oneobtest_chem=.false.
+    anowbufr_ext=.false.
     maginnov_chem=30_r_kind
     magoberr_chem=2_r_kind
     oneob_type_chem='pm2_5'
@@ -307,9 +314,16 @@ contains
     laeroana_gocart = .false.
     laeroana_fv3cmaq = .false.    ! .true. for performing aerosol analysis for regional FV3-CMAQ model(Please other parameters requred in gsimod.F90) 
     laeroana_fv3smoke = .false.
-    pm2_5_innov_threshold = 20.0_r_kind
+    pm2_5_innov_threshold = 15.0_r_kind
+    pm2_5_urban_innov_threshold = 30.0_r_kind
+    pm2_5_bg_threshold = 2.0_r_kind
+    pm10_innov_threshold = 15.0_r_kind
+    pm10_urban_innov_threshold = 30.0_r_kind
+    pm10_bg_threshold = 2.0_r_kind
+    pm10_obs_threshold = 140.0_r_kind ! Barry's manuscript
+    pm10_da_scheme = 1            ! 1: Assmilate full PM10; 2: assimilate pm10-pm2.5
     l_aoderr_table = .false.
-    icvt_cmaq_fv3   = 1           ! 1. Control variable is individual aerosol specie; 2: CV is total mass per I,J,K mode
+    icvt_cmaq_fv3   = 1           ! 1: Control variable is individual aerosol specie; 2: CV is total mass per I,J,K mode
     raod_radius_mean_scale = 1.0_r_kind  ! Tune radius of particles when calculating AOD using CRTM
     raod_radius_std_scale  = 1.0_r_kind  ! Tune standard deviation of particles when calculating AOD using CRTM with CMAQ LUTs.
     aod_qa_limit = 3

--- a/src/gsi/chemmod.f90
+++ b/src/gsi/chemmod.f90
@@ -291,10 +291,15 @@ contains
 !initialiazes default values to &CHEM namelist parameters
     
     berror_chem=.false.
-    berror_fv3_cmaq_regional=.false.  ! Set .true. to use berror for fv3_cmaq_regional, whose cv has 10 characters
-    berror_fv3_sd_regional=.false.    ! Set .true. to use berror for rrfs_sd model, whose cv has 10 characters
+    berror_fv3_cmaq_regional=.false.  ! .False. : Dont perform aerosal DA for the online RRFS_CMAQ model so dont need to read in B for RRFS_CMAQ.  
+                                      ! .true.  : Use berror for fv3_cmaq_regional, whose cv has 10 characters
+    berror_fv3_sd_regional=.false.    ! .False. : Dont perform aerosal DA for the RRFS_SD model so dont need to read in B for RRFS_SD.  
+                                      ! .true. to use berror for rrfs_sd model, whose cv has 10 characters
     oneobtest_chem=.false.
-    anowbufr_ext=.false.
+    anowbufr_ext=.false.              ! .False. : use default anowbufr data
+                                      ! .True.  : use the extented bufr data
+                                      ! that includes PM10, station elevation
+                                      ! etal in addition to pm2.5. 
     maginnov_chem=30_r_kind
     magoberr_chem=2_r_kind
     oneob_type_chem='pm2_5'

--- a/src/gsi/chemmod.f90
+++ b/src/gsi/chemmod.f90
@@ -42,7 +42,7 @@ module chemmod
 ! fv3smoke
   public :: naero_smoke_fv3,aeronames_smoke_fv3
   public :: pm2_5_innov_threshold,pm2_5_urban_innov_threshold,pm2_5_bg_threshold 
-  public :: pm10_innov_threshold,pm10_urban_innov_threshold,pm10_bg_threshold,pm10_obs_threshold,pm10_da_scheme
+  public :: pm10_innov_threshold,pm10_urban_innov_threshold,pm10_bg_threshold,pm10_obs_threshold
 
   public :: naero_gocart_wrf,aeronames_gocart_wrf
 
@@ -78,7 +78,7 @@ module chemmod
   logical :: luse_deepblue
   character(len=max_varname_length) :: crtm_aerosol_model,crtm_aerosolcoeff_format,crtm_aerosolcoeff_file
   integer(i_kind) :: aod_qa_limit  ! qa >=  aod_qa_limit will be retained
-  integer(i_kind) :: icvt_cmaq_fv3,pm10_da_scheme
+  integer(i_kind) :: icvt_cmaq_fv3
   real(r_kind)    :: raod_radius_mean_scale,raod_radius_std_scale
   real(r_kind)    :: ppmv_conv = 96.06_r_kind/28.964_r_kind*1.0e+3_r_kind
   real(r_kind)    :: pm2_5_innov_threshold,pm2_5_urban_innov_threshold,pm2_5_bg_threshold
@@ -326,7 +326,6 @@ contains
     pm10_urban_innov_threshold = 30.0_r_kind
     pm10_bg_threshold = 2.0_r_kind
     pm10_obs_threshold = 140.0_r_kind ! Barry's manuscript
-    pm10_da_scheme = 1            ! 1: Assmilate full PM10; 2: assimilate pm10-pm2.5
     l_aoderr_table = .false.
     icvt_cmaq_fv3   = 1           ! 1: Control variable is individual aerosol specie; 2: CV is total mass per I,J,K mode
     raod_radius_mean_scale = 1.0_r_kind  ! Tune radius of particles when calculating AOD using CRTM

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -180,12 +180,15 @@
   use gsi_chemguess_mod, only: gsi_chemguess_init,gsi_chemguess_final
   use tcv_mod, only: init_tcps_errvals,tcp_refps,tcp_width,tcp_ermin,tcp_ermax
   use chemmod, only : init_chem,berror_chem,berror_fv3_cmaq_regional,oneobtest_chem,&
+       berror_fv3_sd_regional,&
        maginnov_chem,magoberr_chem,&
        oneob_type_chem,oblat_chem,&
+       anowbufr_ext,&
        oblon_chem,obpres_chem,diag_incr,elev_tolerance,tunable_error,&
        in_fname,out_fname,incr_fname, &
        laeroana_gocart, l_aoderr_table, aod_qa_limit, luse_deepblue, lread_ext_aerosol, &
-       laeroana_fv3cmaq,laeroana_fv3smoke,pm2_5_innov_threshold,crtm_aerosol_model,crtm_aerosolcoeff_format,crtm_aerosolcoeff_file, &
+       laeroana_fv3cmaq,laeroana_fv3smoke,pm2_5_innov_threshold,pm2_5_urban_innov_threshold,pm2_5_bg_threshold,&
+       crtm_aerosol_model,crtm_aerosolcoeff_format,crtm_aerosolcoeff_file, &
        icvt_cmaq_fv3, raod_radius_mean_scale,raod_radius_std_scale 
 
   use chemmod, only : wrf_pm2_5,aero_ratios
@@ -1583,6 +1586,12 @@
 ! chem(options for gsi chem analysis) :
 !     berror_chem       - .true. when background  for chemical species that require
 !                          conversion to lower case and/or species names longer than 5 chars
+!     berror_fv3_cmaq_regional   - .true. use background error stat for online
+!                                         RRFS_CMAQ model. Control variable
+!                                         names extended up to 10 chars
+!     berror_fv3_sd_regional     - .true. use background error stat for online
+!                                         RRFS_SD model. Control variable
+!                                         names extended up to 10 chars
 !     oneobtest_chem    - one-ob trigger for chem constituent analysis
 !     maginnov_chem     - O-B make-believe residual for one-ob chem test
 !     magoberr_chem     - make-believe obs error for one-ob chem test
@@ -1604,13 +1613,15 @@
 !     luse_deepblue     - whether to use MODIS AOD from the deepblue   algorithm
 !     lread_ext_aerosol - if true, reads aerfNN file for aerosol arrays rather than sigfNN (NGAC NEMS IO)
 
-  namelist/chem/berror_chem,berror_fv3_cmaq_regional,oneobtest_chem,maginnov_chem,magoberr_chem,&
+  namelist/chem/berror_chem,berror_fv3_cmaq_regional,berror_fv3_sd_regional,& 
+       oneobtest_chem,anowbufr_ext,maginnov_chem,magoberr_chem,&
        oneob_type_chem,oblat_chem,oblon_chem,obpres_chem,&
        diag_incr,elev_tolerance,tunable_error,&
        in_fname,out_fname,incr_fname,&
        laeroana_gocart, laeroana_fv3cmaq,laeroana_fv3smoke,l_aoderr_table, aod_qa_limit, &
        crtm_aerosol_model,crtm_aerosolcoeff_format,crtm_aerosolcoeff_file, &
        icvt_cmaq_fv3,pm2_5_innov_threshold, &
+       pm2_5_innov_threshold,pm2_5_urban_innov_threshold,pm2_5_bg_threshold,&
        raod_radius_mean_scale,raod_radius_std_scale, luse_deepblue,&
        aero_ratios,wrf_pm2_5, lread_ext_aerosol
 

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -181,12 +181,15 @@
   use gsi_chemguess_mod, only: gsi_chemguess_init,gsi_chemguess_final
   use tcv_mod, only: init_tcps_errvals,tcp_refps,tcp_width,tcp_ermin,tcp_ermax
   use chemmod, only : init_chem,berror_chem,berror_fv3_cmaq_regional,oneobtest_chem,&
+       berror_fv3_sd_regional,&
        maginnov_chem,magoberr_chem,&
        oneob_type_chem,oblat_chem,&
+       anowbufr_ext,&
        oblon_chem,obpres_chem,diag_incr,elev_tolerance,tunable_error,&
        in_fname,out_fname,incr_fname, &
        laeroana_gocart, l_aoderr_table, aod_qa_limit, luse_deepblue, lread_ext_aerosol, &
-       laeroana_fv3cmaq,laeroana_fv3smoke,pm2_5_innov_threshold,crtm_aerosol_model,crtm_aerosolcoeff_format,crtm_aerosolcoeff_file, &
+       laeroana_fv3cmaq,laeroana_fv3smoke,pm2_5_innov_threshold,pm2_5_urban_innov_threshold,pm2_5_bg_threshold,&
+       crtm_aerosol_model,crtm_aerosolcoeff_format,crtm_aerosolcoeff_file, &
        icvt_cmaq_fv3, raod_radius_mean_scale,raod_radius_std_scale 
 
   use chemmod, only : wrf_pm2_5,aero_ratios
@@ -1585,6 +1588,12 @@
 ! chem(options for gsi chem analysis) :
 !     berror_chem       - .true. when background  for chemical species that require
 !                          conversion to lower case and/or species names longer than 5 chars
+!     berror_fv3_cmaq_regional   - .true. use background error stat for online
+!                                         RRFS_CMAQ model. Control variable
+!                                         names extended up to 10 chars
+!     berror_fv3_sd_regional     - .true. use background error stat for online
+!                                         RRFS_SD model. Control variable
+!                                         names extended up to 10 chars
 !     oneobtest_chem    - one-ob trigger for chem constituent analysis
 !     maginnov_chem     - O-B make-believe residual for one-ob chem test
 !     magoberr_chem     - make-believe obs error for one-ob chem test
@@ -1606,13 +1615,15 @@
 !     luse_deepblue     - whether to use MODIS AOD from the deepblue   algorithm
 !     lread_ext_aerosol - if true, reads aerfNN file for aerosol arrays rather than sigfNN (NGAC NEMS IO)
 
-  namelist/chem/berror_chem,berror_fv3_cmaq_regional,oneobtest_chem,maginnov_chem,magoberr_chem,&
+  namelist/chem/berror_chem,berror_fv3_cmaq_regional,berror_fv3_sd_regional,& 
+       oneobtest_chem,anowbufr_ext,maginnov_chem,magoberr_chem,&
        oneob_type_chem,oblat_chem,oblon_chem,obpres_chem,&
        diag_incr,elev_tolerance,tunable_error,&
        in_fname,out_fname,incr_fname,&
        laeroana_gocart, laeroana_fv3cmaq,laeroana_fv3smoke,l_aoderr_table, aod_qa_limit, &
        crtm_aerosol_model,crtm_aerosolcoeff_format,crtm_aerosolcoeff_file, &
        icvt_cmaq_fv3,pm2_5_innov_threshold, &
+       pm2_5_innov_threshold,pm2_5_urban_innov_threshold,pm2_5_bg_threshold,&
        raod_radius_mean_scale,raod_radius_std_scale, luse_deepblue,&
        aero_ratios,wrf_pm2_5, lread_ext_aerosol
 

--- a/src/gsi/m_berror_stats_reg.f90
+++ b/src/gsi/m_berror_stats_reg.f90
@@ -12,7 +12,7 @@
       use kinds,only : i_kind,r_kind
       use constants, only: zero,one,max_varname_length,half
       use gridmod, only: nsig
-      use chemmod, only : berror_chem,berror_fv3_cmaq_regional,upper2lower,lower2upper
+      use chemmod, only : berror_chem,berror_fv3_cmaq_regional,berror_fv3_sd_regional,upper2lower,lower2upper
       use m_berror_stats, only: usenewgfsberror,berror_stats
 
       implicit none
@@ -312,7 +312,7 @@ end subroutine berror_read_bal_reg
       use constants, only: zero,one,ten,three
       use mpeu_util,only: getindex
       use radiance_mod, only: icloud_cv,n_clouds_fwd,cloud_names_fwd
-      use chemmod, only: berror_fv3_cmaq_regional
+      use chemmod, only: berror_fv3_cmaq_regional,berror_fv3_sd_regional
 
       implicit none
 
@@ -466,7 +466,7 @@ end subroutine berror_read_bal_reg
         var=upper2lower(varshort)
         if (trim(var) == 'pm25') var = 'pm2_5'
      else 
-        if ( berror_fv3_cmaq_regional) then
+        if ( berror_fv3_cmaq_regional .or. berror_fv3_sd_regional) then
           read(inerr,iostat=istat) varlong, isig
           var=varlong
         else

--- a/src/gsi/read_anowbufr.f90
+++ b/src/gsi/read_anowbufr.f90
@@ -232,8 +232,6 @@ subroutine read_anowbufr(nread,ndata,nodata,gstime,&
         conc=indata(ncopopm)
         if ( iret > 0 .and. (conc < conc_missing ) .and. &
                (conc >= zero)) then
-           if(indata(nxob) > r360)cycle 
-           if(indata(nyob) > 0.5_r_kind*r360)cycle
            
            if(indata(nxob) >= r360)  indata(nxob) = indata(nxob) - r360
            if(indata(nxob) <  zero)  indata(nxob) = indata(nxob) + r360

--- a/src/gsi/read_anowbufr.f90
+++ b/src/gsi/read_anowbufr.f90
@@ -232,6 +232,8 @@ subroutine read_anowbufr(nread,ndata,nodata,gstime,&
         conc=indata(ncopopm)
         if ( iret > 0 .and. (conc < conc_missing ) .and. &
                (conc >= zero)) then
+           if(indata(nxob) > r360)cycle 
+           if(indata(nyob) > 0.5_r_kind*r360)cycle
            
            if(indata(nxob) >= r360)  indata(nxob) = indata(nxob) - r360
            if(indata(nxob) <  zero)  indata(nxob) = indata(nxob) + r360

--- a/src/gsi/read_anowbufr.f90
+++ b/src/gsi/read_anowbufr.f90
@@ -51,7 +51,7 @@ subroutine read_anowbufr(nread,ndata,nodata,gstime,&
         elev_missing,site_scale,tunable_error,&
         code_pm25_ncbufr,code_pm25_anowbufr,&
         code_pm10_ncbufr,code_pm10_anowbufr,&
-        anowbufr_ext,pm10_da_scheme,pm2_5_teom_max,pm10_teom_max
+        anowbufr_ext,pm2_5_teom_max,pm10_teom_max
 
   use mpimod, only: npe
 

--- a/src/gsi/satthin.F90
+++ b/src/gsi/satthin.F90
@@ -134,6 +134,8 @@ module satthin
   use obsmod, only: time_window_max
   use constants, only: deg2rad,rearth_equator,zero,two,pi,half,one,&
        rad2deg,r1000
+  use chemmod, only: laeroana_fv3smoke
+
   implicit none
 
 ! set default to private
@@ -961,7 +963,10 @@ contains
     end if
     if (.not.lobserver) then
        if(allocated(veg_frac)) deallocate(veg_frac)
-       if(allocated(veg_type)) deallocate(veg_type)
+!       veg_type will be used in setuppm2_5.f90 for rrfs_sd PM2.5 DA
+       if(.not. laeroana_fv3smoke )then
+         if(allocated(veg_type)) deallocate(veg_type)
+       endif
        if(allocated(soil_type)) deallocate(soil_type)
        if(allocated(soil_moi)) deallocate(soil_moi)
        if(allocated(sfc_rough)) deallocate(sfc_rough)

--- a/src/gsi/setuppm2_5.f90
+++ b/src/gsi/setuppm2_5.f90
@@ -779,13 +779,12 @@ subroutine setuppm2_5(obsLL,odiagLL,lunin,mype,nreal,nobs,isis,is,conv_diagsave)
                 mype,nfldsig)
           call tintrp2a11(pm25wc(:,:,:,2,nfldsig),pm25wc_ges(2),dlat,dlon,dtime,hrdifsig,&
                 mype,nfldsig)
-          !write(6,"(A,L3,F8.3,1x,F8.3,F6.2,4F7.2)")"OBS_INF ",muse(i),data(ilate,i),data(ilone,i),veg_type_ges,pm2_5ges,innov,pm25wc_ges(1),pm25wc_ges(2)
-          if (pm25wc_ges(1) >= 2.0_r_kind) then
+          if (pm25wc_ges(1) >= pm2_5_bg_threshold) then
             pm25wc_ges(1)=1.0_r_kind
           else
             pm25wc_ges(1)=0.0_r_kind
           end if
-          if (pm25wc_ges(2) >= 2.0_r_kind) then
+          if (pm25wc_ges(2) >= pm2_5_bg_threshold) then
             pm25wc_ges(2)=1.0_r_kind
           else
             pm25wc_ges(2)=0.0_r_kind
@@ -793,7 +792,6 @@ subroutine setuppm2_5(obsLL,odiagLL,lunin,mype,nreal,nobs,isis,is,conv_diagsave)
           if ( (pm25wc_ges(1)+pm25wc_ges(2)) < 1.0_r_kind ) then
             muse(i) = .false. 
           end if
-          write(6,"(A,L3,F8.3,1x,F8.3,5F7.2)")"PM2_5_INF",muse(i),data(ilate,i),data(ilone,i),pm2_5ges,innov,pm25wc_ges(1:2),veg_type_ges
         else
           pm25wc_ges = 0.0_r_kind
         end if

--- a/src/gsi/setuppm2_5.f90
+++ b/src/gsi/setuppm2_5.f90
@@ -780,6 +780,8 @@ subroutine setuppm2_5(obsLL,odiagLL,lunin,mype,nreal,nobs,isis,is,conv_diagsave)
           call tintrp2a11(pm25wc(:,:,:,2,nfldsig),pm25wc_ges(2),dlat,dlon,dtime,hrdifsig,&
                 mype,nfldsig)
           if (pm25wc_ges(1) >= pm2_5_bg_threshold) then
+            pm25wc_ges(1)=1.0_r_kind
+          else
             pm25wc_ges(1)=0.0_r_kind
           end if
           if (pm25wc_ges(2) >= pm2_5_bg_threshold) then

--- a/src/gsi/setuppm2_5.f90
+++ b/src/gsi/setuppm2_5.f90
@@ -713,7 +713,7 @@ subroutine setuppm2_5(obsLL,odiagLL,lunin,mype,nreal,nobs,isis,is,conv_diagsave)
 !
         if (laeroana_fv3smoke) then
           if (.not. allocated(veg_type)) then 
-             print*,"VEG_TYPE NOT ALLOCATED",mype 
+             print*,"VEG_TYPE NOT ALLOCATED, WILL NOT BE USED IN PM2.5 DA FOR RRFS_SD",mype 
           else
              call intrp2a11(veg_type(:,:,1),veg_type_ges,dlat,dlon,mype)
           endif
@@ -747,7 +747,6 @@ subroutine setuppm2_5(obsLL,odiagLL,lunin,mype,nreal,nobs,isis,is,conv_diagsave)
            innov = conc - pm2_5ges
            if (laeroana_fv3smoke) then
               if ( veg_type_ges == 13.0_r_kind ) then 
-                 print*,"PM25_urban_found"
                  if (abs(innov) < pm2_5_urban_innov_threshold) then
                     muse(i)=.false.
                  end if 

--- a/src/gsi/setuppm2_5.f90
+++ b/src/gsi/setuppm2_5.f90
@@ -780,8 +780,6 @@ subroutine setuppm2_5(obsLL,odiagLL,lunin,mype,nreal,nobs,isis,is,conv_diagsave)
           call tintrp2a11(pm25wc(:,:,:,2,nfldsig),pm25wc_ges(2),dlat,dlon,dtime,hrdifsig,&
                 mype,nfldsig)
           if (pm25wc_ges(1) >= pm2_5_bg_threshold) then
-            pm25wc_ges(1)=1.0_r_kind
-          else
             pm25wc_ges(1)=0.0_r_kind
           end if
           if (pm25wc_ges(2) >= pm2_5_bg_threshold) then


### PR DESCRIPTION
**Description**

Refine the PM2.5 DA for the RRFS_SD model by use of veg_type, which is used to decide whether the obs is in urban area or not. Different thresholds for innovations outside/inside urban areas will be used.  Add new namelist parameters, such as threshold for innovations, anowbufr type 
Read in station terrain height, PM10 et al if extended BUFR format for anow air quality data is used 

Fixes #606 


**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

<!-- This change will only affect PM2.5 DA for RRFS_SD, so it will not affect any other tests -->

  
**Checklist**

- [X ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

**DUE DATE for this PR is 9/22/2023.** If this PR is not merged into develop by this date, the PR will be closed and returned to the developer.