### PR TITLE
reorder correlated error setup checks

### DIFF
--- a/src/gsi/correlated_obsmod.F90
+++ b/src/gsi/correlated_obsmod.F90
@@ -961,14 +961,18 @@ subroutine upd_varch_
             enddo
             nchanl1=jc
 
-            if(nchanl1==0) call die(myname_,' improperly set GSI_BundleErrorCov')
             if(.not.amiset_(GSI_BundleErrorCov(itbl))) then 
-               if (iamroot_) write(6,*) 'WARNING: Error Covariance not set for ',trim(idnames(itbl))
+               if (iamroot_) write(6,*) trim(myname_), ' WARNING: Error Covariance not set for ',trim(idnames(itbl))
                cycle read_tab
             endif
 
             nch_active=GSI_BundleErrorCov(itbl)%nch_active
-            if(nch_active<0) return
+            if(nch_active<0) then
+               if (iamroot_) write(6,*) trim(myname_), ' WARNING: No active channels for ',trim(idnames(itbl))
+               return
+            endif
+            
+            if(nchanl1==0) call die(myname_,' improperly set GSI_BundleErrorCov')            
 
             if(GMAO_ObsErrorCov)then
                do jj=1,nch_active


### PR DESCRIPTION
**Description**
g-w issue [#2507](https://github.com/NOAA-EMC/global-workflow/issues/2507) flagged a `gsi.x` failure related to correlated error in a historical case.  Rearranging the correlated error setup checks allows `gsi.x` to successfully run the historical case.

Fixes #735

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested?**
Two tests have been conducted
1. Run failed 2021032418 case using updated `gsi.x`.  GSI run to completion
2. Run ctests on Hera.  All tests pass.
```
Test project /scratch1/NCEPDEV/da/Russ.Treadon/git/gsi/develop_test/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_glbens
    Start 4: netcdf_fv3_regional
    Start 5: hafs_4denvar_glbens
    Start 6: hafs_3denvar_hybens
    Start 7: global_enkf
1/7 Test #4: netcdf_fv3_regional ..............   Passed  1209.16 sec
2/7 Test #3: rrfs_3denvar_glbens ..............Passed  1214.33 sec
3/7 Test #7: global_enkf ......................   Passed  1416.07 sec
4/7 Test #2: rtma .............................   Passed  1811.61 sec
5/7 Test #5: hafs_4denvar_glbens ..............   Passed  1887.12 sec
6/7 Test #6: hafs_3denvar_hybens ..............   Passed  1887.89 sec
7/7 Test #1: global_4denvar ...................   Passed  2468.95 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) = 2468.98 sec
```
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
