### PR TITLE
Release/gfsda.v16

### DIFF
--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -913,6 +913,7 @@ OBS_INPUT::
    ahibufr        ahi         himawari8   ahi_himawari8       0.0     1     0
    abibufr        abi         g16         abi_g16             0.0     1     0
    abibufr        abi         g17         abi_g17             0.0     1     0
+   abibufr        abi         g18         abi_g18             0.0     1     0
    rapidscatbufr  uv          null        uv                  0.0     0     0
    ompsnpbufr     ompsnp      npp         ompsnp_npp          0.0     0     0
    ompslpbufr     ompslp      npp         ompslp_npp          0.0     0     0
@@ -926,6 +927,8 @@ OBS_INPUT::
    sstviirs       viirs-m     j1          viirs-m_j1          0.0     4     0
    ahibufr        ahi         himawari9   ahi_himawari9       0.0     1     0
    sstviirs       viirs-m     j2          viirs-m_j2          0.0     4     0
+   atmsbufr21     atms        n21         atms_n21            0.0     1     0
+   crisfsbufr21   cris-fsr    n21         cris-fsr_n21        0.0     1     0
    ompsnpbufr     ompsnp      n21         ompsnp_n21          0.0     0     0
    ompstcbufr     ompstc8     n21         ompstc8_n21         0.0     2     0
    gomebufr       gome        metop-c     gome_metop-c        0.0     2     0

--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -489,18 +489,13 @@ $NLN $OSCATBF          oscatbufr
 $NLN $RAPIDSCATBF      rapidscatbufr
 $NLN $GSNDBF           gsndrbufr
 $NLN $GSNDBF1          gsnd1bufr
-$NLN $B1HRS2           hirs2bufr
 $NLN $B1MSU            msubufr
-$NLN $B1HRS3           hirs3bufr
-$NLN $B1HRS4           hirs4bufr
 $NLN $B1AMUA           amsuabufr
 $NLN $B1AMUB           amsubbufr
 $NLN $B1MHS            mhsbufr
-$NLN $ESHRS3           hirs3bufrears
 $NLN $ESAMUA           amsuabufrears
 $NLN $ESAMUB           amsubbufrears
 #$NLN $ESMHS            mhsbufrears
-$NLN $HRS3DB           hirs3bufr_db
 $NLN $AMUADB           amsuabufr_db
 $NLN $AMUBDB           amsubbufr_db
 #$NLN $MHSDB            mhsbufr_db
@@ -839,8 +834,6 @@ OBS_INPUT::
    sbuvbufr       sbuv2       n16         sbuv8_n16           0.0     0     0
    sbuvbufr       sbuv2       n17         sbuv8_n17           0.0     0     0
    sbuvbufr       sbuv2       n18         sbuv8_n18           0.0     0     0
-   hirs3bufr      hirs3       n17         hirs3_n17           0.0     1     0
-   hirs4bufr      hirs4       metop-a     hirs4_metop-a       0.0     1     1
    gimgrbufr      goes_img    g11         imgr_g11            0.0     1     0
    gimgrbufr      goes_img    g12         imgr_g12            0.0     1     0
    airsbufr       airs        aqua        airs_aqua           0.0     1     1
@@ -874,7 +867,6 @@ OBS_INPUT::
    gomebufr       gome        metop-a     gome_metop-a        0.0     2     0
    omibufr        omi         aura        omi_aura            0.0     2     0
    sbuvbufr       sbuv2       n19         sbuv8_n19           0.0     0     0
-   hirs4bufr      hirs4       n19         hirs4_n19           0.0     1     1
    amsuabufr      amsua       n19         amsua_n19           0.0     1     1
    mhsbufr        mhs         n19         mhs_n19             0.0     1     1
    tcvitl         tcp         null        tcp                 0.0     0     0
@@ -882,7 +874,6 @@ OBS_INPUT::
    seviribufr     seviri      m09         seviri_m09          0.0     1     0
    seviribufr     seviri      m10         seviri_m10          0.0     1     0
    seviribufr     seviri      m11         seviri_m11          0.0     1     0
-   hirs4bufr      hirs4       metop-b     hirs4_metop-b       0.0     1     1
    amsuabufr      amsua       metop-b     amsua_metop-b       0.0     1     1
    mhsbufr        mhs         metop-b     mhs_metop-b         0.0     1     1
    iasibufr       iasi        metop-b     iasi_metop-b        0.0     1     1

--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -918,8 +918,8 @@ OBS_INPUT::
    sstviirs       viirs-m     j1          viirs-m_j1          0.0     4     0
    ahibufr        ahi         himawari9   ahi_himawari9       0.0     1     0
    sstviirs       viirs-m     j2          viirs-m_j2          0.0     4     0
-   atmsbufr21     atms        n21         atms_n21            0.0     1     0
-   crisfsbufr21   cris-fsr    n21         cris-fsr_n21        0.0     1     0
+   atmsbufr       atms        n21         atms_n21            0.0     1     0
+   crisfsbufr     cris-fsr    n21         cris-fsr_n21        0.0     1     0
    ompsnpbufr     ompsnp      n21         ompsnp_n21          0.0     0     0
    ompstcbufr     ompstc8     n21         ompstc8_n21         0.0     2     0
    gomebufr       gome        metop-c     gome_metop-c        0.0     2     0


### PR DESCRIPTION
This PR fixes a typo in the exglobal_atmos_analysis.sh script.  NOAA-21 ATMS and CrIS were pointing to a temporary bufr files that is not present now that the data are operationally dumped.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

The revised script as been tested in a single cycle and the results are as expected.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published