### PR TITLE
fix a bug in read_obs.F90 missing N21 for EARS and DBnet

### DIFF
--- a/src/gsi/read_obs.F90
+++ b/src/gsi/read_obs.F90
@@ -1065,7 +1065,7 @@ subroutine read_obs(ndata,mype)
                    obstype == 'iasi'  .or. obstype == 'atms') .and. &
                   (dplat(i) == 'n17' .or. dplat(i) == 'n18' .or. & 
                    dplat(i) == 'n19' .or. dplat(i) == 'npp' .or. &
-                   dplat(i) == 'n20' .or. &
+                   dplat(i) == 'n20' .or. dplat(i) == 'n21' .or. &
                    dplat(i) == 'metop-a' .or. dplat(i) == 'metop-b' .or. &
                    dplat(i) == 'metop-c') 
 ! direct broadcast from NESDIS/UW
@@ -1076,7 +1076,7 @@ subroutine read_obs(ndata,mype)
                    obstype == 'iasi') .and. &
                   (dplat(i) == 'n17' .or. dplat(i) == 'n18' .or. & 
                    dplat(i) == 'n19' .or. dplat(i) == 'npp' .or. &
-                   dplat(i) == 'n20' .or. &
+                   dplat(i) == 'n20' .or. dplat(i) == 'n21' .or. &
                    dplat(i) == 'metop-a' .or. dplat(i) == 'metop-b' .or. &
                    dplat(i) == 'metop-c') 
 


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

This PR is to fix a bug in read_obs.F90 missing N21 for EARS and DBnet.

Fixes #506

**Type of change**

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
This fix has been tested in RRFS retrospective and RRFS-B real-time runs. 
  
**Checklist**

- [ x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

**DUE DATE for this PR is 11/8/2023.** If this PR is not merged into `develop` by this date, the PR will be closed and returned to the developer.