### PR TITLE
update path to global ctest model data

### DIFF
--- a/regression/global_4denvar.sh
+++ b/regression/global_4denvar.sh
@@ -61,7 +61,7 @@ suffix=tm00.bufr_d
 dumpges=gdas
 COMROOTgfs=$casesdir/gfs/prod
 datobs=$COMROOTgfs/$dumpobs.$PDYa/${cyca}/obs
-dathis=$COMROOTgfs/$dumpges.$PDYg/${cycg}/model_data/atmos/history
+dathis=$COMROOTgfs/$dumpges.$PDYg/${cycg}/model/atmos/history
 datanl=$COMROOTgfs/gdas.$PDYg/${cycg}/analysis/atmos
 datens=$COMROOTgfs/enkfgdas.$PDYg/${cycg}
 
@@ -291,7 +291,7 @@ $nln $dathis/${prefix_ges}.atmf007.nc         ./sigf07
 $nln $dathis/${prefix_ges}.atmf008.nc         ./sigf08
 $nln $dathis/${prefix_ges}.atmf009.nc         ./sigf09
 
-$nln $datens/ensstat/model_data/atmos/history/${prefix_ens}.sfcf006.ensmean.nc         ./sfcf06_anlgrid
+$nln $datens/ensstat/model/atmos/history/${prefix_ens}.sfcf006.ensmean.nc         ./sfcf06_anlgrid
 
 export ENS_PATH='./ensemble_data/'
 mkdir -p ${ENS_PATH}
@@ -301,7 +301,7 @@ for fh in $flist; do
     imem=1
     while [[ $imem -le $NMEM_ENKF ]]; do
 	member="mem"`printf %03i $imem`
-	$nln $datens/$member/model_data/atmos/history/$sigens ${ENS_PATH}sigf${fh}_ens_${member}
+	$nln $datens/$member/model/atmos/history/$sigens ${ENS_PATH}sigf${fh}_ens_${member}
 	(( imem = $imem + 1 ))
     done
 done

--- a/regression/global_enkf.sh
+++ b/regression/global_enkf.sh
@@ -163,13 +163,13 @@ nfhrs=`echo $IAUFHRS_ENKF | sed 's/,/ /g'`
 for fhr in $nfhrs; do
     for imem in $(seq 1 $NMEM_ENKF); do
 	memchar="mem"$(printf %03i $imem)
-	$nln $datens/$memchar/model_data/atmos/history/${prefix_ens}.atmf00${fhr}.nc sfg_${global_adate}_fhr0${fhr}_${memchar}
+	$nln $datens/$memchar/model/atmos/history/${prefix_ens}.atmf00${fhr}.nc sfg_${global_adate}_fhr0${fhr}_${memchar}
         if [ $cnvw_option = ".true." ]; then
-            $nln $datens/$memchar/model_data/atmos/history/${prefix_ens}sfcf00${fhr}.nc sfgsfc_${global_adate}_fhr0${fhr}_${memchar}
+            $nln $datens/$memchar/model/atmos/history/${prefix_ens}sfcf00${fhr}.nc sfgsfc_${global_adate}_fhr0${fhr}_${memchar}
         fi
 	(( imem = $imem + 1 ))
     done
-    $nln $datens/ensstat/model_data/atmos/history/${prefix_ens}.atmf00${fhr}.ensmean.nc sfg_${global_adate}_fhr0${fhr}_ensmean
+    $nln $datens/ensstat/model/atmos/history/${prefix_ens}.atmf00${fhr}.ensmean.nc sfg_${global_adate}_fhr0${fhr}_ensmean
     if [ $cnvw_option = ".true." ]; then
         $nln $datens/${prefix_ens}.sfcf00${fhr}.ensmean.nc sfgsfc_${global_adate}_fhr0${fhr}_ensmean
     fi


### PR DESCRIPTION
**Description**
NCO requires `model_data` be replaced by `model` in COM paths.  This PR updates the paths to input data for global GSI ctests to conform with this standard.

Resolves #761

**Type of change**
- [x] Maintenance

**How Has This Been Tested?**
Run global ctests on Dogwood, Hera, and Hercules
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes