### PR TITLE
Iasi ng bufr change

### DIFF
--- a/src/enkf/enkf_files.cmake
+++ b/src/enkf/enkf_files.cmake
@@ -61,5 +61,3 @@ list(APPEND EnKF_SRC_FV3REG
 #Unused files
 #specmod_shtns.f90 -- This is a faster alternative to specmod.f90
 #specmod_splib.f90 -- This is a copy of specmod.f90
-#observer_nmmb.f90 -- This is soft-linked to observer_reg.f90
-#observer_wrf.f90  -- This is soft-linked to observer_reg.f90

--- a/src/enkf/observer_nmmb.f90
+++ b/src/enkf/observer_nmmb.f90
@@ -1,1 +1,0 @@
-observer_reg.f90

--- a/src/enkf/observer_wrf.f90
+++ b/src/enkf/observer_wrf.f90
@@ -1,1 +1,0 @@
-observer_reg.f90

--- a/src/gsi/read_iasing.f90
+++ b/src/gsi/read_iasing.f90
@@ -424,7 +424,7 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
 
 ! Get the size of the channels and radiance (allchan) array
 ! This is a delayed replication. crchn_reps is the number of IASI-NG replications (channel and radiance)
-           call ufbint(lnbufr,crchn_reps,1,1,iret,'(I1CRSQ)')
+           call ufbint(lnbufr,crchn_reps,1,1,iret,'(RPSEQ001)')
            bufr_nchan = int(crchn_reps)
 
            bufr_size = size(temperature,1)
@@ -622,7 +622,7 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
            call checkob(one,crit1,itx,iuse)
            if(.not. iuse)cycle read_loop
 
-           call ufbseq(lnbufr,cscale,3,4,iret,'IAS1CBSQ')
+           call ufbseq(lnbufr,cscale,3,4,iret,'RPSEQ004')
            if(iret /= 4) then
               write(6,*) 'READ_IASI-NG  read scale error ',iret
               cycle read_loop
@@ -643,7 +643,7 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
            end do
 
 ! Read IASI-NG channel number(CHNM) and radiance (SCRA).
-           call ufbseq(lnbufr,allchan,2,bufr_nchan,iret,'I1CRSQ')
+           call ufbseq(lnbufr,allchan,2,bufr_nchan,iret,'RPSEQ001')
            jstart=1
            scalef=one
 
@@ -739,7 +739,7 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
 ! Only channels 18 and 19 are used.
 
            if ( iasing_cads ) then
-             call ufbseq(lnbufr,imager_info,123,7,iret,'IASICSSQ')
+             call ufbseq(lnbufr,imager_info,123,7,iret,'RPSEQ002')
              if (iret == 7 .and. imager_info(3,1) <= 100.0_r_kind .and. &
                   sum(imager_info(3,:)) > zero .and. imager_coeff ) then   ! if imager cluster info exists
                imager_mean = zero


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

The mnemonics to read the IASI-NG data and the corresponding MetImage data were changed by NESDIS.  This PR is to change the read_iasing subroutine to use the new mnemonics.  
Resolves #815 
There are no dependencies with this change.  

Two links in the /src/enkf directory were also removed, as they are not necessary.
observer_nmmb.f90 -> observer_reg.f90
observer_wrf.f90 -> observer_reg.f90

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

NESDIS provided ~6 hours of proxy data containing these new mnemonics.  The OBSPROC group (Steve Stegall) generated the two dump files consistent with the global workflow. We tested the our changes on these data.

In order for others to test these changes, modifications to scripts in the global-workflow and channel entries in the satinfo file will be required.  The global-workflow script changes are in a separate (global-workflow) pull request.  Changes to the satinfo and scaninfo will be in a separate pull request (gsi/fix) once the script changes to the global-workflow are incorporated.
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published