### PR TITLE
Move to contrib spack-stack on Jet

### DIFF
--- a/modulefiles/gsi_jet.intel.lua
+++ b/modulefiles/gsi_jet.intel.lua
@@ -20,6 +20,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 pushenv("FFLAGS", "-axSSE4.2,AVX,CORE-AVX2")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/mnt/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/gsi/20240208")
+pushenv("GSI_BINARY_SOURCE_DIR", "/lfs5/HFIP/hfv3gfs/glopara/FIX/fix/gsi/20240208")
 
 whatis("Description: GSI environment on Jet with Intel Compilers")

--- a/modulefiles/gsi_jet.intel.lua
+++ b/modulefiles/gsi_jet.intel.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-intel/install/modulefiles/Core")
 
 local python_ver=os.getenv("python_ver") or "3.11.6"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"


### PR DESCRIPTION
**Description**

Following the failure of the lfs4 storage, spack stack was moved to /contrib and jet module files needs updates.
This PR updates Jet module files to point to the new path of spack stack.

Fixes #786 

**Type of change**

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [X] Clone and build on Jet
- [X] Cycle test with Global Workflow at the following resolutions on Jet:
  - [x] 96/48 on kjet
  - [x] 192/96 on kjet
  - [x] 384/192 on kjet
 
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published