### PR TITLE
Fix PackageConfig.cmake.in to include mgbf

### DIFF
--- a/src/gsi/cmake/PackageConfig.cmake.in
+++ b/src/gsi/cmake/PackageConfig.cmake.in
@@ -6,6 +6,8 @@
 #  * @PROJECT_NAME@::gsi - GSI library target
 
 # Include targets file.  This will create IMPORTED target @PROJECT_NAME@
+include("${CMAKE_CURRENT_LIST_DIR}/../mgbf/mgbf-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/../mgbf/mgbf-config-version.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-config-version.cmake")
 include(CMakeFindDependencyMacro)


### PR DESCRIPTION
This PR adds a (proposed) solution for #796. This block should be encapsulated with `if(@BUILD_MGBF@)` or something to that effect as part of resolving #765.

**Description**

Including the mgbf config/target files in gsi's will allow users to call `find_package(GSI)` from their own CMake-based packages without the build failing due to the `mbgf::mbgf` target being undefined/not found.

Fixes #796 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

In GSI repo (head of develop):
```console
mkdir build && cd build
cmake .. -DCMAKE_INSTALL_DIR=$PWD/install -DCMAKE_C_COMPILER=mpicc -DCMAKE_Fortran_COMPILER=mpif90
make -j6
make install
```
Then download https://github.com/NOAA-GSL/rrfs_utl/ (or just create a dummy CMakeLists.txt and call `find_package(GSI REQUIRED)`:
```console
mkdir build && cd build
cmake .. -DCMAKE_PREFIX_PATH=/path/to/gsi/build/install
```
The cmake invocation will fail due to missing `mgbf::mgbf` target.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published