### PR TITLE
add missing jacobian arrays to netcdf ozone diagnostic file (#618)

### DIFF
--- a/src/gsi/setupoz.f90
+++ b/src/gsi/setupoz.f90
@@ -636,8 +636,9 @@ subroutine setupozlay(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
                     call nc_diag_metadata("Row_Anomaly_Index",         sngl(rmiss)  )
                  endif
                  if (save_jacobian) then
-                    call fullarray(dhx_dx, dhx_dx_array)
-                    call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+                    call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+                    call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+                    call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
                  endif
                 !if (wrtgeovals) then
                 !   call nc_diag_data2d("mole_fraction_of_ozone_in_air", sngl(constoz*ozgestmp)) 


### PR DESCRIPTION
**Description**
PR #591 removed jacobian information from the netcdf ozone diagnostic file.  This caused `enkf.x` to crash.  This PR adds the removed ozone jacobian arrays back to the netcdf ozone diagnostic file.

Fixes #618

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested?**
The revised code was tested in the 20210814 18 gdas cycle of a C192L127 enkf parallel.   The updated `gsi.x` created an oznstat file which was successfully processed by `enkf.x`.
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes