### PR TITLE
update GSI_BINARY_SOURCE_DIR for Hercules and Orion (#851)

### DIFF
--- a/modulefiles/gsi_hercules.intel.lua
+++ b/modulefiles/gsi_hercules.intel.lua
@@ -21,6 +21,6 @@ load("intel-oneapi-mkl/2022.2.1")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20241022")
+pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20241022")
 
 whatis("Description: GSI environment on Hercules with Intel Compilers")

--- a/modulefiles/gsi_orion.intel.lua
+++ b/modulefiles/gsi_orion.intel.lua
@@ -21,6 +21,6 @@ load("intel-oneapi-mkl/2022.2.1")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/work/noaa/global/glopara/fix/gsi/20241022")
+pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20241022")
 
 whatis("Description: GSI environment on Orion with Intel Compilers")


### PR DESCRIPTION
**Description**

Update the `GSI_BINARY_SOURCE_DIR` path in the Hercules and Orion modulefiles.   This change is required by changes merged into g-w `develop` via g-w PR [#3488](https://github.com/NOAA-EMC/global-workflow/pull/3488).

Resolves #851

**Type of change**

- [ ] Maintenance (fix to maintain existing functionality)

**How Has This Been Tested?**

Install `RussTreadon-NOAA/GSI:feature/msu_path` on Orion.  Run ctests.  All tests pass.


**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass with my changes
