### PR TITLE
Add parallel netcdf read/write from EnKF for sfc files (paranc option) #707

### DIFF
--- a/src/enkf/controlvec.f90
+++ b/src/enkf/controlvec.f90
@@ -218,19 +218,23 @@ if (paranc) then
    if (nproc == 0) t1 = mpi_wtime()
    call readgriddata_pnc(cvars3d,cvars2d,nc3d,nc2d,clevels,ncdim,nbackgrounds, &
            fgfileprefixes,fgsfcfileprefixes,reducedgrid,grdin,qsat)
+   if (nproc == 0) then
+     t2 = mpi_wtime()
+     print *,'time in readgrid_pnc on root',t2-t1,'secs'
+   end if
 end if
 if (nproc <= ntasks_io-1) then
    if (.not. paranc) then
       if (nproc == 0) t1 = mpi_wtime()
       call readgriddata(nanal1(nproc),nanal2(nproc),cvars3d,cvars2d,nc3d,nc2d,clevels,ncdim,nbackgrounds, &
            fgfileprefixes,fgsfcfileprefixes,reducedgrid,grdin,qsat)
+      if (nproc == 0) then
+        t2 = mpi_wtime()
+        print *,'time in readgrid on root',t2-t1,'secs'
+      end if
    end if
    !print *,'min/max qsat',nanal,'=',minval(qsat),maxval(qsat)
    q_ind = getindex(cvars3d, 'q')
-   if (nproc == 0) then
-     t2 = mpi_wtime()
-     print *,'time in readgridata/readgrid_pnc on root',t2-t1,'secs'
-   end if
    if (pseudo_rh .and. q_ind > 0) then
      do ne=1,nanals_per_iotask
      do nb=1,nbackgrounds

--- a/src/enkf/controlvec.f90
+++ b/src/enkf/controlvec.f90
@@ -215,19 +215,13 @@ allocate(grdin(npts,ncdim,nbackgrounds,nanals_per_iotask))
 q_ind = getindex(cvars3d, 'q')
 if (q_ind > 0)  allocate(qsat(npts,nlevs,nbackgrounds,nanals_per_iotask))
 if (paranc) then
-   if (nproc == 0) then
-     print *, 'calling readgriddata_pnc'
-     t1 = mpi_wtime()
-   end if
+   if (nproc == 0) t1 = mpi_wtime()
    call readgriddata_pnc(cvars3d,cvars2d,nc3d,nc2d,clevels,ncdim,nbackgrounds, &
            fgfileprefixes,fgsfcfileprefixes,reducedgrid,grdin,qsat)
 end if
 if (nproc <= ntasks_io-1) then
    if (.not. paranc) then
-      if (nproc == 0) then
-        print *, 'calling readgriddata'
-        t1 = mpi_wtime()
-      end if
+      if (nproc == 0) t1 = mpi_wtime()
       call readgriddata(nanal1(nproc),nanal2(nproc),cvars3d,cvars2d,nc3d,nc2d,clevels,ncdim,nbackgrounds, &
            fgfileprefixes,fgsfcfileprefixes,reducedgrid,grdin,qsat)
    end if

--- a/src/enkf/controlvec.f90
+++ b/src/enkf/controlvec.f90
@@ -191,7 +191,7 @@ subroutine read_control()
 ! read ensemble members on IO tasks
 implicit none
 real(r_double)  :: t1,t2
-integer(i_kind) :: nb,ne
+integer(i_kind) :: nb,nlev,ne
 integer(i_kind) :: q_ind
 integer(i_kind) :: ierr
 
@@ -215,13 +215,19 @@ allocate(grdin(npts,ncdim,nbackgrounds,nanals_per_iotask))
 q_ind = getindex(cvars3d, 'q')
 if (q_ind > 0)  allocate(qsat(npts,nlevs,nbackgrounds,nanals_per_iotask))
 if (paranc) then
-   if (nproc == 0) t1 = mpi_wtime()
+   if (nproc == 0) then
+     print *, 'calling readgriddata_pnc'
+     t1 = mpi_wtime()
+   end if
    call readgriddata_pnc(cvars3d,cvars2d,nc3d,nc2d,clevels,ncdim,nbackgrounds, &
            fgfileprefixes,fgsfcfileprefixes,reducedgrid,grdin,qsat)
 end if
 if (nproc <= ntasks_io-1) then
    if (.not. paranc) then
-      if (nproc == 0) t1 = mpi_wtime()
+      if (nproc == 0) then
+        print *, 'calling readgriddata'
+        t1 = mpi_wtime()
+      end if
       call readgriddata(nanal1(nproc),nanal2(nproc),cvars3d,cvars2d,nc3d,nc2d,clevels,ncdim,nbackgrounds, &
            fgfileprefixes,fgsfcfileprefixes,reducedgrid,grdin,qsat)
    end if
@@ -229,7 +235,7 @@ if (nproc <= ntasks_io-1) then
    q_ind = getindex(cvars3d, 'q')
    if (nproc == 0) then
      t2 = mpi_wtime()
-     print *,'time in readgridata on root',t2-t1,'secs'
+     print *,'time in readgridata/readgrid_pnc on root',t2-t1,'secs'
    end if
    if (pseudo_rh .and. q_ind > 0) then
      do ne=1,nanals_per_iotask
@@ -357,7 +363,7 @@ if (paranc) then
      endif
      deallocate(grdin_mean)
      t2 = mpi_wtime()
-     print *,'time in write_control on root',t2-t1,'secs'
+     print *,'time in write_control paranc on root',t2-t1,'secs'
    endif 
 end if
 

--- a/src/enkf/gridio_gfs.f90
+++ b/src/enkf/gridio_gfs.f90
@@ -101,7 +101,7 @@
   integer(i_kind) :: soilt4_ind,slc1_ind, slc2_ind, slc3_ind, slc4_ind
 
   integer(i_kind) :: k,iret,nb,i,imem,idvc,nlonsin,nlatsin,nlevsin,ne,nanal
-  !surface
+  ! surface
   integer(i_kind) :: nlonsin_sfc,nlatsin_sfc
 
   logical ice

--- a/src/enkf/gridio_gfs.f90
+++ b/src/enkf/gridio_gfs.f90
@@ -152,7 +152,7 @@
      displs(i+1) = ((lev_pe1(i)-1)*nlons*nlats)
   end do
 
- if (read_atm_file) then  ! read_atm_file ! 1.18.24 want to test only sfc?
+ if (read_atm_file) then  
 
   ! loop through times and do the read
   ne = 1
@@ -498,7 +498,7 @@
 
  end if   !read_atm_file
 
- if (read_sfc_file) then ! sfc read
+ if (read_sfc_file) then 
    ! loop through times and do the read
    ne = 1
    sfcbackgroundloop: do nb=1,ntimes
@@ -507,8 +507,6 @@
    sfcfilename = trim(adjustl(datapath))//trim(adjustl(filesfcprefixes(nb)))//trim(charnanal)
    if (use_gfs_ncio) then
      dset_sfc = open_dataset(sfcfilename, paropen=.true., mpicomm=iocomms(mem_pe(nproc)))
-     !londim = get_dim(dset,'grid_xt'); nlonsin = londim%len
-     !latdim = get_dim(dset,'grid_yt'); nlatsin = latdim%len
    else
      write(6,*)'READGRIDDATA_PNC sfc:  ***FATAL ERROR*** parallel read only supported for netCDF' , ' PROGRAM STOPS'
      call mpi_barrier(mpi_comm_world,ierr)
@@ -631,7 +629,7 @@
    call mpi_barrier(iocomms(mem_pe(nproc)), iret)
 
    end do sfcbackgroundloop ! loop over backgrounds to read in
- end if   !if (read_sfc_file
+ end if   !if (read_sfc_file)
 
   ! remove the sub communicators
   call mpi_barrier(iocomms(mem_pe(nproc)), iret)

--- a/src/enkf/gridio_gfs.f90
+++ b/src/enkf/gridio_gfs.f90
@@ -89,15 +89,21 @@
   real(r_kind), dimension(ndimspec)             :: vrtspec,divspec
   real(r_kind), allocatable, dimension(:)       :: psg,pstend,ak,bk
   real(r_single),allocatable,dimension(:,:,:)   :: ug3d,vg3d
-  type(Dataset) :: dset
+  type(Dataset) :: dset, dset_sfc
   type(Dimension) :: londim,latdim,levdim
 
   integer(i_kind) :: u_ind, v_ind, tv_ind, q_ind, oz_ind, cw_ind
   integer(i_kind) :: qr_ind, qs_ind, qg_ind
   integer(i_kind) :: tsen_ind, ql_ind, qi_ind, prse_ind
   integer(i_kind) :: ps_ind, pst_ind, sst_ind
+  ! surface 
+  integer(i_kind) :: tmp2m_ind, spfh2m_ind, soilt1_ind, soilt2_ind, soilt3_ind
+  integer(i_kind) :: soilt4_ind,slc1_ind, slc2_ind, slc3_ind, slc4_ind
 
   integer(i_kind) :: k,iret,nb,i,imem,idvc,nlonsin,nlatsin,nlevsin,ne,nanal
+  !surface
+  integer(i_kind) :: nlonsin_sfc,nlatsin_sfc
+
   logical ice
   logical use_full_hydro
   integer(i_kind), allocatable, dimension(:) :: mem_pe, lev_pe1, lev_pe2, iocomms
@@ -110,12 +116,6 @@
   logical :: read_sfc_file, read_atm_file
 
   call set_ncio_file_flags(vars3d, n3d, vars2d, n2d, read_sfc_file, read_atm_file)
-
-   if (read_sfc_file) then
-      print *,'paranc not supported for reading surface files'
-      call mpi_barrier(mpi_comm_world,ierr)
-      call mpi_finalize(ierr)
-   endif
 
   ! figure out what member to read and do MPI sub-communicator things
   allocate(mem_pe(0:numproc-1))
@@ -152,6 +152,7 @@
      displs(i+1) = ((lev_pe1(i)-1)*nlons*nlats)
   end do
 
+ if (read_atm_file) then  ! read_atm_file ! 1.18.24 want to test only sfc?
 
   ! loop through times and do the read
   ne = 1
@@ -159,7 +160,6 @@
 
   write(charnanal,'(a3, i3.3)') 'mem', nanal
   filename = trim(adjustl(datapath))//trim(adjustl(fileprefixes(nb)))//trim(charnanal)
-  sfcfilename = trim(adjustl(datapath))//trim(adjustl(filesfcprefixes(nb)))//trim(charnanal)
   if (use_gfs_ncio) then
      dset = open_dataset(filename, paropen=.true., mpicomm=iocomms(mem_pe(nproc)))
      londim = get_dim(dset,'grid_xt'); nlonsin = londim%len
@@ -495,6 +495,143 @@
 
 
   end do backgroundloop ! loop over backgrounds to read in
+
+ end if   !read_atm_file
+
+ if (read_sfc_file) then ! sfc read
+   ! loop through times and do the read
+   ne = 1
+   sfcbackgroundloop: do nb=1,ntimes
+   
+   write(charnanal,'(a3, i3.3)') 'mem', nanal
+   sfcfilename = trim(adjustl(datapath))//trim(adjustl(filesfcprefixes(nb)))//trim(charnanal)
+   if (use_gfs_ncio) then
+     dset_sfc = open_dataset(sfcfilename, paropen=.true., mpicomm=iocomms(mem_pe(nproc)))
+     !londim = get_dim(dset,'grid_xt'); nlonsin = londim%len
+     !latdim = get_dim(dset,'grid_yt'); nlatsin = latdim%len
+   else
+     write(6,*)'READGRIDDATA_PNC sfc:  ***FATAL ERROR*** parallel read only supported for netCDF' , ' PROGRAM STOPS'
+     call mpi_barrier(mpi_comm_world,ierr)
+     call mpi_finalize(ierr)
+   end if
+   if ( reducedgrid ) then
+       write(6,*) "READGRIDDATA_PNC sfc: reducedgrid=T interpolation not valid for writing sfc files"
+       call mpi_barrier(mpi_comm_world,ierr)
+       call mpi_finalize(ierr)
+   endif
+
+   ! land sfc DA variables
+   tmp2m_ind  = getindex(vars2d, 't2m')
+   spfh2m_ind = getindex(vars2d, 'q2m')
+   soilt1_ind = getindex(vars2d, 'st1')
+   slc1_ind = getindex(vars2d, 'sl1')
+   soilt2_ind = getindex(vars2d, 'st2')
+   slc2_ind = getindex(vars2d, 'sl2')
+   soilt3_ind = getindex(vars2d, 'st3')
+   slc3_ind = getindex(vars2d, 'sl3')
+   soilt4_ind = getindex(vars2d, 'st4')
+   slc4_ind = getindex(vars2d, 'sl4')
+
+   ! read in sfc vars, if requested
+   if (tmp2m_ind > 0) then
+       call read_vardata(dset_sfc, 'tmp2m', values_2d, errcode=iret)
+       if (iret /= 0) then
+               print *,'READGRIDDATA_PNC: error reading tmp2m'
+               call stop2(22)
+       endif
+       ug = reshape(values_2d,(/nlons*nlats/))
+       if (iope==0) call copytogrdin(ug,grdin(:,levels(n3d) + tmp2m_ind,nb,ne))
+   endif
+   if (spfh2m_ind > 0) then
+       call read_vardata(dset_sfc, 'spfh2m', values_2d, errcode=iret)
+       if (iret /= 0) then
+               print *,'READGRIDDATA_PNC: error reading spfh2m'
+               call stop2(22)
+       endif
+       ug = reshape(values_2d,(/nlons*nlats/))
+       if (iope==0) call copytogrdin(ug,grdin(:,levels(n3d) + spfh2m_ind,nb,ne))
+   endif
+   if (soilt1_ind > 0) then
+       call read_vardata(dset_sfc, 'soilt1', values_2d, errcode=iret)
+       if (iret /= 0) then
+               print *,'READGRIDDATA_PNC: error reading soilt1'
+               call stop2(22)
+       endif
+       ug = reshape(values_2d,(/nlons*nlats/))
+       if (iope==0) call copytogrdin(ug,grdin(:,levels(n3d) + soilt1_ind,nb,ne))
+   endif
+   if (soilt2_ind > 0) then
+       call read_vardata(dset_sfc, 'soilt2', values_2d, errcode=iret)
+       if (iret /= 0) then
+               print *,'READGRIDDATA_PNC: error reading soilt2'
+               call stop2(22)
+       endif
+       ug = reshape(values_2d,(/nlons*nlats/))
+       if (iope==0) call copytogrdin(ug,grdin(:,levels(n3d) + soilt2_ind,nb,ne))
+   endif
+   if (soilt3_ind > 0) then
+       call read_vardata(dset_sfc, 'soilt3', values_2d, errcode=iret)
+       if (iret /= 0) then
+               print *,'READGRIDDATA_PNC: error reading soilt3'
+               call stop2(22)
+       endif
+       ug = reshape(values_2d,(/nlons*nlats/))
+       if (iope==0) call copytogrdin(ug,grdin(:,levels(n3d) + soilt3_ind,nb,ne))
+   endif
+   if (soilt4_ind > 0) then
+       call read_vardata(dset_sfc, 'soilt4', values_2d, errcode=iret)
+       if (iret /= 0) then
+               print *,'READGRIDDATA_PNC: error reading soilt2'
+               call stop2(22)
+       endif
+       ug = reshape(values_2d,(/nlons*nlats/))
+       if (iope==0) call copytogrdin(ug,grdin(:,levels(n3d) + soilt4_ind,nb,ne))
+   endif
+   if (slc1_ind > 0) then
+       call read_vardata(dset_sfc, 'soill1', values_2d, errcode=iret)
+       if (iret /= 0) then
+               print *,'READGRIDDATA_PNC: error reading soill1'
+               call stop2(22)
+       endif
+       ug = reshape(values_2d,(/nlons*nlats/))
+       if (iope==0) call copytogrdin(ug,grdin(:,levels(n3d) + slc1_ind,nb,ne))
+   endif
+   if (slc2_ind > 0) then
+       call read_vardata(dset_sfc, 'soill2', values_2d, errcode=iret)
+       if (iret /= 0) then
+               print *,'READGRIDDATA_PNC: error reading soill2'
+               call stop2(22)
+       endif
+       ug = reshape(values_2d,(/nlons*nlats/))
+       if (iope==0) call copytogrdin(ug,grdin(:,levels(n3d) + slc2_ind,nb,ne))
+   endif
+   if (slc3_ind > 0) then
+       call read_vardata(dset_sfc, 'soill3', values_2d, errcode=iret)
+       if (iret /= 0) then
+               print *,'READGRIDDATA_PNC: error reading soill3'
+               call stop2(22)
+       endif
+       ug = reshape(values_2d,(/nlons*nlats/))
+       if (iope==0) call copytogrdin(ug,grdin(:,levels(n3d) + slc3_ind,nb,ne))
+   endif
+   if (slc4_ind > 0) then
+       call read_vardata(dset_sfc, 'soill4', values_2d, errcode=iret)
+       if (iret /= 0) then
+               print *,'READGRIDDATA_PNC: error reading soill4'
+               call stop2(22)
+       endif
+       ug = reshape(values_2d,(/nlons*nlats/))
+       if (iope==0) call copytogrdin(ug,grdin(:,levels(n3d) + slc4_ind,nb,ne))
+   endif
+
+   ! bring all the subdomains back to the main PE
+   call mpi_barrier(iocomms(mem_pe(nproc)), iret) 
+   if (allocated(values_2d)) deallocate(values_2d)
+   call close_dataset(dset_sfc)
+   call mpi_barrier(iocomms(mem_pe(nproc)), iret)
+
+   end do sfcbackgroundloop ! loop over backgrounds to read in
+ end if   !if (read_sfc_file
 
   ! remove the sub communicators
   call mpi_barrier(iocomms(mem_pe(nproc)), iret)
@@ -1321,6 +1458,20 @@
   integer(i_kind) :: iope, ionumproc, iolevs, krev, ki
   integer(i_kind) :: ncstart(4), nccount(4)
   logical :: nocompress
+
+  logical :: write_sfc_file, write_atm_file
+  character(len=max_varname_length), dimension(n3d) :: no_vars3d
+  character(len=max_varname_length), dimension(n2d) :: no_vars2d
+
+  call set_ncio_file_flags(vars3d, n3d, vars2d, n2d, write_sfc_file, write_atm_file)
+
+  if (write_sfc_file ) then
+        ! adding the sfc increments requires adjusting several other variables.
+        ! This is done is a separate program.
+        if (nproc == 0) write(6,*) 'gridio/writegriddata_pnc: not coded to write sfc analysis, will write increment for sfc fields'
+        no_vars3d=''
+        call writeincrement_pnc(no_vars3d,vars2d,n3d,n2d,levels,ndim,grdin,no_inflate_flag)
+  endif  
 
   nocompress = .true.
 
@@ -3616,6 +3767,7 @@
   ! soil / snow mask (not fixed)
   integer(i_kind), dimension(nlons,nlats) :: mask
   logical :: write_sfc_file, write_atm_file
+  real(r_double)  :: t1,t2
 
   call set_ncio_file_flags(vars3d, n3d, vars2d, n2d, write_sfc_file, write_atm_file)
 
@@ -3627,6 +3779,7 @@
   nccount = (/nlons, nlats, nlevs/)
 
   if ( write_atm_file) then
+  if (nproc == 0) t1 = mpi_wtime()
   ne = 0
   ensmemloop: do nanal=nanal1,nanal2
   ne = ne + 1
@@ -3954,10 +4107,15 @@
   end do backgroundloop ! loop over backgrounds to read in
   end do ensmemloop ! loop over ens members to read in
 
+  if (nproc == 0) then
+       t2 = mpi_wtime()
+       print *,'time in writeincrement atm_file on root',t2-t1,'secs'
+  endif
   endif ! write_atm_file
 
   if (write_sfc_file) then
 
+     if (nproc == 0) t1 = mpi_wtime() 
      ne = 0
      sfcensmemloop: do nanal=nanal1,nanal2
      ne = ne + 1
@@ -4199,6 +4357,10 @@
 
   end do sfcbackgroundloop ! loop over backgrounds to read in
   end do sfcensmemloop ! loop over ens members to read in
+  if (nproc == 0) then
+       t2 = mpi_wtime()
+       print *,'time in writeincrement sfc_file on root',t2-t1,'secs'
+  endif
 
   endif ! write_sfc_file
 
@@ -4225,7 +4387,8 @@
  subroutine writeincrement_pnc(vars3d,vars2d,n3d,n2d,levels,ndim,grdin,no_inflate_flag)
   use netcdf
   use params, only: nbackgrounds,incfileprefixes,fgfileprefixes,reducedgrid,&
-                    datestring,nhr_anal
+                    datestring,nhr_anal, &
+                    incsfcfileprefixes,fgsfcfileprefixes
   use constants, only: grav,qcmin
   use mpi
   use module_ncio, only: Dataset, Variable, Dimension, open_dataset,&
@@ -4257,12 +4420,17 @@
   integer :: ql_ind, qi_ind, qr_ind, qs_ind, qg_ind
 
   ! netcdf things
-  integer(i_kind) :: dimids3(3),nccount(3),ncstart(3)
+  integer(i_kind) :: dimids3(3),nccount(3),ncstart(3), dimids2(2)
   integer(i_kind) :: ncid_out, lon_dimid, lat_dimid, lev_dimid, ilev_dimid
   integer(i_kind) :: lonvarid, latvarid, levvarid, pfullvarid, ilevvarid, &
                      hyaivarid, hybivarid, uvarid, vvarid, delpvarid, delzvarid, &
                      tvarid, sphumvarid, liqwatvarid, o3varid, icvarid, &
-                     rwmrvarid, snmrvarid, grlevarid 
+                     rwmrvarid, snmrvarid, grlevarid, &
+                     tmp2mvarid, spfh2mvarid, soilt1varid, soilt2varid, &
+                     soilt3varid, soilt4varid, slc1varid, slc2varid, &
+                     slc3varid, slc4varid, maskvarid
+  integer(i_kind) :: tmp2m_ind, spfh2m_ind, soilt1_ind, soilt2_ind,soilt3_ind, &
+                     soilt4_ind,slc1_ind, slc2_ind, slc3_ind, slc4_ind 
   integer(i_kind) :: iadateout
 
   ! fixed fields such as lat, lon, levs
@@ -4274,11 +4442,20 @@
   ! increment
   real(r_kind), dimension(nlons*nlats) :: psinc, inc, ug, vg, work
   real(r_single), allocatable, dimension(:,:,:) :: inc3d, inc3d2, inc3dout
+  real(r_single), allocatable, dimension(:,:) :: inc2d,  inc2dout
   real(r_single), allocatable, dimension(:,:,:) :: tv, tvanl, tmp, tmpanl, q, qanl
   real(r_single), allocatable, dimension(:,:,:) :: q2, qanl2
   real(r_kind), allocatable, dimension(:,:) :: values_2d
   real(r_kind), allocatable, dimension(:) :: psges, delzb, values_1d
 
+  ! soil / snow mask (not fixed)
+  integer(i_kind), dimension(nlons,nlats) :: mask
+
+  logical :: write_sfc_file, write_atm_file
+  real(r_double)  :: t1,t2
+
+  call set_ncio_file_flags(vars3d, n3d, vars2d, n2d, write_sfc_file, write_atm_file) 
+  
   use_full_hydro = .false.
   clip = tiny_r_kind
   read(datestring,*) iadateout
@@ -4317,6 +4494,9 @@
      call mpi_bcast(grdin(1,1,nb,1),npts*ndim, mpi_real4, 0, iocomms(mem_pe(nproc)), iret)
   enddo
 
+  if (write_atm_file ) then   
+   
+  if (nproc == 0) t1 = mpi_wtime()
   ! loop through times and do the read
   ne = 1
   backgroundloop: do nb=1,nbackgrounds
@@ -4772,8 +4952,261 @@
   if (allocated(delzb)) deallocate(delzb)
   if (allocated(psges)) deallocate(psges)
 
+  !closing file 
+  call nccheck_incr(nf90_close(ncid_out))
 
   end do backgroundloop ! loop over backgrounds to write out
+  if (nproc == 0) then
+       t2 = mpi_wtime()
+       print *,'time in writeincrement_pnc atm_file on root',t2-t1,'secs'
+  endif
+ end if ! if (write_atm_file)
+
+  if (write_sfc_file ) then
+
+   if (nproc == 0) t1 = mpi_wtime()
+
+   tmp2m_ind  = getindex(vars2d, 't2m')   !< indices in the state or control var arrays
+   spfh2m_ind = getindex(vars2d, 'q2m')
+   soilt1_ind = getindex(vars2d, 'st1')
+   slc1_ind = getindex(vars2d, 'sl1')
+   soilt2_ind = getindex(vars2d, 'st2')
+   slc2_ind = getindex(vars2d, 'sl2')
+   soilt3_ind = getindex(vars2d, 'st3')
+   slc3_ind = getindex(vars2d, 'sl3')
+   soilt4_ind = getindex(vars2d, 'st4')
+   slc4_ind = getindex(vars2d, 'sl4')
+
+   ! loop through times and do the read
+   ne = 1
+   write(charnanal,'(i3.3)') nanal
+   sfcbackgroundloop: do nb=1,nbackgrounds
+
+   if(no_inflate_flag) then
+      filenameout = trim(adjustl(datapath))//trim(adjustl(incsfcfileprefixes(nb)))//"nimem"//charnanal
+   else
+      filenameout = trim(adjustl(datapath))//trim(adjustl(incsfcfileprefixes(nb)))//"mem"//charnanal
+   end if
+   filenamein = trim(adjustl(datapath))//trim(adjustl(fgsfcfileprefixes(nb)))//"mem"//charnanal
+   
+   !! note: only iope=0 is writing the outputs. Having all pes in iocomm write to a file slows it down.
+   !! 
+   if (iope==0) then
+      dsfg = open_dataset(filenamein)
+     ! create the output netCDF increment file
+     call nccheck_incr(nf90_create(path=trim(filenameout), cmode=nf90_netcdf4,ncid=ncid_out))
+
+     ! create dimensions based on analysis resolution, not guess
+     call nccheck_incr(nf90_def_dim(ncid_out, "longitude", nlons, lon_dimid))
+     call nccheck_incr(nf90_def_dim(ncid_out, "latitude", nlats, lat_dimid))
+     dimids2 = (/ lon_dimid, lat_dimid /)
+     ! create variables
+     call nccheck_incr(nf90_def_var(ncid_out, "longitude", nf90_real,(/lon_dimid/), lonvarid))
+     call nccheck_incr(nf90_def_var(ncid_out, "latitude", nf90_real,(/lat_dimid/), latvarid))
+     call nccheck_incr(nf90_def_var(ncid_out, "tmp2m_inc", nf90_real, dimids2,tmp2mvarid))
+     call nccheck_incr(nf90_def_var(ncid_out, "spfh2m_inc", nf90_real, dimids2,spfh2mvarid))
+     call nccheck_incr(nf90_def_var(ncid_out, "soilt1_inc", nf90_real, dimids2,soilt1varid))
+     call nccheck_incr(nf90_def_var(ncid_out, "soilt2_inc", nf90_real, dimids2,soilt2varid))
+     call nccheck_incr(nf90_def_var(ncid_out, "soilt3_inc", nf90_real, dimids2,soilt3varid))
+     call nccheck_incr(nf90_def_var(ncid_out, "soilt4_inc", nf90_real, dimids2,soilt4varid))
+     call nccheck_incr(nf90_def_var(ncid_out, "slc1_inc", nf90_real, dimids2,slc1varid))
+     call nccheck_incr(nf90_def_var(ncid_out, "slc2_inc", nf90_real, dimids2,slc2varid))
+     call nccheck_incr(nf90_def_var(ncid_out, "slc3_inc", nf90_real, dimids2,slc3varid))
+     call nccheck_incr(nf90_def_var(ncid_out, "slc4_inc", nf90_real, dimids2,slc4varid))
+     call nccheck_incr(nf90_def_var(ncid_out, "soilsnow_mask", nf90_int,dimids2, maskvarid))
+     ! place global attributes to serial calc_increment output
+     call nccheck_incr(nf90_put_att(ncid_out, nf90_global, "source", "GSI EnKF"))
+     call nccheck_incr(nf90_put_att(ncid_out, nf90_global, "comment", &
+                       "global landsfc anal increment from writeincrement"))
+     call nccheck_incr(nf90_put_att(ncid_out, nf90_global, "analysis_time",iadateout))
+     call nccheck_incr(nf90_put_att(ncid_out, nf90_global,"IAU_hour_from_guess", nhr_anal(nb)))
+     ! add units to lat/lon because that's what the calc_increment utility has
+     call nccheck_incr(nf90_put_att(ncid_out, lonvarid, "units","degrees_east"))
+     call nccheck_incr(nf90_put_att(ncid_out, latvarid, "units","degrees_north"))
+     ! end the netCDF file definition
+     call nccheck_incr(nf90_enddef(ncid_out))
+
+      ! longitudes
+      call read_vardata(dsfg, 'grid_xt', values_1d, errcode=iret)
+      deglons(:) = values_1d
+      call nccheck_incr(nf90_put_var(ncid_out, lonvarid, deglons, &
+                           start = (/1/), count = (/nlons/)))
+
+      call read_vardata(dsfg, 'grid_yt', values_1d, errcode=iret)
+      ! latitudes
+      do j=1,nlats
+        deglats(nlats-j+1) = values_1d(j)
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, latvarid, deglats, &
+                           start = (/1/), count = (/nlats/)))
+      ! construct mask (1 - soil, 2 - snow, 0 - not snow)
+      ! note: same logic/threshold used in global_cycle to produce
+      ! mask on model grid.
+      call read_vardata(dsfg, 'soill1', values_2d, errcode=iret)
+      mask = 0
+      do j=1,nlats
+         do i = 1, nlons
+            if (values_2d(i,j) .LT. 1.0) then
+            mask(i,nlats-j+1) = 1
+            endif
+         enddo
+      end do
+      call read_vardata(dsfg, 'weasd', values_2d, errcode=iret)
+      do j=1,nlats
+         do i = 1, nlons
+            if (values_2d(i,j) .GT. 0.001) then
+            mask(i,nlats-j+1) = 2
+            endif
+         enddo
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, maskvarid, mask, &
+                        start = ncstart(1:2), count = nccount(1:2)))
+
+      allocate(inc2d(nlons,nlats))
+      allocate(inc2dout(nlons,nlats))
+
+      ! tmp2m increment
+      inc(:) = zero
+      if (tmp2m_ind > 0) then
+         call copyfromgrdin(grdin(:,levels(n3d) + tmp2m_ind,nb,ne),inc)
+      endif
+      inc2d(:,:) = reshape(inc,(/nlons,nlats/))
+      do j=1,nlats
+         inc2dout(:,nlats-j+1) = inc2d(:,j)
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, tmp2mvarid, sngl(inc2dout), &
+                           start = ncstart(1:2), count = nccount(1:2)))
+      ! spfh2m increment
+      inc(:) = zero
+      if (spfh2m_ind > 0) then
+         call copyfromgrdin(grdin(:,levels(n3d)+spfh2m_ind,nb,ne),inc)
+      endif
+      inc2d(:,:) = reshape(inc,(/nlons,nlats/))
+      do j=1,nlats
+         inc2dout(:,nlats-j+1) = inc2d(:,j)
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, spfh2mvarid, sngl(inc2dout), &
+                           start = ncstart(1:2), count = nccount(1:2)))
+      ! soilt1 increment
+      inc(:) = zero
+      if (soilt1_ind > 0) then
+         call copyfromgrdin(grdin(:,levels(n3d)+soilt1_ind,nb,ne),inc)
+      endif
+      inc2d(:,:) = reshape(inc,(/nlons,nlats/))
+      inc2dout=0.
+      do j=1,nlats
+         do i = 1, nlons
+            if (mask(i,nlats-j+1) .NE. 0) inc2dout(i,nlats-j+1) = inc2d(i,j)
+         enddo
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, soilt1varid, sngl(inc2dout), &
+                           start = ncstart(1:2), count = nccount(1:2)))
+      ! soilt2 increment
+      inc(:) = zero
+      if (soilt2_ind > 0) then
+         call copyfromgrdin(grdin(:,levels(n3d)+soilt2_ind,nb,ne),inc)
+      endif
+      inc2d(:,:) = reshape(inc,(/nlons,nlats/))
+      inc2dout=0.
+      do j=1,nlats
+         do i = 1, nlons
+            if (mask(i,nlats-j+1) .NE. 0) inc2dout(i,nlats-j+1) = inc2d(i,j)
+         enddo
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, soilt2varid, sngl(inc2dout), &
+                           start = ncstart(1:2), count = nccount(1:2)))
+      ! soilt3 increment
+      inc(:) = zero
+      if (soilt3_ind > 0) then
+         call copyfromgrdin(grdin(:,levels(n3d)+soilt3_ind,nb,ne),inc)
+      endif
+      inc2d(:,:) = reshape(inc,(/nlons,nlats/))
+      inc2dout=0.
+      do j=1,nlats
+         do i = 1, nlons
+            if (mask(i,nlats-j+1) .NE. 0) inc2dout(i,nlats-j+1) = inc2d(i,j)
+         enddo
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, soilt3varid, sngl(inc2dout), &
+                           start = ncstart(1:2), count = nccount(1:2)))
+      ! soilt4 increment
+      inc(:) = zero
+      if (soilt4_ind > 0) then
+         call copyfromgrdin(grdin(:,levels(n3d)+soilt4_ind,nb,ne),inc)
+      endif
+      inc2d(:,:) = reshape(inc,(/nlons,nlats/))
+      inc2dout=0.
+      do j=1,nlats
+         do i = 1, nlons
+            if (mask(i,nlats-j+1) .NE. 0) inc2dout(i,nlats-j+1) = inc2d(i,j)
+         enddo
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, soilt4varid, sngl(inc2dout), &
+                           start = ncstart(1:2), count = nccount(1:2)))
+      ! slc1 increment
+      inc(:) = zero
+      if (slc1_ind > 0) then
+         call copyfromgrdin(grdin(:,levels(n3d)+slc1_ind,nb,ne),inc)
+      endif
+      inc2d(:,:) = reshape(inc,(/nlons,nlats/))
+      do j=1,nlats
+         inc2dout(:,nlats-j+1) = inc2d(:,j)
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, slc1varid, sngl(inc2dout), &
+                           start = ncstart(1:2), count = nccount(1:2)))
+      ! slc2 increment
+      inc(:) = zero
+      if (slc2_ind > 0) then
+         call copyfromgrdin(grdin(:,levels(n3d)+slc2_ind,nb,ne),inc)
+      endif
+      inc2d(:,:) = reshape(inc,(/nlons,nlats/))
+      do j=1,nlats
+         inc2dout(:,nlats-j+1) = inc2d(:,j)
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, slc2varid, sngl(inc2dout), &
+                           start = ncstart(1:2), count = nccount(1:2)))
+      ! slc3 increment
+      inc(:) = zero
+      if (slc3_ind > 0) then
+         call copyfromgrdin(grdin(:,levels(n3d)+slc3_ind,nb,ne),inc)
+      endif
+      inc2d(:,:) = reshape(inc,(/nlons,nlats/))
+      do j=1,nlats
+         inc2dout(:,nlats-j+1) = inc2d(:,j)
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, slc3varid, sngl(inc2dout), &
+                           start = ncstart(1:2), count = nccount(1:2)))
+      ! slc4 increment
+      inc(:) = zero
+      if (slc4_ind > 0) then
+         call copyfromgrdin(grdin(:,levels(n3d)+slc4_ind,nb,ne),inc)
+      endif
+      inc2d(:,:) = reshape(inc,(/nlons,nlats/))
+      do j=1,nlats
+         inc2dout(:,nlats-j+1) = inc2d(:,j)
+      end do
+      call nccheck_incr(nf90_put_var(ncid_out, slc4varid, sngl(inc2dout), &
+                        start = ncstart(1:2), count = nccount(1:2)))
+
+      call close_dataset(dsfg,errcode=iret)
+      if (iret/=0) then
+         write(6,*)'gridio/writeincrement_par: problem closing netcdf sfc fg dataset, iret=',iret
+         call stop2(23)
+      endif
+      ! deallocate things
+      deallocate(inc2d,inc2dout)
+
+      call nccheck_incr(nf90_close(ncid_out))
+
+   end if
+   
+   end do sfcbackgroundloop ! loop over backgrounds to read in   
+   if (nproc == 0) then
+        t2 = mpi_wtime()
+        print *,'time in writeincrement_pnc sfc_file on root',t2-t1,'secs'
+   endif   
+  endif  !write_Sfc
+
   ! remove the sub communicators
   call mpi_barrier(iocomms(mem_pe(nproc)), iret)
   call mpi_comm_free(iocomms(mem_pe(nproc)), iret)

--- a/src/gsi/read_cris.f90
+++ b/src/gsi/read_cris.f90
@@ -334,14 +334,18 @@ subroutine read_cris(mype,val_cris,ithin,isfcalc,rmesh,jsatid,gstime,&
      spc_filename = trim(crtm_coeffs_path)//'viirs-m_n20.SpcCoeff.bin' 
      sensorlist_imager = 'viirs-m_n20'
      inquire(file=trim(spc_filename), exist=imager_coeff)
-     if ( .not. imager_coeff ) spc_filename = trim(crtm_coeffs_path)//'viirs-m_j1.SpcCoeff.bin'
-     sensorlist_imager = 'viirs-m_j1'
+     if ( .not. imager_coeff ) then
+       spc_filename = trim(crtm_coeffs_path)//'viirs-m_j1.SpcCoeff.bin'
+       sensorlist_imager = 'viirs-m_j1'
+     endif
   elseif ( trim(jsatid) == 'n21' ) then
      spc_filename = trim(crtm_coeffs_path)//'viirs-m_n21.SpcCoeff.bin' 
      sensorlist_imager = 'viirs-m_n21'
      inquire(file=trim(spc_filename), exist=imager_coeff)
-     if ( .not. imager_coeff ) spc_filename = trim(crtm_coeffs_path)//'viirs-m_j2.SpcCoeff.bin'
-     sensorlist_imager = 'viirs-m_j2'
+     if ( .not. imager_coeff ) then
+       spc_filename = trim(crtm_coeffs_path)//'viirs-m_j2.SpcCoeff.bin'
+       sensorlist_imager = 'viirs-m_j2'
+     endif
   endif   
   inquire(file=trim(spc_filename), exist=imager_coeff)
   if ( imager_coeff ) then

--- a/src/gsi/read_cris.f90
+++ b/src/gsi/read_cris.f90
@@ -334,18 +334,14 @@ subroutine read_cris(mype,val_cris,ithin,isfcalc,rmesh,jsatid,gstime,&
      spc_filename = trim(crtm_coeffs_path)//'viirs-m_n20.SpcCoeff.bin' 
      sensorlist_imager = 'viirs-m_n20'
      inquire(file=trim(spc_filename), exist=imager_coeff)
-     if ( .not. imager_coeff ) then
-       spc_filename = trim(crtm_coeffs_path)//'viirs-m_j1.SpcCoeff.bin'
-       sensorlist_imager = 'viirs-m_j1'
-     endif
+     if ( .not. imager_coeff ) spc_filename = trim(crtm_coeffs_path)//'viirs-m_j1.SpcCoeff.bin'
+     sensorlist_imager = 'viirs-m_j1'
   elseif ( trim(jsatid) == 'n21' ) then
      spc_filename = trim(crtm_coeffs_path)//'viirs-m_n21.SpcCoeff.bin' 
      sensorlist_imager = 'viirs-m_n21'
      inquire(file=trim(spc_filename), exist=imager_coeff)
-     if ( .not. imager_coeff ) then
-       spc_filename = trim(crtm_coeffs_path)//'viirs-m_j2.SpcCoeff.bin'
-       sensorlist_imager = 'viirs-m_j2'
-     endif
+     if ( .not. imager_coeff ) spc_filename = trim(crtm_coeffs_path)//'viirs-m_j2.SpcCoeff.bin'
+     sensorlist_imager = 'viirs-m_j2'
   endif   
   inquire(file=trim(spc_filename), exist=imager_coeff)
   if ( imager_coeff ) then


### PR DESCRIPTION
**DUE DATE for merger of this PR into develop is 4/8/2024 (six weeks after PR creation).**

**Description**
Currently, when the soil analysis is used we turn off parallel read/write, since the parallel routines to read/write the soil states and increments have not been coded. However, the default in operations is to do parallel read/write (paranc=.true.).
This "feature add" enables writing land states read and write in parallel (or in serial as in the past) based on user config. 

Fixes #707

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

The 7 regression tests have passed on hera.

Start testing: Feb 26 16:52 UTC

1/7 Testing: global_4denvar
Test time = 2711.52 sec
Test Passed.

2/7 Testing: rtma
Test time = 1999.66 sec
Test Passed.

3/7 Testing: rrfs_3denvar_glbens
Test time = 3678.76 sec
Test Passed.

4/7 Testing: netcdf_fv3_regional
Test time = 672.00 sec
Test Passed.

5/7 Testing: hafs_4denvar_glbens
Test time = 1825.27 sec
Test Passed.

6/7 Testing: hafs_3denvar_hybens
Test time = 2484.58 sec
Test Passed.

7/7 Testing: global_enkf
Test time = 2749.58 sec
Test Passed.

End testing: Feb 26 21:21 UTC
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published