### PR TITLE
update fix submodule hash to include gfs.v16.3.9 updates

### DIFF
--- a/modulefiles/gsi_cheyenne.intel.lua
+++ b/modulefiles/gsi_cheyenne.intel.lua
@@ -18,7 +18,7 @@ load("mkl/2022.1")
 load("gsi_common")
 
 load(pathJoin("prod_util", os.getenv("prod_util_ver") or "1.2.2"))
-pushenv("GSI_BINARY_SOURCE_DIR", "/glade/work/epicufsrt/contrib/GSI_data/fix/20230601")
+pushenv("GSI_BINARY_SOURCE_DIR", "/glade/work/epicufsrt/contrib/GSI_data/fix/20230911")
 
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")

--- a/modulefiles/gsi_gaea.lua
+++ b/modulefiles/gsi_gaea.lua
@@ -23,7 +23,7 @@ local MKLROOT="/opt/intel/oneapi/mkl/2022.0.2/"
 prepend_path("LD_LIBRARY_PATH",pathJoin(MKLROOT,"lib/intel64"))
 pushenv("MKLROOT", MKLROOT)
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/lustre/f2/dev/role.epic/contrib/GSI_data/fix/20230601")
+pushenv("GSI_BINARY_SOURCE_DIR", "/lustre/f2/dev/role.epic/contrib/GSI_data/fix/20230911")
 
 setenv("CC","cc")
 setenv("FC","ftn")

--- a/modulefiles/gsi_hera.gnu.lua
+++ b/modulefiles/gsi_hera.gnu.lua
@@ -22,6 +22,6 @@ load("gsi_common")
 load(pathJoin("prod_util", prod_util_ver))
 load(pathJoin("openblas", openblas_ver))
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230601")
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230911")
 
 whatis("Description: GSI environment on Hera with GNU Compilers")

--- a/modulefiles/gsi_hera.intel.lua
+++ b/modulefiles/gsi_hera.intel.lua
@@ -25,6 +25,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230601")
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230911")
 
 whatis("Description: GSI environment on Hera with Intel Compilers")

--- a/modulefiles/gsi_jet.lua
+++ b/modulefiles/gsi_jet.lua
@@ -26,6 +26,6 @@ pushenv("CFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 pushenv("FFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/mnt/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/gsi/20230601")
+pushenv("GSI_BINARY_SOURCE_DIR", "/mnt/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/gsi/20230911")
 
 whatis("Description: GSI environment on Jet with Intel Compilers")

--- a/modulefiles/gsi_orion.lua
+++ b/modulefiles/gsi_orion.lua
@@ -25,6 +25,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20230601")
+pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20230911")
 
 whatis("Description: GSI environment on Orion with Intel Compilers")

--- a/modulefiles/gsi_s4.lua
+++ b/modulefiles/gsi_s4.lua
@@ -23,6 +23,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-march=ivybridge")
 pushenv("FFLAGS", "-march=ivybridge")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/data/prod/glopara/fix/gsi/20230601")
+pushenv("GSI_BINARY_SOURCE_DIR", "/data/prod/glopara/fix/gsi/20230911")
 
 whatis("Description: GSI environment on S4 with Intel Compilers")

--- a/modulefiles/gsi_wcoss2.lua
+++ b/modulefiles/gsi_wcoss2.lua
@@ -20,6 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 
 load("gsi_common")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20230601")
+pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20230911")
 
 whatis("Description: GSI environment on WCOSS2")


### PR DESCRIPTION
**Description**
This PR updates the `fix` submodule to bring in GFS v16.3.9 updates to `global_convinfo.txt` and `global_ozinfo.txt`.  Issue #620 provides additional information on the GFS v16.3.9 updates.

Please **note** the following
- The change to `global_ozinfo.txt` alters analysis results if ompsnp observation from NOAA-20, NOAA-21, or NPP are processed by gsi.x or `enkf.x`.
- The change to `global_convinfo.txt` alters analysis results if PlanetIQ GPSRO (type 267) is processed by `gsi.x` or `enkf.x`.

Fixes #620 

**Type of change**
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

See the **Note** above for potential impact on analysis results.

**How Has This Been Tested?**
ctests have been run on Hera, Orion, and WCOSS2 (Cactus) with results posted in issue #620.
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
