### PR TITLE
Feature/add abi g19

### DIFF
--- a/regression/regression_namelists.sh
+++ b/regression/regression_namelists.sh
@@ -180,6 +180,7 @@ OBS_INPUT::
    sstviirs       viirs-m     npp         viirs-m_npp         0.0     4     0
    sstviirs       viirs-m     j1          viirs-m_j1          0.0     4     0
    abibufr        abi         g18         abi_g18             0.0     1     0
+   abibufr        abi         g19         abi_g19             0.0     1     0
    ahibufr        ahi         himawari9   ahi_himawari9       0.0     1     0
    atmsbufr       atms        n21         atms_n21            0.0     1     1
    crisfsbufr     cris-fsr    n21         cris-fsr_n21        0.0     1     0
@@ -470,6 +471,7 @@ OBS_INPUT::
    lghtInGSI      lghtn       null      lghtn                1.0     0     0
    larcInGSI      larccld     null      larccld              1.0     0     0
    abibufr        abi         g18       abi_g18              0.0     2     0
+   abibufr        abi         g19       abi_g19              0.0     2     0
 ::
  &SUPEROB_RADAR
    del_azimuth=5.,del_elev=.25,del_range=5000.,del_time=.5,elev_angle_max=5.,minnum=50,range_max=100000., l2superob_only=.false.,
@@ -723,6 +725,9 @@ OBS_INPUT::
    gmibufr        gmi         gpm         gmi_gpm             0.0     3     0
    saphirbufr     saphir      meghat      saphir_meghat       0.0     3     0
    ahibufr        ahi         himawari8   ahi_himawari8       0.0     3     0
+   ahibufr        ahi         himawari9   ahi_himawari9       0.0     3     0
+   abibufr        abi         g18         abi_g18             0.0     3     0
+   abibufr        abi         g19         abi_g19             0.0     3     0
 ::
  &SUPEROB_RADAR
    del_azimuth=5.,del_elev=.25,del_range=10000.,del_time=1.0,elev_angle_max=5.,minnum=1,range_max=200000.,
@@ -926,6 +931,7 @@ export gsi_namelist="
         sattypes_rad(77)= 'viirs-m_j2',    dsis(77)= 'viirs-m_j2',
         sattypes_rad(78)= 'atms_n21',      dsis(78)= 'atms_n21',
         sattypes_rad(79)= 'cris-fsr_n21',  dsis(79)= 'cris-fsr_n21',
+        sattypes_rad(80)= 'abi_g19',       dsis(80)= 'abi_g19',
     /
     &ozobs_enkf
         sattypes_oz(1) = 'sbuv2_n16',
@@ -1056,6 +1062,7 @@ export gsi_namelist="
    sattypes_rad(77)= 'viirs-m_j2',    dsis(77)= 'viirs-m_j2',
    sattypes_rad(78)= 'atms_n21',      dsis(78)= 'atms_n21',
    sattypes_rad(79)= 'cris-fsr_n21',  dsis(79)= 'cris-fsr_n21',
+   sattypes_rad(80)= 'abi_g19',       dsis(80)= 'abi_g19',
   $SATOBS_ENKF
  /
  &ozobs_enkf

--- a/regression/regression_namelists_db.sh
+++ b/regression/regression_namelists_db.sh
@@ -159,6 +159,9 @@ OBS_INPUT::
    ahibufr        ahi         himawari8   ahi_himawari8       0.0     1     0
    abibufr        abi         g16         abi_g16             0.0     1     0
    abibufr        abi         g17         abi_g17             0.0     1     0
+   ahibufr        ahi         himawari9   ahi_himawari9       0.0     1     0
+   abibufr        abi         g18         abi_g18             0.0     1     0
+   abibufr        abi         g19         abi_g19             0.0     1     0
    rapidscatbufr  uv          null        uv                  0.0     0     0
    ompsnpbufr     ompsnp      npp         ompsnp_npp          0.0     0     0
    ompstcbufr     ompstc8     npp         ompstc8_npp         0.0     2     0
@@ -452,6 +455,7 @@ OBS_INPUT::
    lghtInGSI      lghtn       null      lghtn                1.0     0     0
    larcInGSI      larccld     null      larccld              1.0     0     0
    abibufr        abi         g18       abi_g18              0.0     2     0
+   abibufr        abi         g18       abi_g19              0.0     2     0
 ::
  &SUPEROB_RADAR
    del_azimuth=5.,del_elev=.25,del_range=5000.,del_time=.5,elev_angle_max=5.,minnum=50,range_max=100000., l2superob_only=.false.,

--- a/src/gsi/read_abi.f90
+++ b/src/gsi/read_abi.f90
@@ -240,6 +240,8 @@ subroutine read_abi(mype,val_abi,ithin,rmesh,jsatid,&
      kidsat = 271
   elseif (jsatid == 'g18') then 
      kidsat = 272
+  elseif (jsatid == 'g19') then 
+     kidsat = 273
   else
      write(6,*) 'READ_ABI: Unrecognized value for jsatid '//jsatid//': RETURNING'
      return

--- a/src/gsi/read_obs.F90
+++ b/src/gsi/read_obs.F90
@@ -314,6 +314,8 @@ subroutine read_obs_check (lexist,filename,jsatid,dtype,minuse,nread)
          kidsat=271
        else if(jsatid == 'g18' .or. jsatid == 'g18_prep')then
          kidsat=272
+       else if(jsatid == 'g19' .or. jsatid == 'g19_prep')then
+         kidsat=273
        else if(jsatid == 'himawari8')then
          kidsat=173
        else if(jsatid == 'himawari9')then


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
GOES-19 ABI Clear-Sky Radiance (CSR) products have been operationally available since April 7, 2025. Since then, the global dump gsrcsr has included radiances from both GOES-18 (GOES-West) and GOES-19 (GOES-East).

This PR updates two GSI read subroutines to include the satellite ID for GOES-19. It also makes corresponding changes to the regression test scripts by adding GOES-19 (G19) to the Obs_input list. These updates enable GSI to process GOES-19 ABI CSR data.

The associated issue is: #850

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
The regression tests have been conducted on Hera and all passed. Please Note: The default test data directory (/scratch1/NCEPDEV/da/Russ.Treadon/CASES/) does not contain GOES-19 CSR data, so identical results were expected between the control and experiment runs.

6 Test project /scratch1/NCEPDEV/stmp2/Haixia.Liu/GSI_abi_g19/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test #3: rrfs_3denvar_rdasens .............   Passed  805.04 sec
2/6 Test #2: rtma .............................   Passed  1755.07 sec
3/6 Test #4: hafs_4denvar_glbens ..............   Passed  1780.99 sec
4/6 Test #5: hafs_3denvar_hybens ..............   Passed  1781.08 sec
5/6 Test #6: global_enkf ......................   Passed  1927.87 sec
6/6 Test #1: global_4denvar ...................   Passed  2218.32 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) = 2218.34 sec

Meanwhile, I have already had a parallel experiment set up and running on Hera with these changes incorporated. The analysis results are as expected when the G19 CSR is either monitored or assimilated. The gsistat files from my control and experiment can be found on Hera: 

- control: /scratch1/NCEPDEV/da/Haixia.Liu/archive/g19csrc 
- experiment: /scratch1/NCEPDEV/da/Haixia.Liu/archive/g19csre

 G19 CSR is turned on starting with the 2025040906 cycle. 

G19 CRTM coefficient files can be found at: /scratch1/NCEPDEV/da/Andrew.Collard/CRTM/fix_REL-3.1.1.3/fix

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published