### PR TITLE
Update fix files to include the *_CLDDET.NL files for CADS

### DIFF
--- a/regression/global_4denvar.sh
+++ b/regression/global_4denvar.sh
@@ -128,6 +128,8 @@ errtable=$fixgsi/prepobs_errtable.global
 aeroinfo=$fixgsi/global_aeroinfo.txt
 atmsbeaminfo=$fixgsi/atms_beamwidth.txt
 cloudyinfo=$fixgsi/cloudy_radiance_info.txt
+cris_clddet=$fixgsi/CRIS_CLDDET.NL
+iasi_clddet=$fixgsi/IASI_CLDDET.NL
 
 emiscoef_IRwater=$fixcrtm/Nalli.IRwater.EmisCoeff.bin
 emiscoef_IRice=$fixcrtm/NPOESS.IRice.EmisCoeff.bin
@@ -169,6 +171,8 @@ $ncp $errtable ./errtable
 $ncp $aeroinfo ./aeroinfo
 $ncp $atmsbeaminfo ./atms_beamwidth.txt
 $ncp $cloudyinfo   ./cloudy_radiance_info.txt
+$ncp $cris_clddet ./CRIS_CLDDET.NL
+$ncp $iasi_clddet ./IASI_CLDDET.NL
 
 $ncp $bufrtable ./prepobs_prep.bufrtable
 $ncp $bftab_sst ./bftab_sstphr

--- a/regression/regression_namelists.sh
+++ b/regression/regression_namelists.sh
@@ -68,7 +68,7 @@ export gsi_namelist="
    dfact=0.75,dfact1=3.0,noiqc=.true.,oberrflg=.false.,c_varqc=0.04,
    use_poq7=.true.,qc_noirjaco3_pole=.true.,vqc=.false.,nvqc=.true.,hub_norm=.true.,
    aircraft_t_bc=.true.,biaspredt=1.0e5,upd_aircraft=.true.,cleanup_tail=.true.,
-   tcp_width=70.0,tcp_ermax=7.35,
+   tcp_width=70.0,tcp_ermax=7.35,cris_cads=.true.,iasi_cads=.true.,
    $OBSQC
  /
  &OBS_INPUT


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
The new infrared cloud and aerosol detection software has several tunable parameters that will be specific to different instruments (AIRS, CrIS, IASI).  These files are read by the GSI and used for the specific instrument.  These files are the cloud detection parameters derived for the specific instruments.  

Fixes #739 

**Type of change**
- [ ] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
I have been testing and tuning these *_CLDDET.NL files within a recent version of the global-workflow on Hera.  For this specific PR, I pointed the FIXgsi variable within the global workflow to the fix directory within this branch.  Bit identical cost functions were produced.  Both gdasanal tests set CRIS_CADS=.true. and IASI_CADS=.true. which uses the *_CLDDET.NL files.  The current ctests do not use these new files. 

control:
FIXgsi=/scratch1/NCEPDEV/jcsda/Jim.Jung/noscrub/global-workflow/fix/gsi
cost,grad,step,b,step? =   1   0  1.572082981537153479E+06  5.162285845468648404E+03  8.603064812549240381E-01  0.000000000000000000E+00  good
cost,grad,step,b,step? =   2 150  1.163641044648056850E+06  8.899223101760822985E+00  1.077442122849054051E+00  8.917117178616245088E-01  good

new gsi branch
FIXgsi=/scratch1/NCEPDEV/jcsda/Jim.Jung/noscrub/GSI_CADS-fix/fix
cost,grad,step,b,step? =   1   0  1.572082981537153479E+06  5.162285845468648404E+03  8.603064812549240381E-01  0.000000000000000000E+00  good
cost,grad,step,b,step? =   2 150  1.163641044648056850E+06  8.899223101760822985E+00  1.077442122849054051E+00  8.917117178616245088E-01  good

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published