### PR TITLE
add option to ignore qm=9 for T2m and q2m in prepbufr files.

### DIFF
--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -107,7 +107,7 @@
      factv,factl,factp,factg,factw10m,facthowv,factcldch,niter,niter_no_qc,biascor,&
      init_jfunc,qoption,cwoption,switch_on_derivatives,tendsflag,jiterstart,jiterend,R_option,&
      bcoption,diurnalbc,print_diag_pcg,tsensible,diag_precon,step_start,pseudo_q2,&
-     clip_supersaturation,cnvw_option,hofx_2m_sfcfile
+     clip_supersaturation,cnvw_option,hofx_2m_sfcfile, ignore_2mQM
   use state_vectors, only: init_anasv,final_anasv
   use control_vectors, only: init_anacv,final_anacv,nrf,nvars,nrf_3d,cvars3d,cvars2d,&
      nrf_var,lcalc_gfdl_cfrac,incvars_to_zero,incvars_zero_strat,incvars_efold 
@@ -1087,9 +1087,16 @@
 !      time_window_rad  - upper limit on time window for certain radiance input data
 !      ext_sonde        - logical for extended forward model on sonde data
 !      l_foreaft_thin -   separate TDR fore/aft scan for thinning
+!      hofx_2m_sfcfile  - Calculate h(x) for q2m and T2m from 
+!                         same fields in sfc_data.tile files
+!                         (for use in global 2m DA) 
+!      ignore_2mQM      - ignore quality mark of 9 (no obs errors)
+!                         for T2m and q2m in prepbufr file, and
+!                         insert hard-coded obs errors (for reanalysis,
+!                         allows use of archived prepbufr files)
 
   namelist/obs_input/dmesh,time_window_max,time_window_rad, &
-       ext_sonde,l_foreaft_thin,hofx_2m_sfcfile
+       ext_sonde,l_foreaft_thin,hofx_2m_sfcfile, ignore_2mQM
 
 ! SINGLEOB_TEST (one observation test case setup):
 !      maginnov   - magnitude of innovation for one ob

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -2317,6 +2317,8 @@
      write(6,strongopts)
      write(6,obsqc)
      write(6,*)'EXT_SONDE on type 120 =',ext_sonde
+     write(6,*)'hofx_2m_sfcfile =', hofx_2m_sfcfile
+     write(6,*)'ignore_2mQM =', ignore_2mQM
      ngroup=0
      do i=1,ndat
         dthin(i) = max(dthin(i),0)

--- a/src/gsi/jfunc.f90
+++ b/src/gsi/jfunc.f90
@@ -137,11 +137,13 @@ module jfunc
   public :: varq
   public :: cnvw_option
   public :: hofx_2m_sfcfile
+  public :: ignore_2mQM
 
   logical first,last,switch_on_derivatives,tendsflag,print_diag_pcg,tsensible,diag_precon
   logical clip_supersaturation,R_option
   logical pseudo_q2,limitqobs
   logical hofx_2m_sfcfile
+  logical ignore_2mQM
   logical cnvw_option
   integer(i_kind) iout_iter,miter,iguess,nclen,qoption,cwoption
   integer(i_kind) jiter,jiterstart,jiterend,iter
@@ -253,6 +255,9 @@ contains
 
 !   option to calculate hofx for T2m and q2m by interpolating from 2m vars in sfc file
     hofx_2m_sfcfile=.false.
+
+!   option to ignore qm=9 in prepbufr file for T2m and q2m
+    ignore_2mQM=.false.
 
     return
   end subroutine init_jfunc

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -1685,9 +1685,8 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
               pmq(k)=nint(qcmark(8,k))
            end do
 
-!          187, 181, and 183 are the screen-level obs over land
-!          note: don't need the hofx_2m_sfcfile if set usage in convinfo, and qm updated in the input file
-           global_2m_land = ( (kx==187 .or. kx==181 .or. kx==183) .and. hofx_2m_sfcfile )
+!          187 and 181, are the screen-level obs over land
+           global_2m_land = ( (kx==187 .or. kx==181) .and. hofx_2m_sfcfile )
 
 !          If temperature ob, extract information regarding virtual
 !          versus sensible temperature
@@ -2016,17 +2015,13 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                 if (tob .and. qm==9 ) then
                      qm=2
                      tqm(k)=2
-                     if (kx==187) obserr(3,k)=2.0_r_double
-                     if (kx==181) obserr(3,k)=2.0_r_double
-                     if (kx==183) obserr(3,k)=2.0_r_double
+                     obserr(3,k)=2.0_r_double
                 endif
                 if (qob .and. qm == 9 ) then 
                      qm=2
                      qqm(k) = 2
                      ! qob err specified as fraction of qsat, multiplied by 10.
-                     if (kx==187) obserr(2,k)=1.0_r_double
-                     if (kx==181) obserr(2,k)=1.0_r_double
-                     if (kx==183) obserr(2,k)=1.0_r_double
+                     obserr(2,k)=1.0_r_double
                 endif
               endif
 !             Set usage variable              

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -219,7 +219,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                          apply_hilbertcurve,destroy_hilbertcurve
   use ndfdgrids,only: init_ndfdgrid,destroy_ndfdgrid,relocsfcob,adjust_error
   use ndfdgrids,only: valley_adjustment
-  use jfunc, only: tsensible, hofx_2m_sfcfile
+  use jfunc, only: tsensible, hofx_2m_sfcfile, ignore_2mQM
   use deter_sfc_mod, only: deter_sfc_type,deter_sfc2
   use gsi_nstcouplermod, only: nst_gsi,nstinfo
   use gsi_nstcouplermod, only: gsi_nstcoupler_deter
@@ -2012,9 +2012,8 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
 
 !             Over-ride QM=9 and hard-wire errors for land obs and hofx_sfc_file option
 !             Can be deleted once prepbufr processing updated.
-              if ( global_2m_land ) then
+              if ( global_2m_land .and. ignore_2mQM ) then
                 if (tob .and. qm==9 ) then
-                     pqm(k)=2 ! otherwise, type 183 will be discarded.
                      qm=2
                      tqm(k)=2
                      if (kx==187) obserr(3,k)=2.0_r_double
@@ -2022,7 +2021,8 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                      if (kx==183) obserr(3,k)=2.0_r_double
                 endif
                 if (qob .and. qm == 9 ) then 
-                     qm = 2
+                     qm=2
+                     qqm(k) = 2
                      ! qob err specified as fraction of qsat, multiplied by 10.
                      if (kx==187) obserr(2,k)=1.0_r_double
                      if (kx==181) obserr(2,k)=1.0_r_double


### PR DESCRIPTION
**Description**

Updates read_prepbufr with an explicit flag (ignore_2mQM) to over-ride quality mark of 9 (no obs error) in prepbufr files for q2m and T2m. Previously, these quality marks were ignored for all cases when the 2m obs are assimilated. With the coming update to the obs table in  GSI-fix PR [33 ](https://github.com/NOAA-EMC/GSI-fix/pull/33) to include the obs errors in the prepbufr, we now only need to ignore the quality marks when using archived prepbufr files (i.e., for the reanalysis).

Also fixes bug that was preventing q2m from being assimilated, by not properly resettings the quality mark.

Resolves #861 

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Compared: 
-ignore_2mQM = .true. and original obs table (with no obs errors for q2m and T2m) 
-ignore_2mQM = .False. and obs table from GSI-fix PR [33 ](https://github.com/NOAA-EMC/GSI-fix/pull/33). 

The two are not the same, but differences can be explained. Specifically, the latter excludes a handful more obs that the former, due to these obs have quality mark = 9 due to missing pressure obs errors. 
  
**Checklist**

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published 

Is dependent on GSI-fix PR [33 ](https://github.com/NOAA-EMC/GSI-fix/pull/33) 