### PR TITLE
Update global_enkf ctest for tapering of perturbations (#806)

### DIFF
--- a/regression/global_enkf.sh
+++ b/regression/global_enkf.sh
@@ -90,6 +90,7 @@ export write_spread_diag=${write_spread_diag:-".false."}
 export cnvw_option=${cnvw_option:-".false."}
 export netcdf_diag=${netcdf_diag:-".true."}
 export modelspace_vloc=${modelspace_vloc:-".true."} # if true, 'vlocal_eig.dat' is needed
+export taperanalperts=${taperanalperts:-".true."}
 export IAUFHRS_ENKF=${IAUFHRS_ENKF:-'3,6,9'}
 export DO_CALC_INCREMENT=${DO_CALC_INCREMENT:-"NO"}
 export INCREMENTS_TO_ZERO="'liq_wat_inc','icmr_inc','rwmr_inc','snmr_inc','grle_inc'"

--- a/regression/regression_namelists.sh
+++ b/regression/regression_namelists.sh
@@ -967,7 +967,7 @@ export gsi_namelist="
   univaroz=.false.,adp_anglebc=.true.,angord=4,use_edges=.false.,emiss_bc=.true.,
   letkf_flag=${letkf_flag},nobsl_max=${nobsl_max},denkf=${denkf},getkf=${getkf}.,
   nhr_anal=${IAUFHRS_ENKF},nhr_state=${IAUFHRS_ENKF},
-  lobsdiag_forenkf=$lobsdiag_forenkf,
+  lobsdiag_forenkf=$lobsdiag_forenkf,taperanalperts=${taperanalperts},
   write_spread_diag=$write_spread_diag,
   modelspace_vloc=$modelspace_vloc,
   use_correlated_oberrs=${use_correlated_oberrs},


### PR DESCRIPTION
**Description**

The global_enkf ctest needs to be updated to include a change to the configuration of GFSv17. The upper layer ensemble spread is too large, so we are enabling a new feature in the EnKF to reduce the spread as part of the ensemble analysis.  This feature was previously included in the GSI EnKF source code (Issue https://github.com/NOAA-EMC/GSI/issues/728) and being turned on in the global-workflow through https://github.com/NOAA-EMC/global-workflow/pull/3097.  The g-w PR is not required to exercise this PR.

Fixes #806 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

The taperanalperts feature was tested in an ATM-only C384/C192 cycling parallel on Hera.  The GSI regression tests were run on Hera (results in following comment).
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published