### PR TITLE
Make GSI compile on CSPs with Rocky 8

### DIFF
--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -1,16 +1,21 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/modules/modulefiles")
 
-local python_ver=os.getenv("python_ver") or "3.10.13"
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.3.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.3.0"
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
+local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
-local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 
+load("gnu")
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+unload("gnu")
+
+local python_ver=os.getenv("python_ver") or "3.11.6"
+local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+
 load(pathJoin("python", python_ver))
 load(pathJoin("cmake", cmake_ver))
 
@@ -20,6 +25,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/Wei.Huang/data/hack-orion/fix/gsi/20241022")
+pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20241022")
 
 whatis("Description: GSI environment on NOAA Cloud with Intel Compilers")

--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -6,20 +6,20 @@ prepend_path("MODULEPATH", "/apps/modules/modulefiles")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
-local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 
 load("gnu")
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 unload("gnu")
 
+load("gsi_common")
+
+local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 local python_ver=os.getenv("python_ver") or "3.11.6"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 
-load(pathJoin("python", python_ver))
 load(pathJoin("cmake", cmake_ver))
-
-load("gsi_common")
+load(pathJoin("python", python_ver))
 load(pathJoin("prod_util", prod_util_ver))
 
 pushenv("CFLAGS", "-xHOST")


### PR DESCRIPTION
With QOSAP request to run DA on AWS, we need to Make GSI compile on CSPs with Rocky 8.

Only need to update module file: gsi_noaacloud.intel.lua

 Fixes #855

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

It compiles on AWS successfully.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published