### PR TITLE
CrIS viirs bug fix

### DIFF
--- a/src/gsi/read_cris.f90
+++ b/src/gsi/read_cris.f90
@@ -334,14 +334,18 @@ subroutine read_cris(mype,val_cris,ithin,isfcalc,rmesh,jsatid,gstime,&
      spc_filename = trim(crtm_coeffs_path)//'viirs-m_n20.SpcCoeff.bin' 
      sensorlist_imager = 'viirs-m_n20'
      inquire(file=trim(spc_filename), exist=imager_coeff)
-     if ( .not. imager_coeff ) spc_filename = trim(crtm_coeffs_path)//'viirs-m_j1.SpcCoeff.bin'
-     sensorlist_imager = 'viirs-m_j1'
+     if ( .not. imager_coeff ) then
+       spc_filename = trim(crtm_coeffs_path)//'viirs-m_j1.SpcCoeff.bin'
+       sensorlist_imager = 'viirs-m_j1'
+     endif
   elseif ( trim(jsatid) == 'n21' ) then
      spc_filename = trim(crtm_coeffs_path)//'viirs-m_n21.SpcCoeff.bin' 
      sensorlist_imager = 'viirs-m_n21'
      inquire(file=trim(spc_filename), exist=imager_coeff)
-     if ( .not. imager_coeff ) spc_filename = trim(crtm_coeffs_path)//'viirs-m_j2.SpcCoeff.bin'
-     sensorlist_imager = 'viirs-m_j2'
+     if ( .not. imager_coeff ) then
+       spc_filename = trim(crtm_coeffs_path)//'viirs-m_j2.SpcCoeff.bin'
+       sensorlist_imager = 'viirs-m_j2'
+     endif
   endif   
   inquire(file=trim(spc_filename), exist=imager_coeff)
   if ( imager_coeff ) then


### PR DESCRIPTION
**DUE DATE for merger of this PR into develop is 4/8/2024 (six weeks after PR creation).**

**Description**
The new cloud and aerosol detection software (CADS) requires the corresponding imager CRTM coefficient files. There are satellite identifier mis-matches for CrIS-VIIRS instruments on NOAA-20 and NOAA-21. The VIIRS files are named J1 and J2 for NOAA-20 and -21 respectively. Eventually the CRTM group will develop the correct named files. When this happens read_cris should transition to the new file names without incident. The current code will fail.

The code changes in read_cris will transition between j2 and n21 without incident.  This was tested on S4 and Hera.  The same logic was put in for J1 and n20 but can't be tested.  This PR will fix #706.  

Fixes #706

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

Ctests were conducted on Hera and Orion.  

Hera stats:
    Start 1: [=[global_4denvar]=]
    Start 2: [=[rtma]=]
    Start 3: [=[rrfs_3denvar_glbens]=]
    Start 4: [=[netcdf_fv3_regional]=]
    Start 5: [=[hafs_4denvar_glbens]=]
    Start 6: [=[hafs_3denvar_hybens]=]
    Start 7: [=[global_enkf]=]
1/7 Test #3: [=[rrfs_3denvar_glbens]=] ........   Passed  1210.74 sec
2/7 Test #4: [=[netcdf_fv3_regional]=] ........   Passed  1510.34 sec
3/7 Test #7: [=[global_enkf]=] ................   Passed  1689.43 sec
4/7 Test #6: [=[hafs_3denvar_hybens]=] ........   Passed  1826.83 sec
5/7 Test #2: [=[rtma]=] .......................   Passed  1996.78 sec
6/7 Test #5: [=[hafs_4denvar_glbens]=] ........   Passed  2187.12 sec
7/7 Test #1: [=[global_4denvar]=] .............   Passed  2213.32 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) = 2213.33 sec


Orion stats:
    Start 1: [=[global_4denvar]=]
    Start 2: [=[rtma]=]
    Start 3: [=[rrfs_3denvar_glbens]=]
    Start 4: [=[netcdf_fv3_regional]=]
    Start 5: [=[hafs_4denvar_glbens]=]
    Start 6: [=[hafs_3denvar_hybens]=]
    Start 7: [=[global_enkf]=]
1/7 Test #4: [=[netcdf_fv3_regional]=] ........   Passed  666.36 sec
2/7 Test #7: [=[global_enkf]=] ................   Passed  683.18 sec
3/7 Test #3: [=[rrfs_3denvar_glbens]=] ........   Passed  730.58 sec
4/7 Test #2: [=[rtma]=] .......................   Passed  1088.72 sec
5/7 Test #6: [=[hafs_3denvar_hybens]=] ........   Passed  1399.00 sec
6/7 Test #1: [=[global_4denvar]=] .............   Passed  1623.90 sec
7/7 Test #5: [=[hafs_4denvar_glbens]=] ........***Failed  1639.01 sec

86% tests passed, 1 tests failed out of 7

Total Test time (real) = 1639.03 sec

The failure on orion is a time threshold test:
The runtime for hafs_4denvar_glbens_loproc_updat is 389.841067 seconds.  This has exceeded maximum allowable threshold time of 389.025272 seconds,
resulting in Failure time-thresh of the regression test.

