### PR TITLE
restore the line to initialize  'raterr2' as zero

### DIFF
--- a/src/gsi/setuprad.f90
+++ b/src/gsi/setuprad.f90
@@ -1801,6 +1801,7 @@ contains
         diagadd=zero
         account_for_corr_obs = .false.
         varinv0=zero
+        raterr2 = zero
 !$omp parallel do  schedule(dynamic,1) private(ii,m,k,asum)
         do ii=1,nchanl
            m=ich(ii)


### PR DESCRIPTION
This PR is to fix the issue #648 

Fixes #648

**DUE DATE for merger of this PR into `develop` is 6/29/2023 (six weeks after PR creation).**