### PR TITLE
Updates for handling CrIS SWIR data 

### DIFF
--- a/src/gsi/qcmod.f90
+++ b/src/gsi/qcmod.f90
@@ -2456,14 +2456,14 @@ subroutine qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse,goessndr,airs
         if (passive_bc .and. iuse_rad(j)==-1) then
           if (lcloud .ge. kmax(i)) then
             if(.not.cris) then
-              if(luse)aivals(11,is)   = aivals(11,is) + one
+               if(luse)aivals(11,is)   = aivals(11,is) + one
             else if(cris) then
-              if(.not. cris_sw .and. wavenumber(i) < 2000.0) then
-                if(luse)aivals(11,is)   = aivals(11,is) + one
-              else if(cris_sw .and. wavenumber(i) >= 2000.0) then
-                if(luse)aivals(11,is)   = aivals(11,is) + one
-              end if
-            endif
+               if(.not. cris_sw .and. wavenumber(i) < 2000.0) then
+                 if(luse)aivals(11,is)   = aivals(11,is) + one
+               else if(cris_sw .and. wavenumber(i) >= 2000.0) then
+                 if(luse)aivals(11,is)   = aivals(11,is) + one
+               end if
+            end if
             varinv(i) = zero
             varinv_use(i) = zero
             if(id_qc(i) == igood_qc)id_qc(i)=ifail_cloud_qc
@@ -2513,15 +2513,12 @@ subroutine qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse,goessndr,airs
           if(abs(dts*ts(i)) > delta)then
 !           QC3 in statsrad
             if(.not.cris) then
-              if(luse .and. varinv(i) > zero) &
-                 aivals(10,is)   = aivals(10,is) + one
+              if(luse .and. varinv(i) > zero) aivals(10,is)   = aivals(10,is) + one
             else if(cris) then
               if(.not. cris_sw .and. wavenumber(i) < 2000.0) then
-                if(luse .and. varinv(i) > zero) &
-                   aivals(10,is)   = aivals(10,is) + one
+                 if(luse .and. varinv(i) > zero) aivals(10,is)   = aivals(10,is) + one
               else if(cris_sw .and. wavenumber(i) >= 2000.0) then
-                if(luse .and. varinv(i) > zero) &
-                   aivals(10,is)   = aivals(10,is) + one
+                 if(luse .and. varinv(i) > zero) aivals(10,is)   = aivals(10,is) + one
               end if
             end if
             varinv(i) = zero
@@ -2536,8 +2533,11 @@ subroutine qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse,goessndr,airs
        do i=1,nchanl
           if (ts(i) > 0.2_r_kind) then
            !             QC3 in statsrad
-            if(luse .and. varinv(i) > zero) &
-                aivals(10,is) = aivals(10,is) + one
+            if(.not. cris_sw .and. wavenumber(i) < 2000.0) then
+              if(luse .and. varinv(i) > zero) aivals(10,is) = aivals(10,is) + one
+            else if(cris_sw .and. wavenumber(i) >= 2000.0) then
+              if(luse .and. varinv(i) > zero) aivals(10,is) = aivals(10,is) + one
+            end if
             varinv(i) = zero
             if(id_qc(i) == igood_qc) id_qc(i) = ifail_sfcir_qc
           end if
@@ -2566,13 +2566,13 @@ subroutine qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse,goessndr,airs
               varinv(i) = zero
               if (  id_qc(i) == igood_qc ) id_qc(i) = ifail_tzr_qc
               if(.not.cris) then
-                 if(luse)aivals(13,is) = aivals(13,is) + one
-               else if(cris) then
-                 if(.not. cris_sw .and. wavenumber(i) < 2000.0) then
-                   if(luse) aivals(13,is)   = aivals(13,is) + one
-                 else if(cris_sw .and. wavenumber(i) >= 2000.0) then
-                   if(luse) aivals(13,is)   = aivals(13,is) + one
-                 end if
+                if(luse)aivals(13,is) = aivals(13,is) + one
+              else if(cris) then
+                if(.not. cris_sw .and. wavenumber(i) < 2000.0) then
+                  if(luse) aivals(13,is)   = aivals(13,is) + one
+                else if(cris_sw .and. wavenumber(i) >= 2000.0) then
+                  if(luse) aivals(13,is)   = aivals(13,is) + one
+                end if
               endif
            endif
          endif
@@ -2584,6 +2584,7 @@ subroutine qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse,goessndr,airs
   if (cenlatx < one) then
      if(.not. cris_sw) then
         if(luse)aivals(6,is) = aivals(6,is) + one
+     endif
      efact   = half*(cenlatx+one)
      do i=1,nchanl
         if(varinv(i) > tiny_r_kind) errf(i)=efact*errf(i)

--- a/src/gsi/qcmod.f90
+++ b/src/gsi/qcmod.f90
@@ -2199,6 +2199,7 @@ subroutine qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse,goessndr,airs
 
 
   real(r_kind) :: demisf,dtempf,efact,dtbf,term,cenlatx,sfchgtfact
+  real(r_kind) :: pangs_rad,solazi_rad,satazi_rad,relazi_rad,glint_rad,glint
   real(r_kind) :: sum1,sum2,sum3,tmp,dts,delta
   integer(i_kind) :: i,j,lcloud,m,isurface_chan
   integer(i_kind), dimension(nchanl) :: irday

--- a/src/gsi/qcmod.f90
+++ b/src/gsi/qcmod.f90
@@ -2330,7 +2330,7 @@ subroutine qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse,goessndr,airs
   cldp=r10*prsltmp(1)
 
 !  Cloud and aerosol detection routines (ECMWF)
-  if (cris .and. cris_cads .and. (.not. cris_sw)) then
+  if (cris .and. cris_cads) then
       I_Sensor_ID = 27
       chan_array = nuchan(ich)                  ! channel numbers
       tb_bc = tbc + tsim                        ! observation BT with bias correction
@@ -2382,7 +2382,7 @@ subroutine qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse,goessndr,airs
 
 ! compute cloud stats 
 ! If using CADS
-  if ((cris .and. cris_cads) .or. (iasi .and. iasi_cads) .or. (airs .and. airs_cads) .and. (.not. cris_sw)) then
+  if ((cris .and. cris_cads) .or. (iasi .and. iasi_cads) .or. (airs .and. airs_cads)) then
 
 !   Reject channels affected by clouds
     do i=1, nchanl

--- a/src/gsi/setuprad.f90
+++ b/src/gsi/setuprad.f90
@@ -369,6 +369,7 @@ contains
   real(r_kind) si_obs,si_fg                
 ! real(r_kind) si_mean                     
   real(r_kind) total_cloud_cover
+  real(r_kind) tref,errfl
 
   logical cao_flag                       
   logical hirs2,msu,goessndr,hirs3,hirs4,hirs,amsua,amsub,airs,hsb,goes_img,ahi,mhs,abi

--- a/src/gsi/setuprad.f90
+++ b/src/gsi/setuprad.f90
@@ -1450,7 +1450,7 @@ contains
               end if
            end do
 
-           if (.not. cris) then
+           if ((.not. cris) .or. (cris .and. cris_cads)) then
               cris_sw=.false.
               call qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse(n),goessndr,airs,cris,iasi, &
                  hirs,zsges,cenlat,frac_sea,pangs,trop5,zasat,sun_azimuth,sat_azimuth,tzbgr, &
@@ -1458,7 +1458,7 @@ contains
                  emissivity_k,ts,tsim,id_qc,aivals,errf,varinv,varinv_use,cld,cldp,kmax, & 
                  zero_irjaco3_pole(n),imager_cluster_fraction(:,n),imager_cluster_bt(:,:,n), &
                  imager_chan_stdev(:,n),imager_model_bt(:,n),cris_sw)
-           else if (cris) then
+           else if (cris .and. (.not. cris_cads)) then
             ! call qc_irsnd once using the LW channels for cloud detection for
             ! LW QC flags
               cris_sw=.false.

--- a/src/gsi/setuprad.f90
+++ b/src/gsi/setuprad.f90
@@ -213,6 +213,10 @@ contains
 !   2018-07-27  W. Gu   - code changes to reduce the round-off errors
 !   2019-03-13  eliu    - add components to handle precipitation-affected radiances 
 !   2019-03-13  eliu    - add calculation of scattering index for MHS/ATMS 
+!   2019-07-24  ejones  - add scene-dependent observation error for CrIS SW
+!   2019-07-24  ejones  - add capability to use different channel sets for cloud detection for CrIS
+!                         (i.e. use only LW channels for LW cloud detection and only SW channels for SW
+!                         cloud detection in qc_irsnd subroutine in qcmod.f90)
 !   2019-03-27  h. liu  - add ABI assimilation
 !   2019-08-20  zhu     - add flexibility to allow radiances being assimilated without bias correction
 !   2021-02-20  x.li    - add viirs
@@ -285,7 +289,8 @@ contains
       itime,ilon,ilat,ilzen_ang,ilazi_ang,iscan_ang,iscan_pos,iszen_ang,isazi_ang, &
       ifrac_sea,ifrac_lnd,ifrac_ice,ifrac_sno,itsavg, &
       izz,idomsfc,isfcr,iff10,ilone,ilate, &
-      isst_hires,isst_navy,idata_type,iclr_sky,itref,idtw,idtc,itz_tr
+      isst_hires,isst_navy,idata_type,iclr_sky,itref,idtw,idtc,itz_tr, &
+      get_crtm_temp_tl
   use qcmod, only: qc_ssmi,qc_geocsr,qc_ssu,qc_avhrr,qc_goesimg,qc_msu,qc_irsnd,qc_amsua,qc_mhs,qc_atms
   use crtm_interface, only: ilzen_ang2,iscan_ang2,iszen_ang2,isazi_ang2
   use clw_mod, only: calc_clw, ret_amsua, gmi_37pol_diff
@@ -351,6 +356,7 @@ contains
   real(r_kind) ys_bias_sst,cosza,val_obs
   real(r_kind) sstnv,sstcu,sstph,dtp_avh,dta,dqa
   real(r_kind) bearaz,sun_zenith,sun_azimuth
+  real(r_kind) sat_azimuth
 !  real(r_kind) sfc_speed,frac_sea,clw,tpwc,sgagl,clwp_amsua,tpwc_guess_retrieval
 !  real(r_kind) sfc_speed,frac_sea,clw,tpwc,sgagl,tpwc_guess_retrieval
   real(r_kind) sfc_speed,frac_sea,tpwc_obs,sgagl,tpwc_guess_retrieval
@@ -376,6 +382,7 @@ contains
   logical in_curbin, in_anybin, save_jacobian
   logical account_for_corr_obs
   logical,dimension(nobs):: zero_irjaco3_pole
+  logical cris_sw   ! for CrIS SW processing
 
 ! Declare local arrays
 
@@ -409,6 +416,8 @@ contains
   real(r_kind) :: clw_guess,clw_guess_retrieval,ciw_guess,rain_guess,snow_guess,clw_avg
   real(r_kind),dimension(:), allocatable :: rsqrtinv
   real(r_kind),dimension(:), allocatable :: rinvdiag
+  real(r_kind),dimension(:), allocatable :: tl_tbobs,errf_LW,errf_SW
+  real(r_kind),dimension(:), allocatable :: varinv_LW,varinv_SW,varinv_useLW,varinv_useSW
 
 !for GMI (dual scan angles)
   real(r_kind),dimension(nchanl):: emissivity2,ts2, emissivity_k2,tsim2
@@ -421,6 +430,7 @@ contains
   integer(i_kind),dimension(nchanl):: ich,id_qc,ich_diag
   integer(i_kind),dimension(nchanl):: kmax
   integer(i_kind),allocatable,dimension(:) :: sc_index
+  integer(i_kind),allocatable,dimension(:) :: id_qcLW,id_qcSW
   integer(i_kind)  :: state_ind, nind, nnz
 
   logical,dimension(jpch_rad) :: channel_passive
@@ -490,6 +500,7 @@ contains
 ! Initialize logical flags for satellite platform
 
   cao_flag   = .false.     
+  cris_sw    = .false.
   hirs2      = obstype == 'hirs2'
   hirs3      = obstype == 'hirs3'
   hirs4      = obstype == 'hirs4'
@@ -720,6 +731,26 @@ contains
         if (no85GHz .and. mype == 0) write(6,*) &
            'SETUPRAD: using no85GHZ workaround for SSM/I ',isis
      endif
+  endif
+
+! Allocate some arrays for use with CrIS  - EEJ
+  tref = zero
+  errfl = zero
+  if (cris) then
+     allocate(tl_tbobs(nchanl),errf_LW(nchanl),errf_SW(nchanl))
+     allocate(varinv_LW(nchanl),varinv_SW(nchanl),varinv_useLW(nchanl),varinv_useSW(nchanl))
+     allocate(id_qcLW(nchanl),id_qcSW(nchanl))
+     do i=1,nchanl
+        tl_tbobs(i)=zero
+        varinv_LW(i)=zero
+        varinv_SW(i)=zero
+        varinv_useLW(i)=zero
+        varinv_useSW(i)=zero
+        errf_LW(i)=zero
+        errf_SW(i)=zero
+        id_qcLW=-999
+        id_qcSW=-999
+     end do
   endif
 
 !  Find number of channels written to diag file
@@ -1322,6 +1353,7 @@ contains
         do i=1,nchanl
            error0(i) = tnoise(i)
            errf0(i) = error0(i)
+           if(cris) tl_tbobs(i) = error0(i)
         end do
 
 !       Assign observation error for all-sky radiances 
@@ -1332,6 +1364,22 @@ contains
               call radiance_ex_obserr_gmi(radmod,nchanl,clw_obs,clw_guess_retrieval,tnoise,tnoise_cld,error0) 
            end if
         end if
+
+!       If sensor is CrIS, get scene-dependent instrument noise (important in
+!       short-wave) from CRTM to appropriately inflate obs error according to
+!       brightness temperature. Only do for channels in the 431 set with
+!       wavenumber .ge. 2165.63 and .lt. 2386.52 (these seem generally
+!       colder and more noisy)
+        if (cris) then
+           tref = 280.0_r_kind
+           errfl = 0.5_r_kind    ! Error floor or minimum inflation to add to scene-dep error
+           call get_crtm_temp_tl(nchanl,sc_index,tb_obs,error0,tref,tl_tbobs)
+           do i=1,nchanl
+              if (wavenumber(i) > 2165.0 .and. wavenumber(i) < 2386.0) then
+                 error0(i)     = sqrt(tl_tbobs(i)**2 + errfl**2)
+              endif
+           end do
+        endif
 
         do i=1,nchanl
            mm=ich(i)
@@ -1359,6 +1407,10 @@ contains
 
            frac_sea=data_s(ifrac_sea,n)
 
+!          pass solar and satellite azimuth for sun glint
+           sun_azimuth=data_s(isazi_ang,n)
+           sat_azimuth=data_s(ilazi_ang,n)
+
 !  NOTE:  The qc in qc_irsnd uses the inverse squared obs error.
 !     The loop below loads array varinv_use accounting for whether the 
 !     cloud detection flag is set.  Array
@@ -1373,13 +1425,70 @@ contains
               else
                  varinv_use(i) = zero
               end if
+!    Set up error and QC flag arrays for CrIS LW and SW channels to allow
+!    for the use of different channel selections for cloud detection in QC
+              if (cris) then
+                 varinv_useLW(i) = zero
+                 varinv_useSW(i) = zero
+                 id_qcLW(i) = id_qc(i)
+                 id_qcSW(i) = id_qc(i)
+                 varinv_LW(i) = varinv(i)
+                 varinv_SW(i) = varinv(i)
+                 errf_LW(i) = errf(i)
+                 errf_SW(i) = errf(i)
+                 if (varinv(i) < tiny_r_kind) then
+                    varinv_useLW(i) = zero
+                    varinv_useSW(i) = zero
+                 else
+                    if ((icld_det(m)>0) .and. (wavenumber(i)<2000.0)) then
+                       varinv_useLW(i) = varinv(i)
+                    else if ((icld_det(m)>0) .and. (wavenumber(i)>=2000.0)) then
+                       varinv_useSW(i) = varinv(i)
+                    end if
+                 end if
+              end if
            end do
 
-           call qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse(n),goessndr,airs,cris,iasi,      &
-              hirs,zsges,cenlat,frac_sea,pangs,trop5,zasat,tzbgr,tsavg5,tbc,tb_obs,tbcnob,tnoise, &
-              wavenumber,ptau5,prsltmp,tvp,temp,wmix,chan_level,emissivity_k,ts,tsim,         &
-              id_qc,aivals,errf,varinv,varinv_use,cld,cldp,kmax,zero_irjaco3_pole(n),     &
-              imager_cluster_fraction(:,n), imager_cluster_bt(:,:,n), imager_chan_stdev(:,n),imager_model_bt(:,n))
+           if (.not. cris) then
+              cris_sw=.false.
+              call qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse(n),goessndr,airs,cris,iasi, &
+                 hirs,zsges,cenlat,frac_sea,pangs,trop5,zasat,sun_azimuth,sat_azimuth,tzbgr, &
+                 tsavg5,tbc,tb_obs,tbcnob,tnoise,wavenumber,ptau5,prsltmp,tvp,temp,wmix,chan_level, &
+                 emissivity_k,ts,tsim,id_qc,aivals,errf,varinv,varinv_use,cld,cldp,kmax, & 
+                 zero_irjaco3_pole(n),imager_cluster_fraction(:,n),imager_cluster_bt(:,:,n), &
+                 imager_chan_stdev(:,n),imager_model_bt(:,n),cris_sw)
+           else if (cris) then
+            ! call qc_irsnd once using the LW channels for cloud detection for
+            ! LW QC flags
+              cris_sw=.false.
+              call qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse(n),goessndr,airs,cris,iasi, &
+                 hirs,zsges,cenlat,frac_sea,pangs,trop5,zasat,sun_azimuth,sat_azimuth,tzbgr, &
+                 tsavg5,tbc,tb_obs,tbcnob,tnoise,wavenumber,ptau5,prsltmp,tvp,temp,wmix,chan_level, &
+                 emissivity_k,ts,tsim,id_qcLW,aivals,errf_LW,varinv_LW,varinv_useLW,cld,cldp,kmax, &
+                 zero_irjaco3_pole(n),imager_cluster_fraction(:,n),imager_cluster_bt(:,:,n), &
+                 imager_chan_stdev(:,n),imager_model_bt(:,n),cris_sw)
+            ! call qc_irsnd again using the SW channels for cloud detection for
+            ! SW QC flags
+              cris_sw=.true.
+              call qc_irsnd(nchanl,is,ndat,nsig,ich,sea,land,ice,snow,luse(n),goessndr,airs,cris,iasi, &
+                 hirs,zsges,cenlat,frac_sea,pangs,trop5,zasat,sun_azimuth,sat_azimuth,tzbgr, &
+                 tsavg5,tbc,tb_obs,tbcnob,tnoise,wavenumber,ptau5,prsltmp,tvp,temp,wmix,chan_level, &
+                 emissivity_k,ts,tsim,id_qcSW,aivals,errf_SW,varinv_SW,varinv_useSW,cld,cldp,kmax, &
+                 zero_irjaco3_pole(n),imager_cluster_fraction(:,n),imager_cluster_bt(:,:,n), &
+                 imager_chan_stdev(:,n),imager_model_bt(:,n),cris_sw)
+            ! combine intermediate qc flag arrays
+              do i=1,nchanl
+                 if (wavenumber(i)<2000.0) then
+                    id_qc(i)=id_qcLW(i)
+                    varinv(i)=varinv_LW(i)
+                    errf(i)=errf_LW(i)
+                 else if (wavenumber(i)>=2000.0) then
+                    id_qc(i)=id_qcSW(i)
+                    varinv(i)=varinv_SW(i)
+                    errf(i)=errf_SW(i)
+                 end if
+              end do
+           end if
 
 !  --------- MSU -------------------
 !       QC MSU data
@@ -2184,6 +2293,16 @@ contains
 ! Deallocate arrays
   deallocate(diagbufchan)
   deallocate(sc_index)
+
+  if(allocated(tl_tbobs)) deallocate(tl_tbobs)
+  if(allocated(varinv_LW)) deallocate(varinv_LW)
+  if(allocated(varinv_SW)) deallocate(varinv_SW)
+  if(allocated(varinv_useLW)) deallocate(varinv_useLW)
+  if(allocated(varinv_useSW)) deallocate(varinv_useSW)
+  if(allocated(errf_LW)) deallocate(errf_LW)
+  if(allocated(errf_SW)) deallocate(errf_SW)
+  if(allocated(id_qcLW)) deallocate(id_qcLW)
+  if(allocated(id_qcSW)) deallocate(id_qcSW)
 
   if (rad_diagsave .and. nchanl_diag > 0) then
      if (netcdf_diag) call nc_diag_write


### PR DESCRIPTION
**Description**

This is a revival of a previous pull request, which was closed pending the inclusion of the option for some CADS processing for hyperspectral IR observations.

 These updates have been made to enhance the processing of CrIS SWIR observations:

- Allows for CrIS SWIR channels to be used in cloud detection for CrIS SWIR observations (while keeping current functionality to use CrIS LWIR channels for CrIS LWIR and MWIR cloud detection; this is only done if the CADS cloud detection is not used)
- Modifies QC for CrIS SWIR observations to replace a surface check for a sun glint check
- Adds functionality for the computation and use of a scene-dependent observation error
- Adds an additional low-peaking channel (an assimilated CrIS MWIR channel) to the CrIS reader that can be used as a reference if the hard-coded LWIR channel is not present

Fixes #546 


**Type of change**

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


**How Has This Been Tested?**

Experiments were run with these updates on Orion (and with earlier implementations of the updates on Hera). A summary of GSI enhancements and experiment results can be found here - 
[GSImeeting_20230509_ejones.pptx](https://github.com/NOAA-EMC/GSI/files/11899913/GSImeeting_20230509_ejones.pptx)
 
These changes should not impact results if CrIS SWIR channels are not actively assimilated.

Regression tests were performed on Hera and can be found in /scratch2/NESDIS/nesdis-rdo1/Erin.Jones/regression_testing/tests_20240318

Results:
```
1/7 Test #3: [=[rrfs_3denvar_glbens]=] ........   Passed  731.45 sec
2/7 Test #4: [=[netcdf_fv3_regional]=] ........   Passed  968.47 sec
3/7 Test #7: [=[global_enkf]=] ................   Passed  1176.66 sec
4/7 Test #2: [=[rtma]=] .......................   Passed  1212.24 sec
5/7 Test #6: [=[hafs_3denvar_hybens]=] ........   Passed  1344.18 sec
6/7 Test #5: [=[hafs_4denvar_glbens]=] ........   Passed  1649.99 sec
7/7 Test #1: [=[global_4denvar]=] .............   Passed  1987.23 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) = 1987.26 sec  
```

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published