### PR TITLE
add clipping treatment for negative values of non-negative tracers

### DIFF
--- a/src/gsi/gsi_rfv3io_mod.f90
+++ b/src/gsi/gsi_rfv3io_mod.f90
@@ -118,6 +118,11 @@ module gsi_rfv3io_mod
       vgsiname = [character(len=max_varname_length) :: &
         'u','v','w','tsen','delp','q','oz','ql','qi','qr','qs','qg','qnr','dbz','fed','ps','delzinc', &
         aeronames_cmaq_fv3,'pm25at','pm25ac','pm25co','pm2_5','amassi','amassj','amassk',aeronames_smoke_fv3]
+
+  integer(i_kind) ,parameter:: nnonnegtracer=7
+  character(len=max_varname_length), dimension(nnonnegtracer), parameter :: &
+    vnames_nonnegativetracers = [character(len=max_varname_length) :: &
+      "sphum","o3mr","liq_wat","ice_wat","rainwat","snowwat","graupel"]
   character(len=max_varname_length),dimension(:),allocatable:: name_metvars2d
   character(len=max_varname_length),dimension(:),allocatable:: name_metvars3d
   character(len=max_varname_length),dimension(:),allocatable:: name_chemvars3d
@@ -4676,6 +4681,10 @@ subroutine gsi_fv3ncdf_write(grd_ionouv,cstate_nouv,add_saved,filenamein,fv3file
                 call fv3_ll_to_h(work_a(:,:),work_b(:,:),nloncase,nlatcase,nlon_regional,nlat_regional,grid_reverse_flag)
              endif
           endif
+          if (ifindstrloc(vnames_nonnegativetracers,trim(varname))> 0) then
+              write(6,*)'thinkdeb varname for nonegative is ',trim(varname)
+              where (work_b <0.0_r_kind)  work_b=0.0_r_kind
+          endif
           if(fv3_io_layout_y > 1) then
              do nio=0,fv3_io_layout_y-1
                 countloc=(/nxcase,ny_layout_len(nio),1/)
@@ -4834,6 +4843,9 @@ subroutine gsi_fv3ncdf_write_v1(grd_ionouv,cstate_nouv,add_saved,filenamein,fv3f
         work_b(:,:)=work_b(:,:)+workb2(:,:)
       else
         call fv3_ll_to_h(work_a(:,:),work_b(:,:),nloncase,nlatcase,nlon_regional,nlat_regional,grid_reverse_flag)
+      endif
+      if (ifindstrloc(vnames_nonnegativetracers,trim(varname))> 0) then
+           where (work_b <0.0_r_kind)  work_b=0.0_r_kind
       endif
       call check( nf90_put_var(gfile_loc,VarId,work_b,start=startloc,count=countloc) )
     enddo  !ilevtot

--- a/src/gsi/gsi_rfv3io_mod.f90
+++ b/src/gsi/gsi_rfv3io_mod.f90
@@ -4682,7 +4682,6 @@ subroutine gsi_fv3ncdf_write(grd_ionouv,cstate_nouv,add_saved,filenamein,fv3file
              endif
           endif
           if (ifindstrloc(vnames_nonnegativetracers,trim(varname))> 0) then
-              write(6,*)'thinkdeb varname for nonegative is ',trim(varname)
               where (work_b <0.0_r_kind)  work_b=0.0_r_kind
           endif
           if(fv3_io_layout_y > 1) then


### PR DESCRIPTION
**Description**

Clips negative values from fields in the tracer file before writing. Fixes #680.


**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested?**

Tested on Hera in a RRFS CONUS workflow with both hybrid_radar_ref and anal_gsi_input tasks.
See run directory at /scratch2/BMC/zrtrr/aback/hydrometeors_test/
For one hour of the control run without this change, and one hour using the change contained in this PR, the INPUT directory was saved for reference/rerunning before each of the tasks: anal_gsi_input_spinup, hybrid_radar_ref_spinup, cldanl_nonvar_spinup, and run_fcst spinup. Those directories are at, for example /scratch2/BMC/zrtrr/aback/hydrometeors_test/INPUT_after_anal_gsi_input_spinup_before_hybrid_radar_ref_spinup ("control") and /scratch2/BMC/zrtrr/aback/hydrometeors_test/clipped_INPUT_after_anal_gsi_input_spinup_before_hybrid_radar_ref_spinup
(using the code in the PR).
Logs are at /scratch2/BMC/zrtrr/aback/hydrometeors_test/v0.7.9/logs/rrfs.20230610/08/, including new logs produced between all the above-listed tasks, showing all the min and max values in fv_tracer.

  
**Checklist**

The code is Ting Lei's. It looks stylish and understandable to me (Amanda) but maybe Ting should weigh in on this section.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

**DUE DATE for merger of this PR into `develop` is 2/22/2024 (six weeks after PR creation).**