### PR TITLE
Intel 2022 updates

### DIFF
--- a/src/gsi/obsmod.F90
+++ b/src/gsi/obsmod.F90
@@ -1022,12 +1022,12 @@ contains
 
     integer(i_kind),intent(in   ) :: in_pe
     integer(i_kind),intent(in   ) :: num_pe
-    logical :: l_mkdir_stat
+    logical :: l_mkdir_stat, l_dir_exist
 
     character(len=144):: command
     character(len=8):: pe_name, loc_pe_name
     character(len=128):: loc_dirname
-    integer(i_kind) :: i
+    integer(i_kind) :: i, ierror
 
     if (lrun_subdirs) then
        write(pe_name,'(i4.4)') in_pe
@@ -1038,10 +1038,15 @@ contains
              write(loc_pe_name,'(i4.4)') i
              loc_dirname = 'dir.'//trim(loc_pe_name)
 #ifdef __INTEL_COMPILER
-             l_mkdir_stat = MAKEDIRQQ(trim(loc_dirname))
-             if(.not. l_mkdir_stat) then
-                write(6, *) "Failed to create directory ", trim(loc_dirname), " for PE ", loc_pe_name
-                call stop2(678)
+             INQUIRE(directory=trim(loc_dirname), exist=l_dir_exist)
+             if (.not.l_dir_exist) then
+                l_mkdir_stat = MAKEDIRQQ(trim(loc_dirname))
+                if(.not.l_mkdir_stat) then
+                   ierror=GETLASTERRORQQ()
+                   write(6, *) "INIT_DIRECTORIES:  ***ERROR** Failed to create directory ", &
+                        trim(loc_dirname)," for PE ", loc_pe_name, ' ierror= '
+                   call stop2(678)
+                endif
              endif
 #else
              command = 'mkdir -p -m 755 ' // trim(loc_dirname)

--- a/src/gsi/obsmod.F90
+++ b/src/gsi/obsmod.F90
@@ -1044,7 +1044,7 @@ contains
                 if(.not.l_mkdir_stat) then
                    ierror=GETLASTERRORQQ()
                    write(6, *) "INIT_DIRECTORIES:  ***ERROR** Failed to create directory ", &
-                        trim(loc_dirname)," for PE ", loc_pe_name, ' ierror= '
+                        trim(loc_dirname)," for PE ", loc_pe_name, ' ierror= ', ierror
                    call stop2(678)
                 endif
              endif

--- a/src/gsi/setupaod.f90
+++ b/src/gsi/setupaod.f90
@@ -844,7 +844,7 @@ contains
          call nc_diag_metadata("Observation_Class",     obsclass)
          call nc_diag_metadata_to_single("Latitude",(cenlat)) ! observation latitude (degrees)
          call nc_diag_metadata_to_single("Longitude",(cenlon)) ! observation longitude (degrees)
-         call nc_diag_metadata_to_single("Obs_Time",(dtime))!-time_offset)) ! observation time (hours relative to analysis time)
+         call nc_diag_metadata_to_single("Time",(dtime))!-time_offset)) ! observation time (hours relative to analysis time)
          call nc_diag_metadata_to_single("Sol_Zenith_Angle",(pangs)) ! solar zenith angle (degrees)
          call nc_diag_metadata_to_single("Sol_Azimuth_Angle",(data_s(isazi_ang,n))) ! solar azimuth angle (degrees)
          call nc_diag_metadata("Surface_type", nint(data_s(istyp,n)))

--- a/src/gsi/setupoz.f90
+++ b/src/gsi/setupoz.f90
@@ -1720,6 +1720,7 @@ subroutine setupozlev(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
   type(obs_diag),pointer,intent(in):: odiag
 ! Observation class
   character(7),parameter     :: obsclass = '  ozlev'
+  integer(i_kind),parameter  :: ione = 1
   real(r_kind),dimension(miter) :: obsdiag_iuse
            call nc_diag_metadata_to_single("Latitude",           data(ilate,i)                  )
            call nc_diag_metadata_to_single("Longitude",          data(ilone,i)                  )
@@ -1731,9 +1732,9 @@ subroutine setupozlev(obsLL,odiagLL,lunin,mype,stats_oz,nlevs,nreal,nobs,&
            call nc_diag_metadata_to_single("Obs_Minus_Forecast_unadjusted",ozone_inv            )
            call nc_diag_metadata_to_single("Reference_Pressure", preso3l*r100                   ) ! Pa
            if(luse(i)) then
-             call nc_diag_metadata_to_single("Analysis_Use_Flag",  one                          )
+             call nc_diag_metadata("Analysis_Use_Flag",  ione                                   )
            else
-             call nc_diag_metadata_to_single("Analysis_Use_Flag", -one                          )
+             call nc_diag_metadata("Analysis_Use_Flag", -ione                                   )
            endif
 
            call nc_diag_metadata_to_single("Input_Observation_Error",obserror                   )

--- a/src/gsi/setuprad.f90
+++ b/src/gsi/setuprad.f90
@@ -2575,7 +2575,7 @@ contains
 
                  call nc_diag_metadata_to_single("Elevation",zsges                         ) ! model (guess) elevation at observation location
 
-                 call nc_diag_metadata_to_single("Time",dtime,time_offset,'-')
+                 call nc_diag_metadata_to_single("Obs_Time",dtime,time_offset,'-')
 
                  call nc_diag_metadata_to_single("Scan_Position",data_s(iscan_pos,n)           ) ! sensor scan position
                  call nc_diag_metadata_to_single("Sat_Zenith_Angle", zasat,rad2deg,'*') ! satellite zenith angle (degrees)


### PR DESCRIPTION
**Description**
This PR fixes two types of bugs discovered when cycling `gsi.x` and `enkf.x` with intel/2022 in the global workflow
1. modify variables written to netcdf diagnostic files by `gsi.x` to be consistent with codes which read netcdf diagnostic files
2. modify `lrun_subdirs=.true.` option of `gsi.x` to properly handle the case in which sub-directories already exist in the run directory

Fixes #623

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
Ctests have been on Hera, Orion, and WCOSS2 (Cactus) with acceptable behavior.  A global parallel covering the period 2021073106 through 2021080118 has been run on Hera, Orion, and WCOSS2 (Cactus).  All global workflow jobs ran as expected.
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes