### PR TITLE
Update fix submodule (Rcov_crisn21) & GSI_BINARY_SOURCE_DIR

### DIFF
--- a/modulefiles/gsi_gaea.intel.lua
+++ b/modulefiles/gsi_gaea.intel.lua
@@ -31,7 +31,7 @@ local MKLROOT="/opt/intel/oneapi/mkl/2022.0.2/"
 prepend_path("LD_LIBRARY_PATH",pathJoin(MKLROOT,"lib/intel64"))
 pushenv("MKLROOT", MKLROOT)
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/lustre/f2/dev/role.epic/contrib/GSI_data/fix/20230911")
+pushenv("GSI_BINARY_SOURCE_DIR", "/lustre/f2/dev/role.epic/contrib/GSI_data/fix/20240208")
 
 setenv("CC","cc")
 setenv("FC","ftn")

--- a/modulefiles/gsi_hera.gnu.lua
+++ b/modulefiles/gsi_hera.gnu.lua
@@ -22,6 +22,6 @@ load("gsi_common")
 load(pathJoin("prod_util", prod_util_ver))
 load(pathJoin("openblas", openblas_ver))
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230911")
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20240208")
 
 whatis("Description: GSI environment on Hera with GNU Compilers")

--- a/modulefiles/gsi_hera.intel.lua
+++ b/modulefiles/gsi_hera.intel.lua
@@ -20,6 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20230911")
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20240208")
 
 whatis("Description: GSI environment on Hera with Intel Compilers")

--- a/modulefiles/gsi_hercules.intel.lua
+++ b/modulefiles/gsi_hercules.intel.lua
@@ -21,6 +21,6 @@ load("intel-oneapi-mkl/2022.2.1")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20230911")
+pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20240208")
 
 whatis("Description: GSI environment on Hercules with Intel Compilers")

--- a/modulefiles/gsi_jet.intel.lua
+++ b/modulefiles/gsi_jet.intel.lua
@@ -20,6 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 pushenv("FFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/mnt/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/gsi/20230911")
+pushenv("GSI_BINARY_SOURCE_DIR", "/mnt/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/gsi/20240208")
 
 whatis("Description: GSI environment on Jet with Intel Compilers")

--- a/modulefiles/gsi_orion.intel.lua
+++ b/modulefiles/gsi_orion.intel.lua
@@ -20,6 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20230911")
+pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20240208")
 
 whatis("Description: GSI environment on Orion with Intel Compilers")

--- a/modulefiles/gsi_s4.intel.lua
+++ b/modulefiles/gsi_s4.intel.lua
@@ -20,6 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-march=ivybridge")
 pushenv("FFLAGS", "-march=ivybridge")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/data/prod/glopara/fix/gsi/20230911")
+pushenv("GSI_BINARY_SOURCE_DIR", "/data/prod/glopara/fix/gsi/20240208")
 
 whatis("Description: GSI environment on S4 with Intel Compilers")

--- a/modulefiles/gsi_wcoss2.intel.lua
+++ b/modulefiles/gsi_wcoss2.intel.lua
@@ -46,6 +46,6 @@ load(pathJoin("ncio", ncio_ver))
 load(pathJoin("crtm", crtm_ver))
 load(pathJoin("ncdiag",ncdiag_ver))
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20230911")
+pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20240208")
 
 whatis("Description: GSI environment on WCOSS2")


### PR DESCRIPTION
**DUE DATE for merger of this PR into develop is 4/24/2024 (six weeks after PR creation).**

**Description**
The PR includes two changes
- update the hash for the `fix` submodule in order to pull correlated observation error file `Rcov_crisn21` into `fix/` when the GSI is built.
- update `GSI_BINARY_SOURCE_DIR` to point at 20240208

Fixes #714
Fixes #717

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
 - clone and build PR branch on WCOSS2, Hera, Orion and Hercules
 - run ctests on each platform
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
