### PR TITLE
Ensure status is 'old' for blacklist

### DIFF
--- a/src/gsi/blacklist.f90
+++ b/src/gsi/blacklist.f90
@@ -102,7 +102,7 @@ contains
 
     if (blacklist_initialized) return
     iblktbl = 19
-    open(iblktbl,file='blacklist',form='formatted')
+    open(iblktbl, file='blacklist', form='formatted', status='old')
     rewind iblktbl
     ibcnt = 0
     ilcnt = 0


### PR DESCRIPTION
**Description**
Found in https://github.com/NOAA-EMC/global-workflow/pull/3599#issuecomment-2843006032
This PR should error if the blacklist file is missing rather than create a file of size 0.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Still needs testing
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published