### PR TITLE
Update Jet modulefiles to Rocky8

### DIFF
--- a/modulefiles/gsi_jet.intel.lua
+++ b/modulefiles/gsi_jet.intel.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local python_ver=os.getenv("python_ver") or "3.11.6"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

- Jet has been upgraded to the Rocky8 Linux OS and present module file no longer works
- Update Jet module file to use Rocky8 installation of spack-stack;

Fixes #732
Refs NOAA-EMC/global-workflow#2377

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

This change affects only Jet, there is no need to test on other systems
Cycled experiments (48+ hours) at resolutions
- [x] 96/48 on xjet and kjet
- [x] 192/96 on kjet
- [x] 384/192 on kjet
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published