### PR TITLE
nread bug in read_radar.f90

### DIFF
--- a/src/gsi/read_radar.f90
+++ b/src/gsi/read_radar.f90
@@ -907,6 +907,7 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
      end do superobs
 
      close(lnbufr)     ! A simple unformatted fortran file should not be mixed with a bufr I/O
+     nread=nsuper2_kept
 
      LEVEL_TWO_READ_2: if(loop==0 .and. sis=='l2rw') then      
         write(6,*)'READ_RADAR:  ',trim(outmessage),' reached eof on 2/2.5/3 superob radar file'
@@ -2151,6 +2152,7 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
 
   end if
 
+  if (trim(infile) == 'tldplrbufr' .and. trim(infile) == 'tldplrso') then
   erad = rearth
   thiserr=5.0_r_kind
 
@@ -2190,6 +2192,7 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
   naftswp=0
   nfore=0
   naft=0
+  end if
 
   xscale=100._r_kind
   xscalei=one/xscale

--- a/src/gsi/read_radar.f90
+++ b/src/gsi/read_radar.f90
@@ -2152,7 +2152,6 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
 
   end if
 
-  if (trim(infile) == 'tldplrbufr' .and. trim(infile) == 'tldplrso') then
   erad = rearth
   thiserr=5.0_r_kind
 
@@ -2178,7 +2177,6 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
   ibadstaheight=0
   notgood=0
   notgood0=0
-  nread=0
   ntdrvr_in=0
   ntdrvr_kept=0
   ntdrvr_thin1=0
@@ -2192,7 +2190,6 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
   naftswp=0
   nfore=0
   naft=0
-  end if
 
   xscale=100._r_kind
   xscalei=one/xscale
@@ -2525,7 +2522,7 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
      end do ! end of loop, reading TDR so data files
      close(lnbufr)
 
-  else
+  else if (trim(infile) == 'tldplrbufr' ) then
 
      nswptype=0
      nmrecs=0


### PR DESCRIPTION

<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
In read_radar.f90, the value of nread should be "nsuper2_kept" and shouldn't be reset to zero after processing TDR data.

Resolves #737

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published