### PR TITLE
fix a bug in deter_sfc_gmi (#778)

### DIFF
--- a/src/gsi/deter_sfc_mod.f90
+++ b/src/gsi/deter_sfc_mod.f90
@@ -1410,7 +1410,7 @@ subroutine deter_sfc_gmi(dlat_earth,dlon_earth,isflg)
      n_grid=int(40000 / grid_dist) + 1
      klatn = max(klat1 - n_grid, 1)
      klonn = klon1 - n_grid
-     if (klonn < 0)  klonn = nlon_sfc - klonn
+     if (klonn < 1)  klonn = nlon_sfc - klonn
      klatpn = min((klat1 + n_grid), nlat_sfc)
      klonpn = klon1 + n_grid
      if (klonpn > nlon_sfc)  klonpn = klonpn - nlon_sfc


### PR DESCRIPTION

**Description**

To fix a bug  in deter_sfc_gmi which is dissed in detail in the issue #778 Debug gsi.x aborts in deter_sfc_gmi with invalid array index

changed a check for the subscript of  an array. 

Resolves #778 

**Type of change**

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published