### PR TITLE
fix for cris-fsr memory corruption (issue #755)

### DIFF
--- a/src/gsi/correlated_obsmod.F90
+++ b/src/gsi/correlated_obsmod.F90
@@ -422,7 +422,7 @@ logical :: corr_obs
       ErrorCov%nch_active = coun
       if (.not.GMAO_ObsErrorCov) ErrorCov%nctot = nctot
       call create_(coun,ErrorCov)
-      allocate(indxRf(nch_active),indxR(nch_active),Rcov(nctot,nctot))
+      allocate(indxRf(coun),indxR(nch_active),Rcov(nctot,nctot))
 
 !     Read GSI-like channel numbers used in estimating R for this instrument
       read(lu,IOSTAT=ioflag) indxR


### PR DESCRIPTION
one line change from @jderber-NOAA to fix memory corruption issue in correlated_obsmod.F90 for cris-fsr data found in reanalysis scout runs.  Detailed description found in issue #755.

Resolves #755

  
**Checklist**

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ x] Any dependent changes have been merged and published