### PR TITLE
Output the dry-bulb air temperature in the observation diagnostic file of conventional Q obs (for 3D RTMA run only)

### DIFF
--- a/src/gsi/setupq.f90
+++ b/src/gsi/setupq.f90
@@ -1238,7 +1238,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         rdiagbuf(21,ii) = 1e+10_r_single     ! spread (filled in by EnKF)
 
         if ( l_rtma3d ) then
-          rdiagbuf(ioff0,ii) = data(itemp,i) ! dry temperature accompanied with qob
+          rdiagbuf(22,ii) = data(itemp,i)    ! dry temperature accompanied with qob
         end if
 
         ioff=ioff0
@@ -1319,7 +1319,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         rdiagbufp(21,iip) = 1e+10_r_single     ! spread (filled in by EnKF)
 
         if ( l_rtma3d ) then
-          rdiagbufp(ioff0,ii) = data(itemp,i)  ! dry temperature accompanied with qob
+          rdiagbufp(22,ii) = data(itemp,i)     ! dry temperature accompanied with qob
         end if
 
         ioff=ioff0

--- a/src/gsi/setupq.f90
+++ b/src/gsi/setupq.f90
@@ -1400,7 +1400,9 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata_to_single("Obs_Minus_Forecast_adjusted",ddiff     )
            call nc_diag_metadata_to_single("Obs_Minus_Forecast_unadjusted",qob,qges,'-')
            call nc_diag_metadata_to_single("Forecast_Saturation_Spec_Hum",qsges    )
-           call nc_diag_metadata_to_single("Observation_Tdry", data(itemp,i)       )
+           if ( l_rtma3d ) then
+              call nc_diag_metadata_to_single("Observation_Tdry", data(itemp,i)    )
+           endif
            if (lobsdiagsave) then
               do jj=1,miter
                  if (odiag%muse(jj)) then
@@ -1465,7 +1467,9 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata_to_single("Obs_Minus_Forecast_adjusted",ddiff     )
            call nc_diag_metadata_to_single("Obs_Minus_Forecast_unadjusted",ddiff   )
            call nc_diag_metadata_to_single("Forecast_Saturation_Spec_Hum",qsges    )
-           call nc_diag_metadata_to_single("Observation_Tdry", data(itemp,i)       )
+           if ( l_rtma3d ) then
+              call nc_diag_metadata_to_single("Observation_Tdry", data(itemp,i)    )
+           endif
 !----
            if (lobsdiagsave) then
               do jj=1,miter


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

- Motivation:
In the Auto-QC utility of 3D-RTMA, the dry-bulb air temperature (hereafter as T_dry) which is accompanied with moisture observation is required in the procedure of the quality control for conventional moisture observations (Q obs). Since this auto-qc of 3DRTMA retrieves many information from the observation diagnostic files (output of GSI run), it should be convenient for the sake of auto-qc of Q obs, if the required T_dry could be output into the observation diagnostics file of Q obs in the GSI run.  

- Modifications to the code:
all the modifications are in source code **setupq.f90**:
add line to use l_rtma3d from module rapidrefresh_cldsurf_mod (l_rtma3d is used to control the output of T_dry for 3DRTMA only)
variable nreal (the length of obs diag information record for each obs) needs to be increased by 1 (when running GSI for 3DRTMA)
in subroutine contents_binary_diag_, add line to put tdry, ie. data(itemp, i), into the array rdiagbuff(22,ii)  (for binary format obsdaig file)
in subroutine contents_netcdf_diag_, add line to put tdry, ie. data(itemp,i),  into new metadata variable "Observation_Tdry" (for netcdf format obsdiag file)

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->
This PR is to address the issue #666 : Adding the (calculated) dry-bulb temperature in the observation diagnostic file for conventional Q obs (only for 3D RTMA)
Fixes #666
 
**Type of change**

Please delete options that are not relevant.

- [*] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- [*] Regression Test of GSI

      1. The modified GSI code passed the regression test of GSI on WCOSS2 and Hera. Here is a brief report of the ctest run on WCOSS2:
```
[gang.zhao@dlogin04:build] (feature/tdry_in_qob_diag_rtma)$ ctest -j 7
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_glbens
    Start 4: netcdf_fv3_regional
    Start 5: hafs_4denvar_glbens
    Start 6: hafs_3denvar_hybens
    Start 7: global_enkf
1/7 Test #4: netcdf_fv3_regional ..............   Passed  482.61 sec
2/7 Test #3: rrfs_3denvar_glbens ..............   Passed  484.60 sec
3/7 Test #7: global_enkf ......................   Passed  608.63 sec
4/7 Test #2: rtma .............................   Passed  968.86 sec
5/7 Test #6: hafs_3denvar_hybens ..............   Passed  1210.33 sec
6/7 Test #5: hafs_4denvar_glbens ..............   Passed  1211.54 sec
7/7 Test #1: global_4denvar ...................   Passed  1382.51 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) = 1382.51 sec

```
     2. Here is the report of regression test on Hera:
```
[Gang.Zhao@hfe01:build] (feature/tdry_in_qob_diag_rtma)$ ctest -j 7
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_glbens
    Start 4: netcdf_fv3_regional
    Start 5: hafs_4denvar_glbens
    Start 6: hafs_3denvar_hybens
    Start 7: global_enkf
1/7 Test #3: rrfs_3denvar_glbens ..............   Passed  1336.88 sec
2/7 Test #7: global_enkf ......................***Failed  1613.55 sec
3/7 Test #6: hafs_3denvar_hybens ..............   Passed  1945.07 sec
4/7 Test #4: netcdf_fv3_regional ..............   Passed  2055.12 sec
5/7 Test #5: hafs_4denvar_glbens ..............   Passed  2126.84 sec
6/7 Test #1: global_4denvar ...................   Passed  2163.53 sec
7/7 Test #2: rtma .............................   Passed  4660.88 sec

86% tests passed, 1 tests failed out of 7

Total Test time (real) = 4660.90 sec

The following tests FAILED:
          7 - global_enkf (Failed)
Errors while running CTest

[Gang.Zhao@hfe01:build] (feature/tdry_in_qob_diag_rtma)$ ctest -R global_enkf
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
    Start 7: global_enkf
1/1 Test #7: global_enkf ......................   Passed  1119.86 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) = 1119.88 sec

```

- [*] The modified GSI code has been tested with an analysis case on Hera (for RRFS-based 3DRTMA case 2022-10-08_12Z)
       In the observation diagnostic file for q-obs generated by GSI, T_dry was added for each record of Q obs in binary format diagnostic file; and in netcdf-4 format diagnostic file, a new metadata variable "Observation_Tdry" was added in the metadata group. The other variables in obsdiag file generated by modified code are still as same as in the obsdiag file from original GSI code. It indicates that the modification does not affect the other variables in the obsdiag files. And in the test run with l_rtma3d=.false. (this is the GSI run not for 3D RTMA), then in the obsdiag file for Q obs, there is no Tdry neither in binary format nor in netcdf-4 format, this is also as expected that this modifications should have no influence for other GSI applications.
  
**Checklist**

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] New and existing tests pass with my changes
- [*] Any dependent changes have been merged and published

**DUE DATE for merger of this PR into `develop` is 6/29/2023 (six weeks after PR creation).**