### PR TITLE
Saving the original reported observation information if they are changed by terrain-match adjustment in subroutine setupt

### DIFF
--- a/src/gsi/setupt.f90
+++ b/src/gsi/setupt.f90
@@ -286,6 +286,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind),dimension(34) :: ptablt
   real(r_single),allocatable,dimension(:,:)::rdiagbuf
   real(r_single),allocatable,dimension(:,:)::rdiagbufp
+  real(r_kind),  allocatable,dimension(:,:)::data_kept
 
 
   real(r_kind),dimension(nsig):: prsltmp2
@@ -298,6 +299,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   integer(i_kind) regime
   integer(i_kind) idomsfc,iskint,iff10,isfcr
   integer(i_kind) ibb,ikk,idddd
+  integer(i_kind) i_dat
 
   integer(i_kind),dimension(nobs):: buddyuse
 
@@ -375,7 +377,26 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
 !  call GSD terrain match for surface temperature observation
   if(l_gsd_terrain_match_surftobs) then
+     if ( l_rtma3d ) then               !keeping original reported info changed in gsd_terrain_match_surfTobs
+        if ( allocated(data_kept) ) deallocate(data_kept)
+        allocate(data_kept(5,nobs))
+        data_kept(:,:) = -9999.0_r_kind
+        data_kept(1,:) = data( 5,:)        !tob		: temperature obsevation (tv or tsen) (itob=5)
+        data_kept(2,:) = data( 4,:)        !dlnpob	: log of reported pressure (cb) (ipres=4)
+        data_kept(3,:) = data(19,:)        !stnelev	: station elevation (istnelv=19)
+        data_kept(4,:) = data( 1,:)        !toe		: obs error (ier=1)
+        data_kept(5,:) = 0.0_r_kind        !marker	: =0, if obs info is not changed in gsd_terrain_match_surfTobs
+     end if
      call gsd_terrain_match_surfTobs(mype,nele,nobs,data)
+     if ( l_rtma3d ) then               !checking if original reported info is changed in gsd_terrain_match_surfTobs
+        do i_dat=1,nobs
+           if ( abs(data_kept(1,i_dat)-data( 5,i_dat)) > tiny_r_kind .or.       &
+                abs(data_kept(2,i_dat)-data( 4,i_dat)) > tiny_r_kind .or.       &
+                abs(data_kept(3,i_dat)-data(19,i_dat)) > tiny_r_kind ) then
+              data_kept(5,:) = 1.0_r_kind  !marker	: =1, if obs info is changed in gsd_terrain_match_surfTobs
+           end if
+        end do
+     end if
   endif
 
 !    index information for data array (see reading routine)
@@ -502,6 +523,9 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        allocate(cprvstg(nobs),csprvstg(nobs))      ! provider/subprovider info
        if(l_pbl_pseudo_surfobst) allocate(cprvstgp(nobs*3),csprvstgp(nobs*3))  ! provider of pseudo obs 
      endif
+     if ( l_rtma3d .and. l_gsd_terrain_match_surftobs ) then
+        nreal = nreal + 3          ! to save the reported obs info (tob, lnpob, stnelev)
+     end if
      if (save_jacobian) then
        nnz   = 2                   ! number of non-zero elements in dH(x)/dx profile
        nind   = 1
@@ -1382,6 +1406,8 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     if(l_pbl_pseudo_surfobst) deallocate(cdiagbufp,rdiagbufp)
   end if
 
+  if ( allocated(data_kept) ) deallocate(data_kept)
+
 
 ! End of routine
 
@@ -1593,6 +1619,8 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   subroutine contents_binary_diag_(odiag)
     type(obs_diag),pointer,intent(in):: odiag
 
+    real(r_kind)                     :: prest_kept
+
     cdiagbuf(ii)    = station_id         ! station id
 
     rdiagbuf(1,ii)  = ictype(ikx)        ! observation type
@@ -1667,6 +1695,17 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        r_sprvstg           = data(isprvd,i)
        csprvstg(ii)        = c_sprvstg       ! subprovider name
     endif
+
+!   saving the original reported obs info changed in gsd_terrain_match_surfTobs
+    if ( l_rtma3d .and. l_gsd_terrain_match_surftobs ) then
+       idia = idia + 1
+       rdiagbuf(idia,ii) = data_kept(1,i)    ! original reported tob
+       idia = idia + 1
+       prest_kept = r10*exp(data_kept(2,i))  ! cb --> mb
+       rdiagbuf(idia,ii) = prest_kept        ! original reported log of pressure (cb)
+       idia = idia + 1
+       rdiagbuf(idia,ii) = data_kept(3,i)    ! original reported station elevation
+    end if
 
     if (save_jacobian) then
        call writearray(dhx_dx, rdiagbuf(idia+1:nreal,ii))
@@ -1746,6 +1785,18 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 !      r_sprvstg           = data(isprvd,i)
        csprvstgp(iip)        = '88888888'    !c_sprvstg       ! subprovider name
     endif
+
+!   saving the original reported obs info changed in gsd_terrain_match_surfTobs
+!   (pseudo obs does not call gsd_terrain_match_surfTobs, but because same "nreal"
+!    is used for both true obs and pseudo obs, save the "fake" info for pseudo obs)
+    if ( l_rtma3d .and. l_gsd_terrain_match_surftobs ) then
+       idia = idia + 1
+       rdiagbufp(idia,iip) = -9999._r_single ! original reported tob
+       idia = idia + 1
+       rdiagbufp(idia,iip) = -9999._r_single ! original reported log of pressure (cb)
+       idia = idia + 1
+       rdiagbufp(idia,iip) = -9999._r_single ! original reported station elevation
+    end if
 !----
 
      if (save_jacobian) then
@@ -1762,6 +1813,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_single),parameter::     missing = -9.99e9_r_single
 
   real(r_kind),dimension(miter) :: obsdiag_iuse
+  real(r_kind)                  :: prest_kept
 
     call nc_diag_metadata("Station_ID",              station_id             )
     call nc_diag_metadata("Observation_Class",       obsclass               )
@@ -1841,6 +1893,15 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        call nc_diag_metadata("Subprovider_Name",  c_sprvstg                    )
     endif
 
+!   saving the original reported obs info changed in gsd_terrain_match_surfTobs
+    if ( l_rtma3d .and. l_gsd_terrain_match_surftobs ) then
+       call nc_diag_metadata_to_single("Observation_reported",       data_kept(1,i) )
+       prest_kept = r10*exp(data_kept(2,i))          ! cb --> mb
+       call nc_diag_metadata_to_single("Pressure_reported",          prest_kept     )
+       call nc_diag_metadata_to_single("Station_Elevation_reported", data_kept(3,i) )
+       call nc_diag_metadata_to_single("ObsInfo_UnChanged_marker",   data_kept(5,i) )
+    end if
+
     if (save_jacobian) then
        call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
        call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
@@ -1909,6 +1970,15 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        call nc_diag_metadata("Subprovider_Name",  "88888888"                   )
     endif
 
+!   saving the original reported obs info changed in gsd_terrain_match_surfTobs
+!   (pseudo obs does not call gsd_terrain_match_surfTobs, but because same "nreal"
+!    is used for both true obs and pseudo obs, save the "fake" info for pseudo obs)
+    if ( l_rtma3d .and. l_gsd_terrain_match_surftobs ) then
+       call nc_diag_metadata("Observation_reported",       missing         )
+       call nc_diag_metadata("Pressure_reported",          missing         )
+       call nc_diag_metadata("Station_Elevation_reported", missing         )
+       call nc_diag_metadata("ObsInfo_UnChanged_marker",   missing         )
+    end if
 !----
     if (save_jacobian) then
        call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)

--- a/src/gsi/setupt.f90
+++ b/src/gsi/setupt.f90
@@ -524,7 +524,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        if(l_pbl_pseudo_surfobst) allocate(cprvstgp(nobs*3),csprvstgp(nobs*3))  ! provider of pseudo obs 
      endif
      if ( l_rtma3d .and. l_gsd_terrain_match_surftobs ) then
-        nreal = nreal + 3          ! to save the reported obs info (tob, lnpob, stnelev)
+        nreal = nreal + 4          ! to save the reported obs info (tob, lnpob, stnelev and change-marker)
      end if
      if (save_jacobian) then
        nnz   = 2                   ! number of non-zero elements in dH(x)/dx profile
@@ -1705,6 +1705,8 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        rdiagbuf(idia,ii) = prest_kept        ! original reported log of pressure (cb)
        idia = idia + 1
        rdiagbuf(idia,ii) = data_kept(3,i)    ! original reported station elevation
+       idia = idia + 1
+       rdiagbuf(idia,ii) = data_kept(5,i)    ! marker if obs info is changed (0:no; 1: changed)
     end if
 
     if (save_jacobian) then
@@ -1796,6 +1798,8 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        rdiagbufp(idia,iip) = -9999._r_single ! original reported log of pressure (cb)
        idia = idia + 1
        rdiagbufp(idia,iip) = -9999._r_single ! original reported station elevation
+       idia = idia + 1
+       rdiagbufp(idia,iip) = -9999._r_single ! marker whether obs info is changed or not
     end if
 !----
 


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

### Description
<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

**_Motivation_**
When using the function "gsd_terrain_match_surfTobs", for the surface obs-type , the original reported observation of temperature (tob), its pre-set observation error (oerr), the reported pressure (pobs) and the station elevation (stnelev) might be changed, correspondingly the observation information (tob/stnelev/pobs) saved in observation diagnostic file of temperature are not the original reported values. However, some users of (3D)RTMA (e.g. the WFO forecasters) require to keep the original reported observation information available in the obs-diag file. So there is a necessity, for 3DRTMA system, to save the original reported observation information (obs value, pressure, station elevation) before they are changed by terrain-match adjustment. Also see Issue #867 for reference.

**_Methods_**
In subroutine **_setupt_** (in setupt.f90), before calling  subroutine "**_gsd_terrain_match_surfTobs_**", use a new array "**_data_kept_**" to save original value of preset obs error (**_oerr==>data(1,:)_**), reported pressure (**_lnpobs==>data(4,:)_**), the reported temperature obs (**_tob==>data(5,:)_**) and station elevation (**_stnelev==>data(19,:)_**), then dump these original reported data into obs-diag file (in both binary and netcdf format)

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->
Resolves #867

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
- Tests for the Newly-added Function:
  - about the newlly-added function
      1. In setupt.f90, the added function to keep the original reported obs info and store them in the T-obs-diag file is working **_only when 3DRTMA run with terrain-match adjustment_** (l_rtma3d = .true., l_gsd_terrain_match_surftobs = .true.).  
      2. New allocatable  array data_kept is allocated and used to save the original reported tob/oerr/dlnpob/stnelev only for 3DRTMA run with terrain-match adjsutment.  
      3. The original reported obs info is saved in T-obs-diag file only for 3DRTMA run with terrain-match adjustment
  - Test the new function:
      -  **_Control run_** (using current latest GSI code (commit [#d861384](https://github.com/NOAA-EMC/GSI/commit/d8613840800ab6e85d701a75efc16ca2c9c8c177)) in develop branch in offical EMC-GSI repo)  vs **_Experimental run_** (using modified GSI code in branch "feature/saving_obs4sfcT_rtma3d" of my fork of EMC-GSI with added function for this PR, current commit [#6153cb9](https://github.com/GangZhao-NOAA/GSI/commit/6153cb97e8cb15b4c2dab097f379288a7cb390a4)):
          - the analysis files from control run and exp run are **_identical_**, the minimisation (fort.220), obs-fitting stats (fort.201~fort.228) are also **_same_** for both runs;
          - both control and exp run are regional hybrid 3DEnVar run with WRF-ARW firstguess for 3DRTMA;
          - This is because the newly-added code/function in this PR does **NOT** get involved with any GSI analysis operations (such as QC, cost and gradient, minimisation, etc.), the . It just saves a few obs info in an additional array (data_kept) and _**appends (not replaces)**_ the info to the obs diagnostic file. 
      - Test the new function in experimental run for 3DRTMA with terrain-match adjustment (in GSI namelist file, set  l_rtma3d = .true., l_gsd_terrain_match_surftobs = .true.)
          - the analysis results, minimisation, obs-fitting, etc are still same as the results from control run, which is as expected, since newly-added function does not influence the analysis at all;
          - the differences are in the T-obs-diag files:  the newly appended data could be read, they are the original reported obs info, which is expected as the purpose of this PR.
   
- GSI CTest: the modified GSI code passed all the 6 regression tests in current GSI CTest suite on Hera and WCOSS2. 
  - Following the [CTest instructions in GSI Wiki page](https://github.com/NOAA-EMC/GSI/wiki/GSI-Ctests-(regression-tests)#to-use-ctest-to-run-the-regression-tests) to run the CTests;
  - CTests Results:
        <details><summary>the report from CTests running on Hera: (<==_click to see the reports_)</summary>
        <p>
(work-env2) [Gang.Zhao@hfe11:build] (feature/saving_obs4sfcT_rtma3d)$ ctest -N
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
  Test # 1: global_4denvar
  Test # 2: rtma
  Test # 3: rrfs_3denvar_rdasens
  Test # 4: hafs_4denvar_glbens
  Test # 5: hafs_3denvar_hybens
  Test # 6: global_enkf
Total Tests: 6
(work-env2) [Gang.Zhao@hfe11:build] (feature/saving_obs4sfcT_rtma3d)$ ctest -j 6
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test # 3: rrfs_3denvar_rdasens .............   Passed  555.23 sec
2/6 Test # 6: global_enkf ......................   Passed  1180.26 sec
3/6 Test # 1: global_4denvar ...................   Passed  3359.21 sec
4/6 Test # 5: hafs_3denvar_hybens ..............   Passed  3578.33 sec
5/6 Test # 4: hafs_4denvar_glbens ..............   Passed  3638.36 sec
6/6 Test # 2: rtma .............................   Passed  11843.52 sec
100% tests passed, 0 tests failed out of 6
Total Test time (real) = 11843.59 sec
        </p>
        </details> 
        <details><summary>the report from CTests running on WCOSS2 Hera:</summary>
        <p>
(work-env2) [Gang.Zhao@hfe11:build] (feature/saving_obs4sfcT_rtma3d)$ ctest -N
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
  Test # 1: global_4denvar
  Test # 2: rtma
  Test # 3: rrfs_3denvar_rdasens
  Test # 4: hafs_4denvar_glbens
  Test # 5: hafs_3denvar_hybens
  Test # 6: global_enkf
Total Tests: 6
(work-env2) [Gang.Zhao@hfe11:build] (feature/saving_obs4sfcT_rtma3d)$ ctest -j 6
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test # 3: rrfs_3denvar_rdasens .............   Passed  555.23 sec
2/6 Test # 6: global_enkf ......................   Passed  1180.26 sec
3/6 Test # 1: global_4denvar ...................   Passed  3359.21 sec
4/6 Test # 5: hafs_3denvar_hybens ..............   Passed  3578.33 sec
5/6 Test # 4: hafs_4denvar_glbens ..............   Passed  3638.36 sec
6/6 Test # 2: rtma .............................   Passed  11843.52 sec
100% tests passed, 0 tests failed out of 6
Total Test time (real) = 11843.59 sec
        </p>
        </details> 
 ### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published