### PR TITLE
Remove HIRS from GSI regression tests

### DIFF
--- a/regression/global_4denvar.sh
+++ b/regression/global_4denvar.sh
@@ -230,17 +230,11 @@ $nln $datobs/${prefix_obs}.ompst8.${suffix}        ./ompstcbufr
 $nln $datobs/${prefix_obs}.ompslp.${suffix}        ./ompslpbufr
 
 $nln $datobs/${prefix_obs}.goesfv.${suffix}        ./gsnd1bufr
-$nln $datobs/${prefix_obs}.hrs3db.${suffix}        ./hirs3bufr_db
 $nln $datobs/${prefix_obs}.airsev.${suffix}        ./airsbufr
 $nln $datobs/${prefix_obs}.sevcsr.${suffix}        ./seviribufr
 $nln $datobs/${prefix_obs}.saphir.${suffix}        ./saphirbufr
 $nln $datobs/${prefix_obs}.avcsam.${suffix}        ./avhambufr
 $nln $datobs/${prefix_obs}.avcspm.${suffix}        ./avhpmbufr
-$nln $datobs/${prefix_obs}.1bhrs4.${suffix}        ./hirs4bufr
-$nln $datobs/${prefix_obs}.1bhrs2.${suffix}        ./hirs2bufr
-$nln $datobs/${prefix_obs}.1bhrs3.${suffix}        ./hirs3bufr
-$nln $datobs/${prefix_obs}.eshrs3.${suffix}        ./hirs3bufrears
-$nln $datobs/${prefix_obs}.hrs3db.${suffix}        ./hirs3bufr_db
 $nln $datobs/${prefix_obs}.mtiasi.${suffix}        ./iasibufr
 $nln $datobs/${prefix_obs}.esiasi.${suffix}        ./iasibufrears
 $nln $datobs/${prefix_obs}.iasidb.${suffix}        ./iasibufr_db

--- a/regression/hafs_3denvar_hybens.sh
+++ b/regression/hafs_3denvar_hybens.sh
@@ -278,13 +278,9 @@ fi
 ln -sf $SATWND           satwndbufr
 ln -sf $SATWHR           satwhrbufr
 ln -sf $GSNDBF1          gsnd1bufr
-ln -sf $B1HRS3           hirs3bufr
-ln -sf $B1HRS4           hirs4bufr
 ln -sf $B1AMUA           amsuabufr
 ln -sf $B1MHS            mhsbufr
-ln -sf $ESHRS3           hirs3bufrears
 ln -sf $ESAMUA           amsuabufrears
-ln -sf $HRS3DB           hirs3bufr_db
 ln -sf $SBUVBF           sbuvbufr
 ln -sf $OMPSNPBF         ompsnpbufr
 ln -sf $OMPSTCBF         ompstcbufr

--- a/regression/hafs_4denvar_glbens.sh
+++ b/regression/hafs_4denvar_glbens.sh
@@ -278,13 +278,9 @@ fi
 ln -sf $SATWND           satwndbufr
 ln -sf $SATWHR           satwhrbufr
 ln -sf $GSNDBF1          gsnd1bufr
-ln -sf $B1HRS3           hirs3bufr
-ln -sf $B1HRS4           hirs4bufr
 ln -sf $B1AMUA           amsuabufr
 ln -sf $B1MHS            mhsbufr
-ln -sf $ESHRS3           hirs3bufrears
 ln -sf $ESAMUA           amsuabufrears
-ln -sf $HRS3DB           hirs3bufr_db
 ln -sf $SBUVBF           sbuvbufr
 ln -sf $OMPSNPBF         ompsnpbufr
 ln -sf $OMPSTCBF         ompstcbufr

--- a/regression/netcdf_fv3_regional.sh
+++ b/regression/netcdf_fv3_regional.sh
@@ -171,7 +171,6 @@ cp $fv3_netcdf_obs/ndas.t06z.radwnd.tm06.bufr_d   ./radarbufr
 cp $fv3_netcdf_obs/ndas.t06z.prepbufr.tm06        ./prepbufr
 cp $fv3_netcdf_obs/ndas.t06z.1bamua.tm06.bufr_d   ./amsuabufr
 cp $fv3_netcdf_obs/ndas.t06z.1bmhs.tm06.bufr_d    ./mhsbufr
-cp $fv3_netcdf_obs/ndas.t06z.1bhrs4.tm06.bufr_d   ./hirs4bufr
 cp $fv3_netcdf_obs/ndas.t06z.goesfv.tm06.bufr_d   ./gsnd1bufr
 cp $fv3_netcdf_obs/ndas.t06z.airsev.tm06.bufr_d   ./airsbufr
 cp $fv3_netcdf_obs/ndas.t06z.satwnd.tm06.bufr_d   ./satwndbufr

--- a/regression/regression_namelists.sh
+++ b/regression/regression_namelists.sh
@@ -98,8 +98,6 @@ OBS_INPUT::
    sbuvbufr       sbuv2       n16         sbuv8_n16           0.0     0     0
    sbuvbufr       sbuv2       n17         sbuv8_n17           0.0     0     0
    sbuvbufr       sbuv2       n18         sbuv8_n18           0.0     0     0
-   hirs3bufr      hirs3       n17         hirs3_n17           0.0     1     0
-   hirs4bufr      hirs4       metop-a     hirs4_metop-a       0.0     1     1
    gimgrbufr      goes_img    g11         imgr_g11            0.0     1     0
    gimgrbufr      goes_img    g12         imgr_g12            0.0     1     0
    airsbufr       airs        aqua        airs_aqua           0.0     1     1
@@ -133,7 +131,6 @@ OBS_INPUT::
    gomebufr       gome        metop-a     gome_metop-a        0.0     2     0
    omibufr        omi         aura        omi_aura            0.0     2     0
    sbuvbufr       sbuv2       n19         sbuv8_n19           0.0     0     0
-   hirs4bufr      hirs4       n19         hirs4_n19           0.0     1     1
    amsuabufr      amsua       n19         amsua_n19           0.0     1     1
    mhsbufr        mhs         n19         mhs_n19             0.0     1     1
    tcvitl         tcp         null        tcp                 0.0     0     0
@@ -141,7 +138,6 @@ OBS_INPUT::
    seviribufr     seviri      m09         seviri_m09          0.0     1     0
    seviribufr     seviri      m10         seviri_m10          0.0     1     0
    seviribufr     seviri      m11         seviri_m11          0.0     1     0
-   hirs4bufr      hirs4       metop-b     hirs4_metop-b       0.0     1     1
    amsuabufr      amsua       metop-b     amsua_metop-b       0.0     1     1
    mhsbufr        mhs         metop-b     mhs_metop-b         0.0     1     1
    iasibufr       iasi        metop-b     iasi_metop-b        0.0     1     1
@@ -391,12 +387,6 @@ OBS_INPUT::
    sbuvbufr       sbuv2       n16       sbuv8_n16            0.0     0     0
    sbuvbufr       sbuv2       n17       sbuv8_n17            0.0     0     0
    sbuvbufr       sbuv2       n18       sbuv8_n18            0.0     0     0
-   hirs3bufr      hirs3       n16       hirs3_n16            0.0     1     0
-   hirs3bufr      hirs3       n17       hirs3_n17            0.0     1     0
-   hirs4bufr      hirs4       metop-a   hirs4_metop-a        0.0     2     0
-   hirs4bufr      hirs4       n18       hirs4_n18            0.0     1     0
-   hirs4bufr      hirs4       n19       hirs4_n19            0.0     2     0
-   hirs4bufr      hirs4       metop-b   hirs4_metop-b        0.0     2     0
    gimgrbufr      goes_img    g11       imgr_g11             0.0     1     0
    gimgrbufr      goes_img    g12       imgr_g12             0.0     1     0
    airsbufr       airs        aqua      airs_aqua            0.0     2     0
@@ -627,8 +617,6 @@ OBS_INPUT::
    sbuvbufr       sbuv2       n16         sbuv8_n16           0.0     0     0
    sbuvbufr       sbuv2       n17         sbuv8_n17           0.0     0     0
    sbuvbufr       sbuv2       n18         sbuv8_n18           0.0     0     0
-   hirs3bufr      hirs3       n17         hirs3_n17           0.0     1     0
-   hirs4bufr      hirs4       metop-a     hirs4_metop-a       0.0     1     1
    gimgrbufr      goes_img    g11         imgr_g11            0.0     1     0
    gimgrbufr      goes_img    g12         imgr_g12            0.0     1     0
    airsbufr       airs        aqua        airs_aqua           0.0     1     1
@@ -663,13 +651,11 @@ OBS_INPUT::
    gomebufr       gome        metop-a     gome_metop-a        0.0     2     0
    omibufr        omi         aura        omi_aura            0.0     2     0
    sbuvbufr       sbuv2       n19         sbuv8_n19           0.0     0     0
-   hirs4bufr      hirs4       n19         hirs4_n19           0.0     1     1
    amsuabufr      amsua       n19         amsua_n19           0.0     2     1
    mhsbufr        mhs         n19         mhs_n19             0.0     3     1
    seviribufr     seviri      m08         seviri_m08          0.0     1     0
    seviribufr     seviri      m09         seviri_m09          0.0     1     0
    seviribufr     seviri      m10         seviri_m10          0.0     1     0
-   hirs4bufr      hirs4       metop-b     hirs4_metop-b       0.0     1     0
    amsuabufr      amsua       metop-b     amsua_metop-b       0.0     2     0
    mhsbufr        mhs         metop-b     mhs_metop-b         0.0     3     0
    iasibufr       iasi        metop-b     iasi_metop-b        0.0     1     0
@@ -846,12 +832,6 @@ OBS_INPUT::
    sbuvbufr       sbuv2       n16         sbuv8_n16             0.0      0      0
    sbuvbufr       sbuv2       n17         sbuv8_n17             0.0      0      0
    sbuvbufr       sbuv2       n18         sbuv8_n18             0.0      0      0
-   hirs2bufr      hirs2       n14         hirs2_n14             0.0      1      0
-   hirs3bufr      hirs3       n16         hirs3_n16             0.0      1      0
-   hirs3bufr      hirs3       n17         hirs3_n17             0.0      1      0
-   hirs4bufr      hirs4       n18         hirs4_n18             0.0      1      0
-   hirs4bufr      hirs4       metop-a     hirs4_metop-a         0.0      1      0
-   hirs4bufr      hirs4       metop-b     hirs4_metop-b         0.0      1      0
    gsndrbufr      sndr        g11         sndr_g11              0.0      1      0
    gsndrbufr      sndr        g12         sndr_g12              0.0      1      0
    gimgrbufr      goes_img    g11         imgr_g11              0.0      1      0
@@ -883,7 +863,6 @@ OBS_INPUT::
    iasibufr       iasi        metop-b     iasi_metop-b          0.0      1      0
    omibufr        omi         aura        omi_aura              0.0      1      0
    sbuvbufr       sbuv2       n19         sbuv8_n19             0.0      1      0
-   hirs4bufr      hirs4       n19         hirs4_n19             0.0      1      0
    amsuabufr      amsua       n19         amsua_n19             0.0      1      0
    mhsbufr        mhs         n19         mhs_n19               0.0      1      0
    tcvitl         tcp         null        tcp                   0.0      0      0

--- a/regression/regression_namelists_db.sh
+++ b/regression/regression_namelists_db.sh
@@ -90,8 +90,6 @@ OBS_INPUT::
    sbuvbufr_      sbuv2       n16         sbuv8_n16           0.0     0     0
    sbuvbufr_      sbuv2       n17         sbuv8_n17           0.0     0     0
    sbuvbufr_      sbuv2       n18         sbuv8_n18           0.0     0     0
-   hirs3bufr_     hirs3       n17         hirs3_n17           0.0     1     0
-   hirs4bufr_skip hirs4       metop-a     hirs4_metop-a       0.0     1     1
    gimgrbufr_     goes_img    g11         imgr_g11            0.0     1     0
    gimgrbufr_     goes_img    g12         imgr_g12            0.0     1     0
    airsbufr_      airs        aqua        airs_aqua           0.0     1     1
@@ -125,7 +123,6 @@ OBS_INPUT::
    gomebufr       gome        metop-a     gome_metop-a        0.0     2     0
    omibufr        omi         aura        omi_aura            0.0     2     0
    sbuvbufr       sbuv2       n19         sbuv8_n19           0.0     0     0
-   hirs4bufr      hirs4       n19         hirs4_n19           0.0     1     1
    amsuabufr      amsua       n19         amsua_n19           0.0     1     1
    mhsbufr        mhs         n19         mhs_n19             0.0     1     1
    tcvitl         tcp         null        tcp                 0.0     0     0
@@ -133,7 +130,6 @@ OBS_INPUT::
    seviribufr     seviri      m09         seviri_m09          0.0     1     0
    seviribufr     seviri      m10         seviri_m10          0.0     1     0
    seviribufr     seviri      m11         seviri_m11          0.0     1     0
-   hirs4bufr      hirs4       metop-b     hirs4_metop-b       0.0     1     1
    amsuabufr      amsua       metop-b     amsua_metop-b       0.0     1     1
    mhsbufr        mhs         metop-b     mhs_metop-b         0.0     1     1
    iasibufr       iasi        metop-b     iasi_metop-b        0.0     1     1
@@ -372,12 +368,6 @@ OBS_INPUT::
    sbuvbufr       sbuv2       n16       sbuv8_n16            0.0     0     0
    sbuvbufr       sbuv2       n17       sbuv8_n17            0.0     0     0
    sbuvbufr       sbuv2       n18       sbuv8_n18            0.0     0     0
-   hirs3bufr      hirs3       n16       hirs3_n16            0.0     1     0
-   hirs3bufr      hirs3       n17       hirs3_n17            0.0     1     0
-   hirs4bufr      hirs4       metop-a   hirs4_metop-a        0.0     2     0
-   hirs4bufr      hirs4       n18       hirs4_n18            0.0     1     0
-   hirs4bufr      hirs4       n19       hirs4_n19            0.0     2     0
-   hirs4bufr      hirs4       metop-b   hirs4_metop-b        0.0     2     0
    gimgrbufr      goes_img    g11       imgr_g11             0.0     1     0
    gimgrbufr      goes_img    g12       imgr_g12             0.0     1     0
    airsbufr       airs        aqua      airs_aqua            0.0     2     0
@@ -611,8 +601,6 @@ OBS_INPUT::
    sbuvbufr       sbuv2       n16         sbuv8_n16           0.0     0     0
    sbuvbufr       sbuv2       n17         sbuv8_n17           0.0     0     0
    sbuvbufr       sbuv2       n18         sbuv8_n18           0.0     0     0
-   hirs3bufr      hirs3       n17         hirs3_n17           0.0     1     0
-   hirs4bufr      hirs4       metop-a     hirs4_metop-a       0.0     1     1
    gimgrbufr      goes_img    g11         imgr_g11            0.0     1     0
    gimgrbufr      goes_img    g12         imgr_g12            0.0     1     0
    airsbufr       airs        aqua        airs_aqua           0.0     1     1
@@ -647,13 +635,11 @@ OBS_INPUT::
    gomebufr       gome        metop-a     gome_metop-a        0.0     2     0
    omibufr        omi         aura        omi_aura            0.0     2     0
    sbuvbufr       sbuv2       n19         sbuv8_n19           0.0     0     0
-   hirs4bufr      hirs4       n19         hirs4_n19           0.0     1     1
    amsuabufr      amsua       n19         amsua_n19           0.0     2     1
    mhsbufr        mhs         n19         mhs_n19             0.0     3     1
    seviribufr     seviri      m08         seviri_m08          0.0     1     0
    seviribufr     seviri      m09         seviri_m09          0.0     1     0
    seviribufr     seviri      m10         seviri_m10          0.0     1     0
-   hirs4bufr      hirs4       metop-b     hirs4_metop-b       0.0     1     0
    amsuabufr      amsua       metop-b     amsua_metop-b       0.0     2     0
    mhsbufr        mhs         metop-b     mhs_metop-b         0.0     3     0
    iasibufr       iasi        metop-b     iasi_metop-b        0.0     1     0
@@ -831,12 +817,6 @@ OBS_INPUT::
    sbuvbufr       sbuv2       n16         sbuv8_n16             0.0      0      0
    sbuvbufr       sbuv2       n17         sbuv8_n17             0.0      0      0
    sbuvbufr       sbuv2       n18         sbuv8_n18             0.0      0      0
-   hirs2bufr      hirs2       n14         hirs2_n14             0.0      1      0
-   hirs3bufr      hirs3       n16         hirs3_n16             0.0      1      0
-   hirs3bufr      hirs3       n17         hirs3_n17             0.0      1      0
-   hirs4bufr      hirs4       n18         hirs4_n18             0.0      1      0
-   hirs4bufr      hirs4       metop-a     hirs4_metop-a         0.0      1      0
-   hirs4bufr      hirs4       metop-b     hirs4_metop-b         0.0      1      0
    gsndrbufr      sndr        g11         sndr_g11              0.0      1      0
    gsndrbufr      sndr        g12         sndr_g12              0.0      1      0
    gimgrbufr      goes_img    g11         imgr_g11              0.0      1      0
@@ -868,7 +848,6 @@ OBS_INPUT::
    iasibufr       iasi        metop-b     iasi_metop-b          0.0      1      0
    omibufr        omi         aura        omi_aura              0.0      1      0
    sbuvbufr       sbuv2       n19         sbuv8_n19             0.0      1      0
-   hirs4bufr      hirs4       n19         hirs4_n19             0.0      1      0
    amsuabufr      amsua       n19         amsua_n19             0.0      1      0
    mhsbufr        mhs         n19         mhs_n19               0.0      1      0
    tcvitl         tcp         null        tcp                   0.0      0      0

--- a/src/gsi/setupsst.f90
+++ b/src/gsi/setupsst.f90
@@ -612,7 +612,7 @@ contains
            if (nst_gsi>0) then
               call nc_diag_metadata_to_single("FoundationTempBG",data(itref,i) )
               call nc_diag_metadata_to_single("DiurnalWarming_at_zob",data(idtw,i) )
-              call nc_diag_metadata_to_single("SkinLayerCooling_at_zob",data(idtw,i) )
+              call nc_diag_metadata_to_single("SkinLayerCooling_at_zob",data(idtc,i) )
               call nc_diag_metadata_to_single("Sensitivity_Tzob_Tr",data(itz_tr,i) )
            endif
  


### PR DESCRIPTION
**Description**

With the update to CRTM 2.4.0.1, an issue with versioning of CRTM HIRS files has been exposed. This is documented in https://github.com/JCSDA/spack-stack/issues/922 and https://github.com/JCSDA/crtm/pull/42.

As HIRS radiances are no longer used in the GSI, these data should be removed from processing until a suitable update to CRTM is available.

Resolves #673 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Build and run ctests on Hera
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

**DUE DATE for merger of this PR into develop is 2/1/2024 (six weeks after PR creation).**