### PR TITLE
A bug fix in setupps

### DIFF
--- a/src/gsi/gsi_rfv3io_mod.f90
+++ b/src/gsi/gsi_rfv3io_mod.f90
@@ -2610,9 +2610,6 @@ subroutine gsi_fv3ncdf_readuv(grd_uv,ges_u,ges_v,fv3filenamegin)
        members(mm1) = mype
     endif
 
-    write(6,115)mype,kbgn,kend,procuse
-115 format('gsi_fv3ncdf_readuv: mype ',i6,' has kbgn,kend= ',2(i6,1x),' set procuse ',l7)
-
     call mpi_allreduce(members,members_read,npe,mpi_integer,mpi_max,mpi_comm_world,ierror)
 
     nread=0

--- a/src/gsi/setupps.f90
+++ b/src/gsi/setupps.f90
@@ -904,7 +904,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
            if(muse(i)) then
               call nc_diag_metadata("Analysis_Use_Flag",    1.0_r_single           )
            else
-              call nc_diag_metadata("Analysis_Use_Flag",    1.0_r_single           )
+              call nc_diag_metadata("Analysis_Use_Flag",   -1.0_r_single           )
            endif
 
            call nc_diag_metadata_to_single("Errinv_Input",  errinv_input           )

--- a/src/gsi/setupspd.f90
+++ b/src/gsi/setupspd.f90
@@ -962,7 +962,7 @@ subroutine setupspd(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
            if(muse(i)) then
               call nc_diag_metadata("Analysis_Use_Flag",    1.0_r_single           )
            else
-              call nc_diag_metadata("Analysis_Use_Flag",    1.0_r_single           )
+              call nc_diag_metadata("Analysis_Use_Flag",   -1.0_r_single           )
            endif
 
            call nc_diag_metadata_to_single("Errinv_Input",errinv_input       )


### PR DESCRIPTION
A bug is found in setupps: un-used ps obs is also marked as 1.
Remove a print statement in rfv3io to simply stdout.

This is PR fixes #637 

**Type of change**
- [ x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
Tested in RRFS retro.

**Checklist**
- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code