### PR TITLE
a quick workaround for increasing the mpi task numbers on orion for ctest :: rrfs_3denvar_rdasens 

### DIFF
--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -90,8 +90,8 @@ case $regtest in
            topts[1]="0:05:00" ; popts[1]="40/3/"  ; ropts[1]="/1"
            topts[2]="0:05:00" ; popts[2]="40/5/"  ; ropts[2]="/1"
         elif [[ "$machine" = "Orion" ]]; then
-           topts[1]="0:15:00" ; popts[1]="5/4/" ; ropts[1]="/1"
-           topts[2]="0:15:00" ; popts[2]="10/4/" ; ropts[2]="/2"
+           topts[1]="0:15:00" ; popts[1]="20/6/" ; ropts[1]="/1"
+           topts[2]="0:15:00" ; popts[2]="20/12/" ; ropts[2]="/2"
         elif [[ "$machine" = "Hercules" ]]; then
            topts[1]="0:05:00" ; popts[1]="40/3/" ; ropts[1]="/1"
            topts[2]="0:05:00" ; popts[2]="40/5/" ; ropts[2]="/2"


### PR DESCRIPTION
It has been under investigation why the GSI would become idle in rrfs_3denvar_rdasens [issue 766](https://github.com/NOAA-EMC/GSI/issues/766).  Following discussions with @RussTreadon-NOAA  [discussion ](https://github.com/NOAA-EMC/GSI/issues/771#issuecomment-2318423899), this PR would provide a quick fix/workaround for rrfs_3denvar_rdasens running on orion by increasing the mpi task numbers running the test. 
Update:  it should be noted. the corresponding local branch had passed regression tests on orion before this PR was  submitted. 