### PR TITLE
adding MPI dependency in CMakeLists.txt of mgbf and using Russ's gsi_…

### DIFF
--- a/modulefiles/gsi_hera.gnu.lua
+++ b/modulefiles/gsi_hera.gnu.lua
@@ -2,8 +2,6 @@ help([[
 ]])
 
 prepend_path("MODULEPATH", "/scratch4/NCEPDEV/stmp/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
---Needed for openmpi build
---prepend_path("MODULEPATH", "/scratch1/NCEPDEV/jcsda/jedipara/spack-stack/modulefiles")
 
 local python_ver=os.getenv("python_ver") or "3.11.6"
 local stack_gnu_ver=os.getenv("stack_gnu_ver") or "9.2.0"

--- a/modulefiles/gsi_hera.gnu.lua
+++ b/modulefiles/gsi_hera.gnu.lua
@@ -1,13 +1,13 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch4/NCEPDEV/stmp/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 --Needed for openmpi build
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/jcsda/jedipara/spack-stack/modulefiles")
+--prepend_path("MODULEPATH", "/scratch1/NCEPDEV/jcsda/jedipara/spack-stack/modulefiles")
 
 local python_ver=os.getenv("python_ver") or "3.11.6"
 local stack_gnu_ver=os.getenv("stack_gnu_ver") or "9.2.0"
-local stack_openmpi_ver=os.getenv("stack_openmpi_ver") or "4.1.5"
+local stack_openmpi_ver=os.getenv("stack_openmpi_ver") or "4.1.6"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 local openblas_ver=os.getenv("openblas_ver") or "0.3.24"

--- a/src/mgbf/CMakeLists.txt
+++ b/src/mgbf/CMakeLists.txt
@@ -30,6 +30,8 @@ endif()
 if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
   add_definitions(-DNDEBUG)
 endif()
+# Find MPI Package
+find_package(MPI REQUIRED)
 
 list(APPEND MGBF_SRC
 kinds.f90
@@ -63,6 +65,8 @@ add_library(${PROJECT_NAME}::mgbf ALIAS mgbf)
 set_target_properties(mgbf PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")
 target_include_directories(mgbf PUBLIC $<BUILD_INTERFACE:${module_dir}>
                                            $<INSTALL_INTERFACE:include/mgbf>)
+target_link_libraries(mgbf  PUBLIC MPI::MPI_Fortran)
+
 
 install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 


### PR DESCRIPTION
Description
This PR is to fix the GSI GNU compiling broken on hera 
Resolves #831 

Added the correct specification of MPI dependency in cmake file for mgbf and added @RussTreadon-NOAA 's changes in gsi_hera.gnu.lua to make right modules loaded on hera. 

Co-author : @RussTreadon-NOAA 

<But now, I have no a "control" GSI without the above changes to run ctests on hera since the GSI would fail in building if there are no those changes.   
@RussTreadon-NOAA, what are your recommendation for ctests problem for this PR.
(Now, I would keep this PR at "draft" mode")   >
Update : Russ clarified (see his following comment) that the successful building of GSI using GNU is enough for this PR. 
