### PR TITLE
Iasi ng fov bugs

### DIFF
--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -67,8 +67,8 @@ case $regtest in
            topts[1]="0:10:00" ; popts[1]="12/8/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="12/10/" ; ropts[2]="/2"
         elif [[ "$machine" = "Orion" ]]; then
-           topts[1]="0:10:00" ; popts[1]="12/8/" ; ropts[1]="/1"
-           topts[2]="0:10:00" ; popts[2]="12/12/" ; ropts[2]="/2"
+           topts[1]="0:20:00" ; popts[1]="12/8/" ; ropts[1]="/1"
+           topts[2]="0:20:00" ; popts[2]="12/12/" ; ropts[2]="/2"
         elif [[ "$machine" = "Hercules" ]]; then
            topts[1]="0:10:00" ; popts[1]="12/8/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="12/12/" ; ropts[2]="/2"

--- a/src/gsi/read_iasing.f90
+++ b/src/gsi/read_iasing.f90
@@ -153,7 +153,7 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
   logical          :: outside,iuse,assim,valid
   logical          :: quiet,cloud_info
 
-  integer(i_kind)  :: ifov, ifor, istep, ipos, instr, iscn, ioff, sensorindex_iasing
+  integer(i_kind)  :: ifov, ifov2, ifor, istep, ipos, instr, iscn, ioff, sensorindex_iasing
   integer(i_kind)  :: i, j, l, iskip, ifovn, ksatid, kidsat, llll
   integer(i_kind)  :: nreal, isflg
   integer(i_kind)  :: itx, k, nele, itt, n
@@ -568,7 +568,12 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
 !         To determine the scan position:
           ifor = (ifov-1) / 16                     ! Determine field-of-regard 
           istep = ifov - ((ifor) * 16)             ! Determine field-of-view within field-of-regard
-          ipos = (ifor * 4) + mod(istep,4)         ! Determine position of field-of-view within scan line
+          ifov2 = mod(istep,4)                     ! Determine position of field-of-view within scan line
+          if ( ifov2 /= 0 ) then
+            ipos = (ifor * 4) + ifov2 
+          else
+            ipos = (ifor * 4) + 4
+          endif
 
 ! Remove data on edges
           if (.not. use_edges .and. &

--- a/src/gsi/read_iasing.f90
+++ b/src/gsi/read_iasing.f90
@@ -424,7 +424,7 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
 
 ! Get the size of the channels and radiance (allchan) array
 ! This is a delayed replication. crchn_reps is the number of IASI-NG replications (channel and radiance)
-           call ufbint(lnbufr,crchn_reps,1,1,iret,'(RPSEQ001)')
+           call ufbint(lnbufr,crchn_reps,1,1,iret,'(I1CRSQ)')
            bufr_nchan = int(crchn_reps)
 
            bufr_size = size(temperature,1)
@@ -570,7 +570,7 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
           istep = ifov - ((ifor) * 16)             ! Determine field-of-view within field-of-regard
           ifov2 = mod(istep,4)                     ! Determine position of field-of-view within scan line
           if ( ifov2 /= 0 ) then
-            ipos = (ifor * 4) + ifov2 
+            ipos = (ifor * 4) + ifov2
           else
             ipos = (ifor * 4) + 4
           endif
@@ -627,7 +627,7 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
            call checkob(one,crit1,itx,iuse)
            if(.not. iuse)cycle read_loop
 
-           call ufbseq(lnbufr,cscale,3,4,iret,'RPSEQ004')
+           call ufbseq(lnbufr,cscale,3,4,iret,'IAS1CBSQ')
            if(iret /= 4) then
               write(6,*) 'READ_IASI-NG  read scale error ',iret
               cycle read_loop
@@ -648,7 +648,7 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
            end do
 
 ! Read IASI-NG channel number(CHNM) and radiance (SCRA).
-           call ufbseq(lnbufr,allchan,2,bufr_nchan,iret,'RPSEQ001')
+           call ufbseq(lnbufr,allchan,2,bufr_nchan,iret,'I1CRSQ')
            jstart=1
            scalef=one
 
@@ -744,7 +744,7 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
 ! Only channels 18 and 19 are used.
 
            if ( iasing_cads ) then
-             call ufbseq(lnbufr,imager_info,123,7,iret,'RPSEQ002')
+             call ufbseq(lnbufr,imager_info,123,7,iret,'IASICSSQ')
              if (iret == 7 .and. imager_info(3,1) <= 100.0_r_kind .and. &
                   sum(imager_info(3,:)) > zero .and. imager_coeff ) then   ! if imager cluster info exists
                imager_mean = zero
@@ -844,7 +844,7 @@ subroutine read_iasing(mype,val_iasing,ithin,isfcalc,rmesh,jsatid,gstime,&
            data_all(4,itx) = dlat                      ! grid relative latitude
            data_all(5,itx) = sat_zenang*deg2rad        ! satellite zenith angle (rad)
            data_all(6,itx) = allspot(11)               ! satellite azimuth angle (deg)
-           data_all(7,itx) = sat_zenang*deg2rad        ! look angle (rad)
+           data_all(7,itx) = sat_zenang*deg2rad        ! satellite zenith angle (rad)
            data_all(8,itx) = ifov                      ! fov number
            data_all(9,itx) = allspot(12)               ! solar zenith angle (deg)
            data_all(10,itx)= allspot(13)               ! solar azimuth angle (deg)


### PR DESCRIPTION
**Description**
An error was discovered in the scan position calculation of read_iasing.f90.  The initial proxy data set did not have enough information to properly calculate the scan position.  It only had field of view spanning 1-16.  There was no field of regard.  In the latest data set the field of view now spans 1 - 224.  This is consistent with the field of view EUMETSAT plans to provide.  Using this new data set, the error was discovered. This PR fixes #IssueNumber #830. 

Resolves #830

**Type of change**
- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
NESDIS generated 2 IASI-NG bufr files with the correct field of view (FOV) range, 1-224.  These bufr files were processed into "dump" files by NCEP.  With these files, I was able to determine there was a problem in the logic determining the scan position.  The problem was traced back to the output of the mod() function.  When mod() = 0, the value should be a multiple of the 4th scan position.  This is now correct.  These tests were conducted with the 2 file sets on S4 at C96 resolution.  

In order to reproduce these results, modifications to the global-workflow, CRTM and the global_satinfo file are required.  The global-workflow needs logic to copy the bufr file(s) into its workspace.  The CRTM version must have iasi-ng and metimage coefficient files. The satinfo file also has to have an iasi-ng_metop-sg_a1 channel selection.

Another issue was found with the FOV information in the bufr files.  The FOV entries are transposed from their expected locations.  The NESDIS bufr file FOV entries are:
1  5  9 13
2  6 10 14
3  7 11 15
4  8 12 16

EUMETSAT's documentation has the FOV entries as:
 1  2  3  4
 5  6  7  8
 9 10 11 12
13 14 15 16

This inconsistency was accounted for in determining the scan position.

I have also replaced the bufr mnemonics to EUMETSAT's published list.  Documentation suggests these mnemonics will be used for IASI-NG distribution, including DBNet.  Here is the link to the web site with the various metop-sg instrument documentation.  The EUMETSAT documentation shows the number of channels distributed will follow a delayed replication entry.

https://user.eumetsat.int/resources/user-guides/metop-sg-test-data

This site also includes the EUMETSAT metop-sg instrument bufr tables
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing tests pass with my changes
This code is currently NOT used by the GSI. 

This code passes the ctests on hera.  Orion continues to hang.

Hera stats:
[Jim.Jung@hfe04 build]$ ctest -j 6
Test project /scratch1/NCEPDEV/jcsda/Jim.Jung/save/ctests/update/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test #3: rrfs_3denvar_rdasens .............   Passed  1045.33 sec
2/6 Test #6: global_enkf ......................   Passed  1515.30 sec
3/6 Test #4: hafs_4denvar_glbens ..............   Passed  2368.49 sec
4/6 Test #1: global_4denvar ...................   Passed  2446.88 sec
5/6 Test #5: hafs_3denvar_hybens ..............   Passed  2618.69 sec
6/6 Test #2: rtma .............................   Passed  2774.23 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) = 2774.27 sec

Orion tests:
Test project /work2/noaa/nesdis-rdo1/jjung/ctests/update/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test #6: global_enkf ......................   Passed  728.02 sec
2/6 Test #3: rrfs_3denvar_rdasens .............   Passed  968.65 sec
3/6 Test #2: rtma .............................   Passed  1627.87 sec
4/6 Test #5: hafs_3denvar_hybens ..............   Passed  2734.22 sec
5/6 Test #4: hafs_4denvar_glbens ..............   Passed  3031.66 sec

I continue to have problems with orion.  The global_4denvar does not complete.

