### PR TITLE
 address Issue 712 : GSI built with debug mode failed in the global_4densvar 

### DIFF
--- a/src/gsi/cmake/gsiapp_compiler_flags_Intel_Fortran.cmake
+++ b/src/gsi/cmake/gsiapp_compiler_flags_Intel_Fortran.cmake
@@ -14,7 +14,7 @@ set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -fp-model strict")
 # DEBUG FLAGS
 ####################################################################
 
-set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -fp-model source -debug -ftrapuv -warn all,nointerfaces -check all,noarg_temp_created -fp-stack-check -fstack-protector")
+set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -init=snan,arrays -fp-model source -debug -ftrapuv -warn all,nointerfaces -check all,noarg_temp_created -fp-stack-check -fstack-protector")
 
 ####################################################################
 # LINK FLAGS

--- a/src/gsi/intjcmod.f90
+++ b/src/gsi/intjcmod.f90
@@ -103,7 +103,7 @@ subroutine intlimq(rval,sval,itbin)
   call gsi_bundlegetpointer(gsi_metguess_bundle(itbin),'q',ges_q_it,ier)
   if(ier/=0)return
  
-!$omp parallel do  schedule(dynamic,1) private(k,j,i,q)
+!$omp parallel do  schedule(dynamic,1) private(k,j,i,ii,q)
   do k = 1,nsig
      do j = 2,lon1+1
         do i = 2,lat1+1

--- a/src/gsi/read_nsstbufr.f90
+++ b/src/gsi/read_nsstbufr.f90
@@ -566,6 +566,7 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
            endif
 !
 !          Determine usage
+!
            ikx = 0
            do i = 1, nconvtype
               if(kx == ictype(i) .and. abs(icuse(i))== 1) ikx=i

--- a/src/gsi/read_nsstbufr.f90
+++ b/src/gsi/read_nsstbufr.f90
@@ -542,9 +542,9 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
               kx = 197
               sstoe = one
            elseif ( trim(subset) == 'NC031002' ) then                            ! TESAC
-              if (  tpf(1,1) >= one .and.  tpf(1,1) < 20.0_r_kind ) then
-                 zob = tpf(1,1)
-              elseif (  tpf(1,1) >= zero .and. tpf(1,1) < one ) then
+              if (  tpf2(1,1) >= one .and.  tpf2(1,1) < 20.0_r_kind ) then
+                 zob = tpf2(1,1)
+              elseif (  tpf2(1,1) >= zero .and. tpf2(1,1) < one ) then
                  zob = one
               endif
               kx = 198   
@@ -553,9 +553,9 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
               kx = 199                                                           ! classify argo & glider to be bathy type
               sstoe = r0_6
            elseif ( trim(subset) == 'NC031001' ) then                            ! BATHY
-              if (  tpf(1,1) >= one .and.  tpf(1,1) <= 20.0_r_kind ) then
-                 zob = tpf(1,1)
-              elseif (  tpf(1,1) >= zero .and. tpf(1,1) < one ) then
+              if (  tpf2(1,1) >= one .and.  tpf2(1,1) <= 20.0_r_kind ) then
+                 zob = tpf2(1,1)
+              elseif (  tpf2(1,1) >= zero .and. tpf2(1,1) < one ) then
                  zob = one
               endif
               kx = 199
@@ -566,7 +566,6 @@ subroutine read_nsstbufr(nread,ndata,nodata,gstime,infile,obstype,lunout, &
            endif
 !
 !          Determine usage
-!
            ikx = 0
            do i = 1, nconvtype
               if(kx == ictype(i) .and. abs(icuse(i))== 1) ikx=i


### PR DESCRIPTION
Resolves: #712
This PR aims to resolve issues reported in Issue [712,](https://github.com/NOAA-EMC/GSI/issues/712) identified during testing of global_4densvar.

1)The correction of the omitted private variable in the OpenMP directive within intlimq has addressed the reproducibility issue across runs using varying numbers of MPI processes.

2) The modification in read_nsstbufr.f90 is  to prevent the incorrect use of variables when they are undefined, which could potentially impact the results. While this fix stops the use of uninitialized variables (e.g., tpf), the correctness of this approach in terms of the algorithm requires verification by  experts on this. I hope @emilyhcliu could help confirm this as a reviewer of this PR. 

3)The addition of -init=snan to the Fortran debugging compile options is particularly beneficial for debugging purpose. This option aids in identifying the use of undefined floating-point variables, a type of error that is  difficult to trace and can lead to unexplained program behavior.