### PR TITLE
GitHub Issue NOAA-EMC/GSI#658 Issues of undefined values and thread safety in intrad.f90

### DIFF
--- a/src/gsi/intrad.f90
+++ b/src/gsi/intrad.f90
@@ -444,7 +444,8 @@ subroutine intrad_(radhead,rval,sval,rpred,spred)
         i4n(k) = i4n(k-1)+latlon11
      enddo
 
-!$omp parallel do schedule(dynamic,1) private(k,i1,i2,i3,i4,mm)
+     tdir=zero
+!$omp parallel do schedule(dynamic,1) private(k,i1,i2,i3,i4)
      do k=1,nsig
         i1 = i1n(k)
         i2 = i2n(k)
@@ -525,7 +526,7 @@ subroutine intrad_(radhead,rval,sval,rpred,spred)
         end do
      end if
 
-!$omp parallel do schedule(dynamic,1) private(nn,k,ncr1)
+!$omp parallel do schedule(dynamic,1) private(nn,k,ncr1,val_quad,mm)
      do nn=1,radptr%nchan
 
 !       include observation increment and lapse rate contributions to bias correction


### PR DESCRIPTION
**Description**

This PR fixes the following issues of undefined values and thread safety found in intrad.f90.
- tdir(1:nsigradjac) is undefined for variables except for (tsen,q,oz,cw,ql,qi,qh,qg,qr,qs,u,v,sst). (e.g., w: vertical velocity)
- val_quad and mm that should be private variables of OpenMP are shared variables.

Fixes #658

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

EnVar tests with the RRFS setting (Radar reflectivity is simultaneously assimilated with the other observations using SDL/VDL) were done on Orion. This fix didn't change the result.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published