### PR TITLE
 A quick fix for incorrect usage of real(i_kind) in mg_input.f90 

### DIFF
--- a/src/mgbf/mg_input.f90
+++ b/src/mgbf/mg_input.f90
@@ -57,7 +57,7 @@ integer(i_kind),intent(in):: imin,jmin
 integer(i_kind),intent(in):: imax0
 integer(i_kind),intent(in):: ampl
 real(r_kind),dimension(imin:imax,jmin:jmax),intent(out):: V
-real(i_kind):: ng,mg,L,m,n
+integer(i_kind):: ng,mg,L,m,n
 !-----------------------------------------------------------------------
 
      do m=imin,jmax
@@ -134,7 +134,7 @@ integer(i_kind),intent(in):: imax,jmax,lmax
 integer(i_kind),intent(in):: imax0
 integer(i_kind),intent(in):: ampl,incrm
 real(r_kind),dimension(lmin:lmax,imin:imax,jmin:jmax),intent(out):: V
-real(i_kind):: ng,mg,L,m,n
+integer(i_kind):: ng,mg,L,m,n
 !-----------------------------------------------------------------------
 
    do l=lmin,lmax


### PR DESCRIPTION

**Description**
 A quick fix for incorrect usage of real(i_kind) in mg_input.f90 , which was identified by D. Kokron.
Fixes #757 
 Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
The building succeeded. And the changed code mg_input.f90 is not used by other codes in the current GSI and hence the change hadn't and would not affect any GSI runs.  

Coauthor : D. Kokron