### PR TITLE
Add writing out of ensemble mean for soil increments.

### DIFF
--- a/src/enkf/controlvec.f90
+++ b/src/enkf/controlvec.f90
@@ -337,7 +337,7 @@ if (nproc <= ntasks_io-1) then
            else
               call writegriddata(0,0,cvars3d,cvars2d,nc3d,nc2d,clevels,ncdim,grdin_mean,no_inflate_flag)
            end if
-        elseif (nc2d>0) then  ! always write sfc mean increment
+        elseif (nc2d>0) then  ! always write sfc mean increment for soil analysis
            no_vars3d=''
            call writeincrement(0,0,no_vars3d,cvars2d,nc3d,nc2d,clevels,ncdim,grdin_mean,no_inflate_flag)
         endif

--- a/src/enkf/controlvec.f90
+++ b/src/enkf/controlvec.f90
@@ -261,6 +261,8 @@ integer(i_kind) :: q_ind, ierr
 real(r_single), allocatable, dimension(:,:) :: grdin_mean_tmp
 real(r_single), allocatable, dimension(:,:,:,:) :: grdin_mean
 
+character(len=max_varname_length), dimension(nc3d) :: no_vars3d
+
 if (nproc <= ntasks_io-1) then
 
    ! scale q by ensemble qsat, prior to averaging
@@ -335,6 +337,9 @@ if (nproc <= ntasks_io-1) then
            else
               call writegriddata(0,0,cvars3d,cvars2d,nc3d,nc2d,clevels,ncdim,grdin_mean,no_inflate_flag)
            end if
+        elseif (nc2d>0) then  ! always write sfc mean increment
+           no_vars3d=''
+           call writeincrement(0,0,no_vars3d,cvars2d,nc3d,nc2d,clevels,ncdim,grdin_mean,no_inflate_flag)
         endif
         deallocate(grdin_mean)
         t2 = mpi_wtime()
@@ -358,6 +363,9 @@ if (paranc) then
         else
            call writegriddata(0,0,cvars3d,cvars2d,nc3d,nc2d,clevels,ncdim,grdin_mean,no_inflate_flag)
         end if
+     elseif (nc2d>0) then  ! always write sfc mean increment
+        no_vars3d=''
+        call writeincrement(0,0,no_vars3d,cvars2d,nc3d,nc2d,clevels,ncdim,grdin_mean,no_inflate_flag)
      endif
      deallocate(grdin_mean)
      t2 = mpi_wtime()

--- a/src/enkf/controlvec.f90
+++ b/src/enkf/controlvec.f90
@@ -337,7 +337,7 @@ if (nproc <= ntasks_io-1) then
            else
               call writegriddata(0,0,cvars3d,cvars2d,nc3d,nc2d,clevels,ncdim,grdin_mean,no_inflate_flag)
            end if
-        elseif (nc2d>0) then  ! always write sfc mean increment for soil analysis
+        elseif (nc2d>0) then  ! always write sfc mean increment for land analysis
            no_vars3d=''
            call writeincrement(0,0,no_vars3d,cvars2d,nc3d,nc2d,clevels,ncdim,grdin_mean,no_inflate_flag)
         endif

--- a/src/enkf/gridio_gfs.f90
+++ b/src/enkf/gridio_gfs.f90
@@ -4114,7 +4114,7 @@
      write(charnanal,'(i3.3)') nanal
      sfcbackgroundloop: do nb=1,nbackgrounds
 
-     if (nanal == 0 .and. write_ensmean) then
+     if (nanal == 0 ) then
         filenamein = trim(adjustl(datapath))//trim(adjustl(fgsfcfileprefixes(nb)))//"ensmean"
         filenameout = trim(adjustl(datapath))//trim(adjustl(incsfcfileprefixes(nb)))//"ensmean"
      else


### PR DESCRIPTION

**Description**

The GFSV17 soil analysis requires the ensemble mean increment to be added to the deterministic member. It's simplest to write it out from the EnKF, as the associated snow mask is available. These updates write out the ensemble mean soil increment when a soil update is calculated.

Addresses issue #801 

**Type of change**

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)


**How Has This Been Tested?**

Tested that it correctly write out the ensemble mean soil increment for paranc = T and F. 

I've run the global regression tests on hera. All passed except: 

The runtime for hafs_4denvar_glbens_hiproc_updat is 364.487057 seconds.  This has exceeded maximum allowable threshold time of 324.213506 seconds,
resulting in Failure of timethresh2 the regression test.

The above test passed all the reproducability tests.
  
The regional EnKF test also passed on hera. 

**Checklist**

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] New and existing tests pass with my changes
- [x ] Any dependent changes have been merged and published