### PR TITLE
Add activation of Himawari-9 to the implementation branch (for the gfsda.v16.3.12 tag)

### DIFF
--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -913,6 +913,7 @@ OBS_INPUT::
    ahibufr        ahi         himawari8   ahi_himawari8       0.0     1     0
    abibufr        abi         g16         abi_g16             0.0     1     0
    abibufr        abi         g17         abi_g17             0.0     1     0
+   abibufr        abi         g18         abi_g18             0.0     1     0
    rapidscatbufr  uv          null        uv                  0.0     0     0
    ompsnpbufr     ompsnp      npp         ompsnp_npp          0.0     0     0
    ompslpbufr     ompslp      npp         ompslp_npp          0.0     0     0
@@ -926,6 +927,8 @@ OBS_INPUT::
    sstviirs       viirs-m     j1          viirs-m_j1          0.0     4     0
    ahibufr        ahi         himawari9   ahi_himawari9       0.0     1     0
    sstviirs       viirs-m     j2          viirs-m_j2          0.0     4     0
+   atmsbufr21     atms        n21         atms_n21            0.0     1     0
+   crisfsbufr21   cris-fsr    n21         cris-fsr_n21        0.0     1     0
    ompsnpbufr     ompsnp      n21         ompsnp_n21          0.0     0     0
    ompstcbufr     ompstc8     n21         ompstc8_n21         0.0     2     0
    gomebufr       gome        metop-c     gome_metop-c        0.0     2     0

--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -489,18 +489,13 @@ $NLN $OSCATBF          oscatbufr
 $NLN $RAPIDSCATBF      rapidscatbufr
 $NLN $GSNDBF           gsndrbufr
 $NLN $GSNDBF1          gsnd1bufr
-$NLN $B1HRS2           hirs2bufr
 $NLN $B1MSU            msubufr
-$NLN $B1HRS3           hirs3bufr
-$NLN $B1HRS4           hirs4bufr
 $NLN $B1AMUA           amsuabufr
 $NLN $B1AMUB           amsubbufr
 $NLN $B1MHS            mhsbufr
-$NLN $ESHRS3           hirs3bufrears
 $NLN $ESAMUA           amsuabufrears
 $NLN $ESAMUB           amsubbufrears
 #$NLN $ESMHS            mhsbufrears
-$NLN $HRS3DB           hirs3bufr_db
 $NLN $AMUADB           amsuabufr_db
 $NLN $AMUBDB           amsubbufr_db
 #$NLN $MHSDB            mhsbufr_db
@@ -839,8 +834,6 @@ OBS_INPUT::
    sbuvbufr       sbuv2       n16         sbuv8_n16           0.0     0     0
    sbuvbufr       sbuv2       n17         sbuv8_n17           0.0     0     0
    sbuvbufr       sbuv2       n18         sbuv8_n18           0.0     0     0
-   hirs3bufr      hirs3       n17         hirs3_n17           0.0     1     0
-   hirs4bufr      hirs4       metop-a     hirs4_metop-a       0.0     1     1
    gimgrbufr      goes_img    g11         imgr_g11            0.0     1     0
    gimgrbufr      goes_img    g12         imgr_g12            0.0     1     0
    airsbufr       airs        aqua        airs_aqua           0.0     1     1
@@ -874,7 +867,6 @@ OBS_INPUT::
    gomebufr       gome        metop-a     gome_metop-a        0.0     2     0
    omibufr        omi         aura        omi_aura            0.0     2     0
    sbuvbufr       sbuv2       n19         sbuv8_n19           0.0     0     0
-   hirs4bufr      hirs4       n19         hirs4_n19           0.0     1     1
    amsuabufr      amsua       n19         amsua_n19           0.0     1     1
    mhsbufr        mhs         n19         mhs_n19             0.0     1     1
    tcvitl         tcp         null        tcp                 0.0     0     0
@@ -882,7 +874,6 @@ OBS_INPUT::
    seviribufr     seviri      m09         seviri_m09          0.0     1     0
    seviribufr     seviri      m10         seviri_m10          0.0     1     0
    seviribufr     seviri      m11         seviri_m11          0.0     1     0
-   hirs4bufr      hirs4       metop-b     hirs4_metop-b       0.0     1     1
    amsuabufr      amsua       metop-b     amsua_metop-b       0.0     1     1
    mhsbufr        mhs         metop-b     mhs_metop-b         0.0     1     1
    iasibufr       iasi        metop-b     iasi_metop-b        0.0     1     1

--- a/scripts/exglobal_atmos_analysis.sh
+++ b/scripts/exglobal_atmos_analysis.sh
@@ -918,8 +918,8 @@ OBS_INPUT::
    sstviirs       viirs-m     j1          viirs-m_j1          0.0     4     0
    ahibufr        ahi         himawari9   ahi_himawari9       0.0     1     0
    sstviirs       viirs-m     j2          viirs-m_j2          0.0     4     0
-   atmsbufr21     atms        n21         atms_n21            0.0     1     0
-   crisfsbufr21   cris-fsr    n21         cris-fsr_n21        0.0     1     0
+   atmsbufr       atms        n21         atms_n21            0.0     1     0
+   crisfsbufr     cris-fsr    n21         cris-fsr_n21        0.0     1     0
    ompsnpbufr     ompsnp      n21         ompsnp_n21          0.0     0     0
    ompstcbufr     ompstc8     n21         ompstc8_n21         0.0     2     0
    gomebufr       gome        metop-c     gome_metop-c        0.0     2     0

--- a/src/gsi/read_nsstbufr.f90
+++ b/src/gsi/read_nsstbufr.f90
@@ -97,7 +97,6 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
   integer(i_kind):: idomsfc,isflg
 
   integer(i_kind) :: ireadmg,ireadsb,klev,msub,nmsub
-  integer(i_kind) :: SST_qcmark, AirT_qcmark
   integer(i_kind), dimension(5) :: idate5
   character(len=8)  :: subset
   character(len=8)  :: crpid
@@ -316,11 +315,9 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
            cycle read_loop
         endif
 
-          call ufbint(lunin,loc,4,1,iret,'CLAT CLATH CLON CLONH,QMST,QMAT')
+          call ufbint(lunin,loc,4,1,iret,'CLAT CLATH CLON CLONH')
           clath=loc(1) ; if ( ibfms(loc(2)).eq.0 ) clath=loc(2)
           clonh=loc(3) ; if ( ibfms(loc(4)).eq.0 ) clonh=loc(4)
-          SST_qcmark = nint(loc(5))
-          AirT_qcmark = nint(loc(6))
 
         nread = nread + 1
 
@@ -593,8 +590,6 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
 !             (kx<180 .or. kx>289 .or. (kx>202 .and. kx<280)) ) cycle read_loop
 
            usage = zero
-!          As the SST qcmark is not being set by SDMEdit, use QMAT (air temperature) as a proxy.
-           if ( SST_qcmark > 3 .OR. AirT_qcmark > 3 ) usage = 120.0_r_kind  
            if (   icuse(ikx) < 0 ) usage = 100.0_r_kind
            if ( ncnumgrp(ikx) > 0 ) then                                ! cross validation on
               if (mod(ndata+1,ncnumgrp(ikx))== ncgroup(ikx)-1) usage=ncmiter(ikx)

--- a/src/gsi/read_nsstbufr.f90
+++ b/src/gsi/read_nsstbufr.f90
@@ -97,6 +97,7 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
   integer(i_kind):: idomsfc,isflg
 
   integer(i_kind) :: ireadmg,ireadsb,klev,msub,nmsub
+  integer(i_kind) :: SST_qcmark, AirT_qcmark
   integer(i_kind), dimension(5) :: idate5
   character(len=8)  :: subset
   character(len=8)  :: crpid
@@ -315,9 +316,11 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
            cycle read_loop
         endif
 
-          call ufbint(lunin,loc,4,1,iret,'CLAT CLATH CLON CLONH')
+          call ufbint(lunin,loc,4,1,iret,'CLAT CLATH CLON CLONH,QMST,QMAT')
           clath=loc(1) ; if ( ibfms(loc(2)).eq.0 ) clath=loc(2)
           clonh=loc(3) ; if ( ibfms(loc(4)).eq.0 ) clonh=loc(4)
+          SST_qcmark = nint(loc(5))
+          AirT_qcmark = nint(loc(6))
 
         nread = nread + 1
 
@@ -590,6 +593,8 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
 !             (kx<180 .or. kx>289 .or. (kx>202 .and. kx<280)) ) cycle read_loop
 
            usage = zero
+!          As the SST qcmark is not being set by SDMEdit, use QMAT (air temperature) as a proxy.
+           if ( SST_qcmark > 3 .OR. AirT_qcmark > 3 ) usage = 120.0_r_kind  
            if (   icuse(ikx) < 0 ) usage = 100.0_r_kind
            if ( ncnumgrp(ikx) > 0 ) then                                ! cross validation on
               if (mod(ndata+1,ncnumgrp(ikx))== ncgroup(ikx)-1) usage=ncmiter(ikx)


### PR DESCRIPTION
@HaixiaLiu-NOAA pointed out the the changes to the fix files in #660 did not include Himawari-9.  This PR turns on channels 8 and 9 of Himawari-9 in Release/gfsda.v16.

Changes are to the fix file only.

To inspect the changes you will need to:
```
git clone --recursive https://github.com/ADCollard/GSI.git GSI_ACollard
cd GSI_ACollard
git checkout release/gfsda.v16
git submodule sync
git submodule update
cd fix
```
Checklist

My code follows the style guidelines of this project
I have performed a self-review of my own code
I have commented my code, particularly in hard-to-understand areas
New and existing tests pass with my changes
Any dependent changes have been merged and published