### PR TITLE
Correct scattering index and enable error inflation in ATMS data,

### DIFF
--- a/src/gsi/clw_mod.f90
+++ b/src/gsi/clw_mod.f90
@@ -1961,6 +1961,7 @@ subroutine ret_amsua(tb_obs,nchanl,tsavg5,zasat,clwp_amsua,ierrret,scat)
 ! Declare local variables 
   real(r_kind) :: d0, d1, d2, coszat
 ! real(r_kind) :: c0, c1, c2
+  real(r_kind) :: tb890 = 0.0
 
   
   coszat=cos(zasat)
@@ -1979,8 +1980,17 @@ subroutine ret_amsua(tb_obs,nchanl,tsavg5,zasat,clwp_amsua,ierrret,scat)
   endif
 
   if (present(scat)) then
-      scat=-113.2_r_kind+(2.41_r_kind-0.0049_r_kind*tb_obs(1))*tb_obs(1)  &
-           +0.454_r_kind*tb_obs(2)-tb_obs(15)
+      if (nchanl == 15) then
+!         AMSU-A
+          tb890 = tb_obs(15)
+      else if (nchanl == 22) then
+!         ATMS
+          tb890 = tb_obs(16)
+      endif
+      if (tb890 > 0.0) then
+        scat=-113.2_r_kind+(2.41_r_kind-0.0049_r_kind*tb_obs(1))*tb_obs(1)  &
+             +0.454_r_kind*tb_obs(2)-tb890
+      endif
       scat=max(zero,scat)
   end if
 

--- a/src/gsi/clw_mod.f90
+++ b/src/gsi/clw_mod.f90
@@ -1961,7 +1961,7 @@ subroutine ret_amsua(tb_obs,nchanl,tsavg5,zasat,clwp_amsua,ierrret,scat)
 ! Declare local variables 
   real(r_kind) :: d0, d1, d2, coszat
 ! real(r_kind) :: c0, c1, c2
-  real(r_kind) :: tb890 = 0.0
+  real(r_kind) :: tb890 = zero
 
   
   coszat=cos(zasat)
@@ -1980,18 +1980,18 @@ subroutine ret_amsua(tb_obs,nchanl,tsavg5,zasat,clwp_amsua,ierrret,scat)
   endif
 
   if (present(scat)) then
-      if (nchanl == 15) then
-!         AMSU-A
-          tb890 = tb_obs(15)
-      else if (nchanl == 22) then
-!         ATMS
-          tb890 = tb_obs(16)
-      endif
-      if (tb890 > 0.0) then
+     if (nchanl == 15) then
+!       AMSU-A
+        tb890 = tb_obs(15)
+     else if (nchanl == 22) then
+!       ATMS
+        tb890 = tb_obs(16)
+     endif
+     if (tb890 > zero) then
         scat=-113.2_r_kind+(2.41_r_kind-0.0049_r_kind*tb_obs(1))*tb_obs(1)  &
              +0.454_r_kind*tb_obs(2)-tb890
-      endif
-      scat=max(zero,scat)
+     endif
+     scat=max(zero,scat)
   end if
 
 end subroutine ret_amsua

--- a/src/gsi/qcmod.f90
+++ b/src/gsi/qcmod.f90
@@ -3670,7 +3670,7 @@ subroutine qc_amsua(nchanl,is,ndat,nsig,npred,sea,land,ice,snow,mixed,luse,   &
            ework = ework+min(0.002_r_kind*sfc_speed**2*error0(i), 0.5_r_kind*error0(i))
            clwtmp=min(abs(clwp_amsua-clw_guess_retrieval), one)
            ework = ework+min(13.0_r_kind*clwtmp*error0(i), 3.5_r_kind*error0(i))
-           if (scatp>9.0_r_kind .and. nchanl==15) then
+           if (scatp>9.0_r_kind) then
               ework = ework+min(1.5_r_kind*(scatp-9.0_r_kind)*error0(i), 2.5_r_kind*error0(i))
            end if
            ework=ework**2


### PR DESCRIPTION
**Description**

The scattering index was not correctly calculated by using a wrong channel at 89GHz.  The error inflation referring to it was turned off instead of correcting the calculation.  This PR corrects the scattering index and enables error inflation in ATMS observations.

Note, no test has been conducted. However, it very likely creates non-zero difference in GSI results.


**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Checklist**

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published