### PR TITLE
Add module file to compile on AWS

### DIFF
--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -4,15 +4,15 @@ help([[
 prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
 
+local python_ver=os.getenv("python_ver") or "3.10.13"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.3.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.3.0"
-local stack_python_ver=os.getenv("stack_python_ver") or "3.11.6"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
-load(pathJoin("python", stack_python_ver))
+load(pathJoin("python", python_ver))
 load(pathJoin("cmake", cmake_ver))
 
 load("gsi_common")
@@ -24,3 +24,5 @@ pushenv("FFLAGS", "-xHOST")
 --pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20240208")
 --pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20240208")
 pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/Wei.Huang/data/hack-orion/fix/gsi/20240208")
+
+whatis("Description: GSI environment on NOAA Cloud with Intel Compilers")

--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -1,0 +1,26 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.3.0"
+local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.3.0"
+local stack_python_ver=os.getenv("stack_python_ver") or "3.11.6"
+local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+load(pathJoin("python", stack_python_ver))
+load(pathJoin("cmake", cmake_ver))
+
+load("gsi_common")
+load(pathJoin("prod_util", prod_util_ver))
+
+pushenv("CFLAGS", "-xHOST")
+pushenv("FFLAGS", "-xHOST")
+
+--pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20240208")
+--pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20240208")
+pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/Wei.Huang/data/hack-orion/fix/gsi/20240208")

--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -1,7 +1,6 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
 
 local python_ver=os.getenv("python_ver") or "3.10.13"
@@ -21,8 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
---pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20240208")
---pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20240208")
 pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/Wei.Huang/data/hack-orion/fix/gsi/20240208")
 
 whatis("Description: GSI environment on NOAA Cloud with Intel Compilers")

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -75,6 +75,10 @@ elif [[ $MACHINE_ID = discover* ]]; then
     export PATH=$PATH:$SPACK_ROOT/bin
     . $SPACK_ROOT/share/spack/setup-env.sh
 
+elif [[ $MACHINE_ID = noaacloud* ]]; then
+    # We are on NOAA Cloud
+    module purge
+
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2
 fi


### PR DESCRIPTION
Add module file to compile on AWS.

Resolves #741 

This only change the ush/module-setup.sh,
and add a module file for AWS.

- [x ] New feature (non-breaking change which adds functionality)


- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code