### PR TITLE
Recover the capability of handling model fields from operation gfs.v16.3

### DIFF
--- a/src/gsi/general_read_gfsatm.f90
+++ b/src/gsi/general_read_gfsatm.f90
@@ -3588,99 +3588,99 @@ subroutine general_read_gfsatm_allhydro_nc(grd,sp_a,filename,uvflag,vordivflag,z
           if ( icount == icm .or. k==nlevs) then
              call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &
                   g_ql,g_qi,g_qr,g_qs,g_qg,icount,iflag,ilev,work,uvflag,vordivflag,g_ni,g_nr)
-      endif
-   enddo ! do k=1,nlevs
-
-   do k=1,nlevs
-      icount=icount+1
-      iflag(icount)=15
-      ilev(icount)=k
-      kr = levs+1-k ! netcdf is top to bottom, need to flip
-
-      if (mype==mype_use(icount)) then
-         call read_vardata(filges, 'nccice', rwork3d0, nslice=kr, slicedim=3)
-         ! cloud ice water number concentration.
-         if ( diff_res ) then
-            grid_b=rwork3d0(:,:,1)
-            vector(1)=.false.
-            call fill2_ns(grid_b,grid_c(:,:,1),latb+2,lonb)
-            call g_egrid2agrid(p_high,grid_c,grid2,1,1,vector)
-            do kk=1,grd%itotsub
-               i=grd%ltosi_s(kk)
-               j=grd%ltosj_s(kk)
-               work(kk)=grid2(i,j,1)
-            enddo
-         else
-            grid=rwork3d0(:,:,1)
-            call general_fill_ns(grd,grid,work)
-         endif
-      endif
-      if ( icount == icm .or. k==nlevs ) then
-         call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &
-              g_ql,g_qi,g_qr,g_qs,g_qg,icount,iflag,ilev,work,uvflag,vordivflag,g_ni,g_nr)
-      endif
-   enddo ! do k=1,nlevs
-
-   do k=1,nlevs
-      icount=icount+1
-      iflag(icount)=16
-      ilev(icount)=k
-      kr = levs+1-k ! netcdf is top to bottom, need to flip
-
-      if (mype==mype_use(icount)) then
-         call read_vardata(filges, 'nconrd', rwork3d0, nslice=kr, slicedim=3)
-         ! rain number concentration.
-         if ( diff_res ) then
-            grid_b=rwork3d0(:,:,1)
-            vector(1)=.false.
-            call fill2_ns(grid_b,grid_c(:,:,1),latb+2,lonb)
-            call g_egrid2agrid(p_high,grid_c,grid2,1,1,vector)
-            do kk=1,grd%itotsub
-               i=grd%ltosi_s(kk)
-               j=grd%ltosj_s(kk)
-               work(kk)=grid2(i,j,1)
-            enddo
-         else
-            grid=rwork3d0(:,:,1)
-            call general_fill_ns(grd,grid,work)
-         endif
-      endif
-      if ( icount == icm .or. k==nlevs) then
-         call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &
-              g_ql,g_qi,g_qr,g_qs,g_qg,icount,iflag,ilev,work,uvflag,vordivflag,g_ni,g_nr)
           endif
        enddo ! do k=1,nlevs
 
-!   do k=1,nlevs
-!      icount=icount+1
-!      iflag(icount)=17
-!      ilev(icount)=k
-!      kr = levs+1-k ! netcdf is top to bottom, need to flip
+       do k=1,nlevs
+          icount=icount+1
+          iflag(icount)=15
+          ilev(icount)=k
+          kr = levs+1-k ! netcdf is top to bottom, need to flip
+
+          if (mype==mype_use(icount)) then
+             call read_vardata(filges, 'nccice', rwork3d0, nslice=kr, slicedim=3)
+             ! cloud ice water number concentration.
+             if ( diff_res ) then
+                grid_b=rwork3d0(:,:,1)
+                vector(1)=.false.
+                call fill2_ns(grid_b,grid_c(:,:,1),latb+2,lonb)
+                call g_egrid2agrid(p_high,grid_c,grid2,1,1,vector)
+                do kk=1,grd%itotsub
+                   i=grd%ltosi_s(kk)
+                   j=grd%ltosj_s(kk)
+                   work(kk)=grid2(i,j,1)
+                enddo
+             else
+                grid=rwork3d0(:,:,1)
+                call general_fill_ns(grd,grid,work)
+             endif
+          endif
+          if ( icount == icm .or. k==nlevs ) then
+             call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &
+                  g_ql,g_qi,g_qr,g_qs,g_qg,icount,iflag,ilev,work,uvflag,vordivflag,g_ni,g_nr)
+          endif
+       enddo ! do k=1,nlevs
+
+       do k=1,nlevs
+          icount=icount+1
+          iflag(icount)=16
+          ilev(icount)=k
+          kr = levs+1-k ! netcdf is top to bottom, need to flip
+
+          if (mype==mype_use(icount)) then
+             call read_vardata(filges, 'nconrd', rwork3d0, nslice=kr, slicedim=3)
+             ! rain number concentration.
+             if ( diff_res ) then
+                grid_b=rwork3d0(:,:,1)
+                vector(1)=.false.
+                call fill2_ns(grid_b,grid_c(:,:,1),latb+2,lonb)
+                call g_egrid2agrid(p_high,grid_c,grid2,1,1,vector)
+                do kk=1,grd%itotsub
+                   i=grd%ltosi_s(kk)
+                   j=grd%ltosj_s(kk)
+                   work(kk)=grid2(i,j,1)
+                enddo
+             else
+                grid=rwork3d0(:,:,1)
+                call general_fill_ns(grd,grid,work)
+             endif
+          endif
+          if ( icount == icm .or. k==nlevs) then
+             call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &
+                  g_ql,g_qi,g_qr,g_qs,g_qg,icount,iflag,ilev,work,uvflag,vordivflag,g_ni,g_nr)
+          endif
+       enddo ! do k=1,nlevs
+
+!       do k=1,nlevs
+!          icount=icount+1
+!          iflag(icount)=17
+!          ilev(icount)=k
+!          kr = levs+1-k ! netcdf is top to bottom, need to flip
 !
-!      if (mype==mype_use(icount)) then
-!         call read_vardata(filges, 'cld_amt', rwork3d0, nslice=kr, slicedim=3)
-!         ! Cloud amount (cloud fraction). 
-!         if ( diff_res ) then
-!            grid_b=rwork3d0(:,:,1)
-!            vector(1)=.false.
-!            call fill2_ns(grid_b,grid_c(:,:,1),latb+2,lonb)
-!            call g_egrid2agrid(p_high,grid_c,grid2,1,1,vector)
-!            do kk=1,grd%itotsub
-!               i=grd%ltosi_s(kk)
-!               j=grd%ltosj_s(kk)
-!               work(kk)=grid2(i,j,1)
-!            enddo
-!         else
-!            grid=rwork3d0(:,:,1)
-!            call general_fill_ns(grd,grid,work)
-!         endif
+!          if (mype==mype_use(icount)) then
+!             call read_vardata(filges, 'cld_amt', rwork3d0, nslice=kr, slicedim=3)
+!             ! Cloud amount (cloud fraction). 
+!             if ( diff_res ) then
+!                grid_b=rwork3d0(:,:,1)
+!                vector(1)=.false.
+!                call fill2_ns(grid_b,grid_c(:,:,1),latb+2,lonb)
+!                call g_egrid2agrid(p_high,grid_c,grid2,1,1,vector)
+!                do kk=1,grd%itotsub
+!                   i=grd%ltosi_s(kk)
+!                   j=grd%ltosj_s(kk)
+!                   work(kk)=grid2(i,j,1)
+!                enddo
+!             else
+!                grid=rwork3d0(:,:,1)
+!                call general_fill_ns(grd,grid,work)
+!             endif
 !
-!      endif
-!      if ( icount == icm .or. k==nlevs ) then
-!         call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &
-!              g_ql,g_qi,g_qr,g_qs,g_qg,icount,iflag,ilev,work,uvflag,vordivflag,g_cf)
-!      endif
-!   enddo ! do k=1,nlevs
+!          endif
+!          if ( icount == icm .or. k==nlevs ) then
+!             call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &
+!                  g_ql,g_qi,g_qr,g_qs,g_qg,icount,iflag,ilev,work,uvflag,vordivflag,g_cf)
+!          endif
+!       enddo ! do k=1,nlevs
 
    else ! read_2m
 

--- a/src/gsi/general_read_gfsatm.f90
+++ b/src/gsi/general_read_gfsatm.f90
@@ -3591,66 +3591,67 @@ subroutine general_read_gfsatm_allhydro_nc(grd,sp_a,filename,uvflag,vordivflag,z
           endif
        enddo ! do k=1,nlevs
 
-       do k=1,nlevs
-          icount=icount+1
-          iflag(icount)=15
-          ilev(icount)=k
-          kr = levs+1-k ! netcdf is top to bottom, need to flip
+       if (imp_physics == 8) then
+          do k=1,nlevs
+             icount=icount+1
+             iflag(icount)=15
+             ilev(icount)=k
+             kr = levs+1-k ! netcdf is top to bottom, need to flip
 
-          if (mype==mype_use(icount)) then
-             call read_vardata(filges, 'nccice', rwork3d0, nslice=kr, slicedim=3)
-             ! cloud ice water number concentration.
-             if ( diff_res ) then
-                grid_b=rwork3d0(:,:,1)
-                vector(1)=.false.
-                call fill2_ns(grid_b,grid_c(:,:,1),latb+2,lonb)
-                call g_egrid2agrid(p_high,grid_c,grid2,1,1,vector)
-                do kk=1,grd%itotsub
-                   i=grd%ltosi_s(kk)
-                   j=grd%ltosj_s(kk)
-                   work(kk)=grid2(i,j,1)
-                enddo
-             else
-                grid=rwork3d0(:,:,1)
-                call general_fill_ns(grd,grid,work)
+             if (mype==mype_use(icount)) then
+                call read_vardata(filges, 'nccice', rwork3d0, nslice=kr, slicedim=3)
+                ! cloud ice water number concentration.
+                if ( diff_res ) then
+                   grid_b=rwork3d0(:,:,1)
+                   vector(1)=.false.
+                   call fill2_ns(grid_b,grid_c(:,:,1),latb+2,lonb)
+                   call g_egrid2agrid(p_high,grid_c,grid2,1,1,vector)
+                   do kk=1,grd%itotsub
+                      i=grd%ltosi_s(kk)
+                      j=grd%ltosj_s(kk)
+                      work(kk)=grid2(i,j,1)
+                   enddo
+                else
+                   grid=rwork3d0(:,:,1)
+                   call general_fill_ns(grd,grid,work)
+                endif
              endif
-          endif
-          if ( icount == icm .or. k==nlevs ) then
-             call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &
-                  g_ql,g_qi,g_qr,g_qs,g_qg,icount,iflag,ilev,work,uvflag,vordivflag,g_ni,g_nr)
-          endif
-       enddo ! do k=1,nlevs
-
-       do k=1,nlevs
-          icount=icount+1
-          iflag(icount)=16
-          ilev(icount)=k
-          kr = levs+1-k ! netcdf is top to bottom, need to flip
-
-          if (mype==mype_use(icount)) then
-             call read_vardata(filges, 'nconrd', rwork3d0, nslice=kr, slicedim=3)
-             ! rain number concentration.
-             if ( diff_res ) then
-                grid_b=rwork3d0(:,:,1)
-                vector(1)=.false.
-                call fill2_ns(grid_b,grid_c(:,:,1),latb+2,lonb)
-                call g_egrid2agrid(p_high,grid_c,grid2,1,1,vector)
-                do kk=1,grd%itotsub
-                   i=grd%ltosi_s(kk)
-                   j=grd%ltosj_s(kk)
-                   work(kk)=grid2(i,j,1)
-                enddo
-             else
-                grid=rwork3d0(:,:,1)
-                call general_fill_ns(grd,grid,work)
+             if ( icount == icm .or. k==nlevs ) then
+                call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &
+                     g_ql,g_qi,g_qr,g_qs,g_qg,icount,iflag,ilev,work,uvflag,vordivflag,g_ni,g_nr)
              endif
-          endif
-          if ( icount == icm .or. k==nlevs) then
-             call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &
-                  g_ql,g_qi,g_qr,g_qs,g_qg,icount,iflag,ilev,work,uvflag,vordivflag,g_ni,g_nr)
-          endif
-       enddo ! do k=1,nlevs
+          enddo ! do k=1,nlevs
 
+          do k=1,nlevs
+             icount=icount+1
+             iflag(icount)=16
+             ilev(icount)=k
+             kr = levs+1-k ! netcdf is top to bottom, need to flip
+
+             if (mype==mype_use(icount)) then
+                call read_vardata(filges, 'nconrd', rwork3d0, nslice=kr, slicedim=3)
+                ! rain number concentration.
+                if ( diff_res ) then
+                   grid_b=rwork3d0(:,:,1)
+                   vector(1)=.false.
+                   call fill2_ns(grid_b,grid_c(:,:,1),latb+2,lonb)
+                   call g_egrid2agrid(p_high,grid_c,grid2,1,1,vector)
+                   do kk=1,grd%itotsub
+                      i=grd%ltosi_s(kk)
+                      j=grd%ltosj_s(kk)
+                      work(kk)=grid2(i,j,1)
+                   enddo
+                else
+                   grid=rwork3d0(:,:,1)
+                   call general_fill_ns(grd,grid,work)
+                endif
+             endif
+             if ( icount == icm .or. k==nlevs) then
+                call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &
+                     g_ql,g_qi,g_qr,g_qs,g_qg,icount,iflag,ilev,work,uvflag,vordivflag,g_ni,g_nr)
+                endif
+          enddo ! do k=1,nlevs
+       endif ! imp_physics
 !       do k=1,nlevs
 !          icount=icount+1
 !          iflag(icount)=17
@@ -3674,7 +3675,6 @@ subroutine general_read_gfsatm_allhydro_nc(grd,sp_a,filename,uvflag,vordivflag,z
 !                grid=rwork3d0(:,:,1)
 !                call general_fill_ns(grd,grid,work)
 !             endif
-!
 !          endif
 !          if ( icount == icm .or. k==nlevs ) then
 !             call general_reload2(grd,g_z,g_ps,g_tv,g_vor,g_div,g_u,g_v,g_q,g_oz, &

--- a/src/gsi/general_read_gfsatm.f90
+++ b/src/gsi/general_read_gfsatm.f90
@@ -3591,6 +3591,7 @@ subroutine general_read_gfsatm_allhydro_nc(grd,sp_a,filename,uvflag,vordivflag,z
           endif
        enddo ! do k=1,nlevs
 
+       ! Read fields specific to Thompson microphysics
        if (imp_physics == 8) then
           do k=1,nlevs
              icount=icount+1


### PR DESCRIPTION
**Description**
Make sure GSI can read the background fields from the operational gfs.v16.3
Please see details in issue [#782](https://github.com/NOAA-EMC/GSI/issues/782)
Resolves #782

I fixed the indentations.  GitHub messes up (confuses) the code indentation change.  
So, to clarify, my code changes are:
- fix indentation  (no code change, just space change)
- add a `if...end` condition to an existing code block

So, the real code change is just two lines (see the following link).  The rest of the changes are related to indentation fixes.  
https://github.com/NOAA-EMC/GSI/commit/3404ddfef03fd52c1fa04411d6613e15b7ef77da?diff=split&w=1


**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

The branch was tested on ORION using two sets of ICs on 2024021900:
- background fields from v17 (/work2/noaa/da/eliu/ICs/UFO_eval/data/para/output_ufo_eval_feb2024/)
- background fields from operational gfs.v16.3 (/work2/noaa/da/eliu/ICs/GDAS_ops/)

The updated code can handle background fields from both gfs.v16.3 and v17.
The updated code does not change the results of regression tests.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published