### PR TITLE
Adding Direct Analysis of Visibility in GSI 3D analysis for HRRR-based 3DRTMA

### DIFF
--- a/src/gsi/cplr_read_wrf_mass_guess.f90
+++ b/src/gsi/cplr_read_wrf_mass_guess.f90
@@ -1394,7 +1394,7 @@ contains
          aerotot_guess,init_aerotot_guess,wrf_pm2_5,aero_ratios
     use rapidrefresh_cldsurf_mod, only: l_hydrometeor_bkio,l_gsd_soiltq_nudge
     use rapidrefresh_cldsurf_mod, only: i_use_2mq4b,i_use_2mt4b
-    use rapidrefresh_cldsurf_mod, only: i_howv_3dda, i_gust_3dda, i_sfcrough_fgs
+    use rapidrefresh_cldsurf_mod, only: i_howv_3dda, i_gust_3dda, i_sfcrough_fgs, i_vis_3dda
     use wrf_mass_guess_mod, only: soil_temp_cld,isli_cld,ges_xlon,ges_xlat,ges_tten,create_cld_grids
     use gsi_bundlemod, only: GSI_BundleGetPointer
     use gsi_metguess_mod, only: gsi_metguess_get,GSI_MetGuess_Bundle
@@ -1406,6 +1406,8 @@ contains
     use obsmod,only: if_model_dbz
     use directDA_radaruse_mod, only: l_use_cvpqx, cvpqx_pval, l_use_dbz_directDA
     use directDA_radaruse_mod, only: l_cvpnr, cvpnr_pval                                          
+    use qcmod, only: pvis,scale_cv
+    use nltransf, only: nltransf_forward
 
     implicit none
     class(read_wrf_mass_guess_class),intent(inout) :: this
@@ -1419,6 +1421,7 @@ contains
   
   ! Declare local variables
     integer(i_kind) kt,kq,ku,kv,kw,kw0,kdbz
+    real(r_kind) dummy_loc,dummyout_loc
   
   ! MASS variable names stuck in here
   
@@ -1447,7 +1450,7 @@ contains
     integer(i_kind) i_qc,i_qi,i_qr,i_qs,i_qg,i_qnr,i_qni,i_qnc,i_w,i_dbz
     integer(i_kind) kqc,kqi,kqr,kqs,kqg,kqnr,kqni,kqnc,i_xlon,i_xlat,i_tt,ktt
     integer(i_kind) i_th2,i_q2,i_soilt1,ksmois,ktslb
-    integer(i_kind) i_howv, i_gust, i_rough
+    integer(i_kind) i_howv, i_gust, i_rough, i_vis
     integer(i_kind) ier, istatus
     integer(i_kind) n_actual_clouds
     integer(i_kind) iv,n_gocart_var
@@ -1473,6 +1476,7 @@ contains
     real(r_kind), pointer :: ges_w_it  (:,:,:)=>NULL()
     real(r_kind), pointer :: ges_howv_it (:,:)=>NULL()
     real(r_kind), pointer :: ges_gust_it (:,:)=>NULL()
+    real(r_kind), pointer :: ges_vis_it ( :,:)=>NULL()
   
     real(r_kind), pointer :: ges_qc (:,:,:)=>NULL()
     real(r_kind), pointer :: ges_qi (:,:,:)=>NULL()
@@ -1567,6 +1571,7 @@ contains
        if( i_howv_3dda > 0 ) num_mass_fields = num_mass_fields + 1
        if( i_gust_3dda > 0 ) num_mass_fields = num_mass_fields + 1
        if( i_sfcrough_fgs > 0 ) num_mass_fields = num_mass_fields + 1
+       if( i_vis_3dda > 0 ) num_mass_fields = num_mass_fields + 1
 
        if (laeroana_gocart .and. wrf_pm2_5 ) then
           if(mype==0) write(6,*)'laeroana_gocart canoot be both true'
@@ -1753,18 +1758,25 @@ contains
          write(identity(i),'("record ",i3,"--howv")')i
          jsig_skip(i)=0 ; igtype(i)=1
        end if
-  !  for wind gust (gust is after tsk/q2/soilt1/th2, and before cloud hydrometers) 
+  !  for wind gust (gust is after tsk/q2/soilt1/th2/howv, and before cloud hydrometers) 
        if ( i_gust_3dda >0 ) then
          i=i+1 ; i_gust=i                                                ! gust
          write(identity(i),'("record ",i3,"--gust")')i
          jsig_skip(i)=0 ; igtype(i)=1
        end if
-  !  for surface roughness (sfcrough is after tsk/q2/soilt1/th2, and before cloud hydrometers) 
+  !  for surface roughness (sfcrough is after tsk/q2/soilt1/th2/howv/gust, and before cloud hydrometers) 
        if ( i_sfcrough_fgs >0 ) then
          i=i+1 ; i_rough=i                                               ! roughtness
          write(identity(i),'("record ",i3,"--rough")')i
          jsig_skip(i)=0 ; igtype(i)=1
        end if
+  !  for visibility (visibility is after tsk/q2/soilt1/th2/howv/gust/znt, and before cloud hydrometers) 
+       if ( i_vis_3dda >0 ) then
+         i=i+1 ; i_vis=i                                                 ! vis
+         write(identity(i),'("record ",i3,"--vis")')i
+         jsig_skip(i)=0 ; igtype(i)=1
+       end if
+
   ! for cloud array
        if(l_hydrometeor_bkio .and. n_actual_clouds>0) then
           i_qc=i+1
@@ -1976,6 +1988,10 @@ contains
           if ( i_gust_3dda >0 ) then
              call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'gust',ges_gust_it,istatus );ier=ier+istatus
              if (ier/=0) call die(trim(myname),'cannot get pointers for met-field: gust, ier =',ier)
+          end if
+          if ( i_vis_3dda >0 ) then
+             call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'vis',ges_vis_it,istatus );ier=ier+istatus
+             if (ier/=0) call die(trim(myname),'cannot get pointers for met-field: vis, ier =',ier)
           end if
           if (l_gsd_soilTQ_nudge) then
              call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'tskn',ges_tsk_it, istatus );ier=ier+istatus 
@@ -2318,6 +2334,16 @@ contains
   ! wind gust (gust)
                 if ( i_gust_3dda >0 ) then
                     ges_gust_it(j,i)  = real(all_loc(j,i,i_0+i_gust),r_kind)
+                end if
+  ! visibility (vis)
+                if ( i_vis_3dda >0 ) then
+  !                 ges_vis_it(j,i)  = real(all_loc(j,i,i_0+i_vis),r_kind)
+  !               Applying nonlinear transform to firstguess of visibility
+  !                 physical space ==> analysis space, "g-space"
+  !                 (firstguess had been pre-processed to be in [1.0, vis_thres])
+                    dummy_loc = real(all_loc(j,i,i_0+i_vis),r_kind)
+                    call nltransf_forward(dummy_loc,dummyout_loc,pvis,scale_cv)
+                    ges_vis_it(j,i)  = dummyout_loc
                 end if
   ! for cloud analysis
                 if(l_hydrometeor_bkio .and. n_actual_clouds>0) then

--- a/src/gsi/cplr_read_wrf_mass_guess.f90
+++ b/src/gsi/cplr_read_wrf_mass_guess.f90
@@ -2337,7 +2337,6 @@ contains
                 end if
   ! visibility (vis)
                 if ( i_vis_3dda >0 ) then
-  !                 ges_vis_it(j,i)  = real(all_loc(j,i,i_0+i_vis),r_kind)
   !               Applying nonlinear transform to firstguess of visibility
   !                 physical space ==> analysis space, "g-space"
   !                 (firstguess had been pre-processed to be in [1.0, vis_thres])

--- a/src/gsi/cplr_regional_io.f90
+++ b/src/gsi/cplr_regional_io.f90
@@ -88,7 +88,7 @@ contains
       use mpimod, only: mpi_comm_world,ierror
       use wrf_params_mod, only: update_pint,cold_start
       use gsi_io, only: verbose
-      use rapidrefresh_cldsurf_mod, only: i_howv_3dda, i_gust_3dda
+      use rapidrefresh_cldsurf_mod, only: i_howv_3dda, i_gust_3dda, i_vis_3dda
       use rapidrefresh_cldsurf_mod, only: i_howv_mask, i_sfcrough_fgs
 
       implicit none
@@ -149,13 +149,14 @@ contains
          call mpi_bcast(byte_swap,1,mpi_integer4,0,mpi_comm_world,ierror)
          call mpi_bcast(i_howv_3dda, 1, mpi_itype, 0, mpi_comm_world, ierror)
          call mpi_bcast(i_gust_3dda, 1, mpi_itype, 0, mpi_comm_world, ierror)
+         call mpi_bcast(i_vis_3dda,  1, mpi_itype, 0, mpi_comm_world, ierror)
          call mpi_bcast(i_howv_mask, 1, mpi_itype, 0, mpi_comm_world, ierror)
          call mpi_bcast(i_sfcrough_fgs, 1, mpi_itype, 0, mpi_comm_world, ierror)
          if(print_verbose)write(6,*)' in convert_regional_guess, for wrf arw binary input, byte_swap=',byte_swap
          if (mype <= 1 .and. print_verbose) then
-            write(6,'(1x,A,4(2x,I4),2x,A6,I6.6,A2)')                                   &
-              ' in convert_regional_guess, i_howv_3dda i_gust_3dda i_howv_mask i_sfcrough_fgs=',     &
-              i_howv_3dda,i_gust_3dda,i_howv_mask,i_sfcrough_fgs,'  (pe=',mype,').'
+            write(6,'(1x,A,5(2x,I4),2x,A6,I6.6,A2)')                                   &
+              ' in convert_regional_guess, i_howv_3dda i_gust_3dda i_vis_3dda i_howv_mask i_sfcrough_fgs=',     &
+              i_howv_3dda,i_gust_3dda,i_vis_3dda,i_howv_mask,i_sfcrough_fgs,'  (pe=',mype,').'
          end if
   
       elseif (cmaq_regional) then

--- a/src/gsi/cplr_wrf_netcdf_interface.f90
+++ b/src/gsi/cplr_wrf_netcdf_interface.f90
@@ -1197,8 +1197,8 @@ contains
 !            Apply threshold vis_thres to first guess of visibility
 !              put data in domain of [1.0, vis_threshold] to prepare for nonlinear transform
 !---------------------------------------------------------------------------
-             if(print_verbose)write(6,'(1x,A,A,2(1x,F12.5))')'convert_netcdf_mass_wrf:: max,min of original ', &
-                trim(adjustl(rmse_var)),'=',maxval(field2),minval(field2)
+             if(print_verbose)write(6,'(1x,3A,2(1x,F12.5))')'convert_netcdf_mass_wrf:: max,min of original ', &
+                trim(adjustl(rmse_var)),' = ',maxval(field2),minval(field2)
              do j=1,nlon_regional
                 do i=1,nlat_regional   
 !                    if (field2(j,i) <= 0.0_r_single) field2(j,i)=one_single
@@ -1206,8 +1206,8 @@ contains
                      field2(j,i) = max(min(field2(j,i), vis_thres), one_single)
                 enddo
              enddo
-             if(print_verbose)write(6,'(1x,A,A,2(1x,F12.5))')'convert_netcdf_mass_wrf:: max,min of adjusted  ', &
-                trim(adjustl(rmse_var)),'=',maxval(field2),minval(field2)
+             if(print_verbose)write(6,'(1x,3A,2(1x,F12.5))')'convert_netcdf_mass_wrf:: max,min of adjusted ', &
+                trim(adjustl(rmse_var)),' = ',maxval(field2),minval(field2)
              write(iunit)field2   !VIS   (2D Visibility)
              i_vis_3dda = 2               ! vis was found both in anavinfo and firstguess
           else

--- a/src/gsi/cplr_wrf_netcdf_interface.f90
+++ b/src/gsi/cplr_wrf_netcdf_interface.f90
@@ -1201,8 +1201,6 @@ contains
                 trim(adjustl(rmse_var)),' = ',maxval(field2),minval(field2)
              do j=1,nlon_regional
                 do i=1,nlat_regional   
-!                    if (field2(j,i) <= 0.0_r_single) field2(j,i)=one_single
-!                    if (field2(j,i) >= vis_thres   ) field2(j,i)=vis_thres
                      field2(j,i) = max(min(field2(j,i), vis_thres), one_single)
                 enddo
              enddo

--- a/src/gsi/cplr_wrf_netcdf_interface.f90
+++ b/src/gsi/cplr_wrf_netcdf_interface.f90
@@ -66,7 +66,7 @@ contains
     use gsi_4dvar, only: nhr_assimilation
     use rapidrefresh_cldsurf_mod, only: l_hydrometeor_bkio,l_gsd_soilTQ_nudge
     use rapidrefresh_cldsurf_mod, only: i_use_2mt4b,i_use_2mq4b
-    use rapidrefresh_cldsurf_mod, only: i_howv_3dda, i_gust_3dda
+    use rapidrefresh_cldsurf_mod, only: i_howv_3dda, i_gust_3dda, i_vis_3dda
     use rapidrefresh_cldsurf_mod, only: i_howv_mask, i_sfcrough_fgs
     use gsi_metguess_mod, only: gsi_metguess_get
     use chemmod, only: laeroana_gocart, ppmv_conv,wrf_pm2_5
@@ -80,6 +80,7 @@ contains
     use obsmod, only   : if_model_dbz
     use gsi_io, only: verbose
     use directDA_radaruse_mod, only: l_use_dbz_directDA
+    use qcmod, only: vis_thres
   
     implicit none
   
@@ -1169,6 +1170,53 @@ contains
                'convert_netcdf_mass_wrf:: ZNT (sfc_roughness) is NOT in firstguess. Re-set i_sfcrough_fgs=',i_sfcrough_fgs
           end if
        end if ! i_sfcrough_fgs (reading surface roughness from netcdf-format background)
+
+!      Reading Visibility (VIS) in firstguess (it is dumped in sigf after TH2/HOWV/GUST/ZNT, and before cloud variables)
+       if(i_vis_3dda >= 1) then                   ! if vis is found in anavinfo
+          rmse_var='VIS'
+          call ext_ncd_get_var_info (dh1,trim(rmse_var),ndim1,ordering,staggering, &
+               start_index,end_index, WrfType, ierr    )
+          if(print_verbose)then
+             write(6,*)' rmse_var=',trim(rmse_var)
+             write(6,*)' ordering=',ordering
+             write(6,*)' WrfType,ierr=',WrfType,ierr
+             write(6,*)' ndim1=',ndim1
+             write(6,*)' staggering=',staggering
+             write(6,*)' start_index=',start_index
+             write(6,*)' end_index=',end_index
+          end if
+          if(ierr == 0) then
+             call ext_ncd_read_field(dh1,DateStr1,TRIM(rmse_var),              &
+                  field2,WRF_REAL,0,0,0,ordering,           &
+                  staggering, dimnames ,               &
+                  start_index,end_index,               & !dom
+                  start_index,end_index,               & !mem
+                  start_index,end_index,               & !pat
+                  ierr                                 )
+!---------------------------------------------------------------------------
+!            Apply threshold vis_thres to first guess of visibility
+!              put data in domain of [1.0, vis_threshold] to prepare for nonlinear transform
+!---------------------------------------------------------------------------
+             if(print_verbose)write(6,'(1x,A,A,2(1x,F12.5))')'convert_netcdf_mass_wrf:: max,min of original ', &
+                trim(adjustl(rmse_var)),'=',maxval(field2),minval(field2)
+             do j=1,nlon_regional
+                do i=1,nlat_regional   
+!                    if (field2(j,i) <= 0.0_r_single) field2(j,i)=one_single
+!                    if (field2(j,i) >= vis_thres   ) field2(j,i)=vis_thres
+                     field2(j,i) = max(min(field2(j,i), vis_thres), one_single)
+                enddo
+             enddo
+             if(print_verbose)write(6,'(1x,A,A,2(1x,F12.5))')'convert_netcdf_mass_wrf:: max,min of adjusted  ', &
+                trim(adjustl(rmse_var)),'=',maxval(field2),minval(field2)
+             write(iunit)field2   !VIS   (2D Visibility)
+             i_vis_3dda = 2               ! vis was found both in anavinfo and firstguess
+          else
+             i_vis_3dda = 0               ! skipping analysis of this variable
+             derr_msg='Warning: Error when get info in firstguess for var : '//trim(rmse_var)//    &
+                      ' ==> Stop GSI analysis ...  ierr='
+             call die(trim(adjustl(myname_)),trim(adjustl(derr_msg)),ierr)
+          end if
+       endif  ! i_vis_3dda (reading 2D visibility from netcdf-format background) 
 
        if(l_hydrometeor_bkio .and. n_actual_clouds>0) then
           rmse_var='QCLOUD'
@@ -2586,6 +2634,7 @@ contains
     use rapidrefresh_cldsurf_mod, only: l_hydrometeor_bkio,l_gsd_soilTQ_nudge
     use rapidrefresh_cldsurf_mod, only: i_gsdcldanal_type
     use rapidrefresh_cldsurf_mod, only: i_howv_3dda, i_gust_3dda, i_sfcrough_fgs
+    use rapidrefresh_cldsurf_mod, only: i_vis_3dda
     use gsi_metguess_mod, only: gsi_metguess_get,GSI_MetGuess_Bundle
     use rapidrefresh_cldsurf_mod, only: i_use_2mt4b,i_use_2mq4b
     use gsi_bundlemod, only: GSI_BundleGetPointer
@@ -3211,6 +3260,34 @@ contains
        read(iunit)   field2   !ZNT (surface roughness)
        if(print_verbose)write(6,*)'update_netcdf_mass_wrf:: max,min ZNT(sfc_rough)=',maxval(field2),minval(field2)
     end if ! i_sfcrough_fgs (surface roughness)
+
+!   writing analysis of visibility (VIS) into firstguess (analysis) file
+!   (Note: in sigf file, visibility is after TH2/HOWV/GUST/ZNT, and before cloud variables.)
+    if(i_vis_3dda==2) then
+       read(iunit)   field2   !VIS (visibility)
+       rmse_var='VIS'
+       if(print_verbose)write(6,'(1x,4A,2(1x,F15.7))')                          &
+                        trim(adjustl(myname_)),'::max,min ',trim(rmse_var),'=', &
+                        maxval(field2),minval(field2)
+       call ext_ncd_get_var_info (dh1,trim(rmse_var),ndim1,ordering,staggering, &
+            start_index,end_index1, WrfType, ierr    )
+       if(print_verbose)then
+          write(6,*)' rmse_var=',trim(rmse_var)
+          write(6,*)' ordering=',ordering
+          write(6,*)' WrfType,WRF_REAL=',WrfType,WRF_REAL
+          write(6,*)' ndim1=',ndim1
+          write(6,*)' staggering=',staggering
+          write(6,*)' start_index=',start_index
+          write(6,*)' end_index1=',end_index1
+       end if
+       call ext_ncd_write_field(dh1,DateStr1,TRIM(rmse_var),              &
+            field2,WRF_REAL,0,0,0,ordering,           &
+            staggering, dimnames ,               &
+            start_index,end_index1,               & !dom
+            start_index,end_index1,               & !mem
+            start_index,end_index1,               & !pat
+            ierr                                 )
+    endif  ! i_vis_3dda (visibility)
 
     if (l_hydrometeor_bkio .and. n_actual_clouds>0) then
       do k=1,nsig_regional

--- a/src/gsi/cplr_wrwrfmassa.f90
+++ b/src/gsi/cplr_wrwrfmassa.f90
@@ -2672,7 +2672,6 @@ contains
         end if
         do i=1,lon2
            do j=1,lat2
-  !            all_loc(j,i,i_vis)=ges_vis_it(j,i)
   !          applying inverse nonlinear transform to analysis of visibility 
   !            analysis "g-space" ==> physical space
                tempvis=ges_vis_it(j,i)

--- a/src/gsi/cplr_wrwrfmassa.f90
+++ b/src/gsi/cplr_wrwrfmassa.f90
@@ -1876,7 +1876,7 @@ contains
     use gsi_io, only: verbose
     use rapidrefresh_cldsurf_mod, only: l_hydrometeor_bkio,l_gsd_soilTQ_nudge,&
          i_use_2mq4b,i_use_2mt4b
-    use rapidrefresh_cldsurf_mod, only: i_howv_3dda, i_gust_3dda
+    use rapidrefresh_cldsurf_mod, only: i_howv_3dda, i_gust_3dda, i_vis_3dda
     use rapidrefresh_cldsurf_mod, only: i_howv_mask, i_sfcrough_fgs
     
     use chemmod, only: laeroana_gocart,wrf_pm2_5
@@ -1891,6 +1891,8 @@ contains
     use directDA_radaruse_mod, only: l_use_dbz_directDA
     use directDA_radaruse_mod, only: init_mm_qnr
     use directDA_radaruse_mod, only: l_cvpnr, cvpnr_pval
+    use qcmod, only: pvis,scale_cv,vis_thres
+    use nltransf, only: nltransf_inverse 
 
     implicit none
   
@@ -1917,7 +1919,7 @@ contains
     integer(i_kind) i_qc,i_qi,i_qr,i_qs,i_qg,i_qnr,i_qni,i_qnc
     integer(i_kind) kqc,kqi,kqr,kqs,kqg,kqnr,kqni,kqnc,i_tt,ktt,kw,kdbz
     integer(i_kind) i_sst,i_skt,i_th2,i_q2,i_soilt1,i_tslb,i_smois,ktslb,ksmois
-    integer(i_kind) i_howv, i_gust
+    integer(i_kind) i_howv, i_gust, i_vis
     integer(i_kind) :: iv, n_gocart_var,i_snowT_check
     integer(i_kind),allocatable :: i_chem(:), kchem(:)
     integer(i_kind) num_mass_fields,num_all_fields,num_all_pad,num_mass_fields_base
@@ -1931,6 +1933,7 @@ contains
     real(r_single) aeta10(nsig),eta10(nsig+1),aeta20(nsig),eta20(nsig+1)
     real(r_single) glon0(nlon_regional,nlat_regional),glat0(nlon_regional,nlat_regional)
     real(r_single) dx_mc0(nlon_regional,nlat_regional),dy_mc0(nlon_regional,nlat_regional)
+    real(r_kind)   tempvis,visout
 
 !--- used to read lakemask for screen off analysis over lake area (e.g., for wave height HOWV)
     character(len=20)   :: filename_lakemask    ! lakemask.bin
@@ -1944,6 +1947,7 @@ contains
     real(r_kind), pointer :: ges_q2(:,:)=>NULL()
     real(r_kind), pointer :: ges_howv_it(:,:)=>NULL()       ! wave height
     real(r_kind), pointer :: ges_gust_it(:,:)=>NULL()       ! wind gust
+    real(r_kind), pointer :: ges_vis_it( :,:)=>NULL()       ! visibility
     real(r_kind), pointer :: ges_soilt1(:,:)=>NULL()
     real(r_kind), pointer :: ges_tslb_it(:,:,:)=>NULL()
     real(r_kind), pointer :: ges_smois_it(:,:,:)=>NULL()
@@ -2023,6 +2027,7 @@ contains
     if(i_use_2mt4b <= 0 .and. i_use_2mq4b > 0) num_mass_fields=num_mass_fields+1
     if(i_howv_3dda > 0) num_mass_fields = num_mass_fields + 1
     if(i_gust_3dda > 0) num_mass_fields = num_mass_fields + 1
+    if(i_vis_3dda > 0 ) num_mass_fields = num_mass_fields + 1
     if ( laeroana_gocart ) then
        call gsi_chemguess_get ( 'aerosols::3d', n_gocart_var, ier )
        if ( n_gocart_var > 0 ) then
@@ -2086,16 +2091,22 @@ contains
     else
        i_howv=i_q2
     end if
-!   gust is after howv, and before cloud hydrometers
+!   gust is after howv, and before vis(ibility)
     if ( i_gust_3dda > 0 ) then
        i_gust=i_howv+1
     else
        i_gust=i_howv
     end if
+!   vis(ibility) is after gust, and before cloud hydrometers
+    if ( i_vis_3dda > 0 ) then
+       i_vis=i_gust+1
+    else
+       i_vis=i_gust
+    end if
   
-  ! for hydrometeors
+  ! for hydrometeors (after q2/howv/gust/vis)
     if(l_hydrometeor_bkio .and. n_actual_clouds>0) then
-       i_qc=i_gust+1
+       i_qc=i_vis+1
        i_qr=i_qc+lm
        i_qs=i_qr+lm
        i_qi=i_qs+lm
@@ -2129,13 +2140,13 @@ contains
     else
        if ( laeroana_gocart) then
           do iv = 1, n_gocart_var
-             i_chem(iv)=i_gust+(iv-1)*lm+1
+             i_chem(iv)=i_vis+(iv-1)*lm+1
           end do
        endif
   
        if ( wrf_pm2_5 ) then
           iv=1
-          i_chem(iv)=i_gust+(iv-1)*lm+1
+          i_chem(iv)=i_vis+(iv-1)*lm+1
        endif
   
   
@@ -2652,6 +2663,24 @@ contains
            end do
         end do
     end if
+  ! Visibility (vis)
+    if ( i_vis_3dda > 0 ) then
+        call GSI_BundleGetPointer ( GSI_MetGuess_Bundle(it), 'vis', ges_vis_it, istatus );ier=ier+istatus
+        if (ier/=0) then ! doesn't have to die - code can be generalized to bypass missing vars
+            write(6,*)'wrwrfmassa_netcdf_wrf: getpointer for visibility failed, cannot retrieve vis, ier =',ier
+            call stop2(999)
+        end if
+        do i=1,lon2
+           do j=1,lat2
+  !            all_loc(j,i,i_vis)=ges_vis_it(j,i)
+  !          applying inverse nonlinear transform to analysis of visibility 
+  !            analysis "g-space" ==> physical space
+               tempvis=ges_vis_it(j,i)
+               call nltransf_inverse(tempvis,visout,pvis,scale_cv) 
+               all_loc(j,i,i_vis)=max(min(visout,vis_thres),one)
+           end do
+        end do
+    end if
   
     if(mype == 0) then
   ! SM   This is landmask
@@ -2979,6 +3008,35 @@ contains
           write(lendian_out)temp1
        end if
     end if
+
+  ! update VIS (visibility): after gust
+    if ( i_vis_3dda > 0 ) then
+
+       if(mype == 0) read(lendian_in)temp1
+       if(mype == 0) write(6,*)' at 10.23 (vis: fgs) in wrwrfmassa,max,min(temp1)=', &
+                                           maxval(temp1),minval(temp1)
+       call strip(all_loc(:,:,i_vis),strp)
+       tempa=zero_single
+       call mpi_gatherv(strp,ijn(mype+1),mpi_real4, &
+            tempa,ijn,displs_g,mpi_real4,0,mpi_comm_world,ierror)
+       if(mype == 0) then
+          write(6,*)' at 10.24 (vis: anl on analysis grid) in wrwrfmassa,max,min(tempa)=', &
+                            maxval(tempa),minval(tempa)
+          call fill_mass_grid2t(temp1,im,jm,tempb,2)
+          do i=1,iglobal
+             tempa(i)=tempa(i)-tempb(i)
+          end do
+          write(6,*)' at 10.25 (vis: inc on analysis grid) in wrwrfmassa,max,min(tempa)=', &
+                             maxval(tempa),minval(tempa)
+
+          call unfill_mass_grid2t(tempa,im,jm,temp1)
+          write(6,*)' at 10.26 (vis: anl on   model  grid) in wrwrfmassa,max,min(temp1)=', &
+                             maxval(temp1),minval(temp1)
+          write(lendian_out)temp1
+
+       end if     !endif mype==0
+
+    end if ! i_vis_3dda > 0
 
   !
   ! for saving cloud analysis results

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -185,7 +185,7 @@
                             i_cloud_q_innovation,i_ens_mean,DTsTmax,&
                             i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check, &
                             corp_howv, hwllp_howv, corp_gust, hwllp_gust, oerr_gust, i_howv_mask, &
-                            i_sfcrough_fgs
+                            i_sfcrough_fgs, corp_vis, hwllp_vis
   use gsi_metguess_mod, only: gsi_metguess_init,gsi_metguess_final
   use gsi_chemguess_mod, only: gsi_chemguess_init,gsi_chemguess_final
   use tcv_mod, only: init_tcps_errvals,tcp_refps,tcp_width,tcp_ermin,tcp_ermax
@@ -1624,6 +1624,10 @@
 !                           = 0 : do not read surface roughness from firstguess,
 !                                 and use the default value instead (default)
 !                           = 1 : read surface roughness from firstguess and use it in analysis
+!      corp_vis      - real, static background error of visibility (stddev error),
+!                            in transformed space, not physical space
+!      hwllp_vis     - real, background error de-correlation length scale of visibility
+!                            in transformed space, not physical space
 !
   namelist/rapidrefresh_cldsurf/dfi_radar_latent_heat_time_period, &
                                 metar_impact_radius,metar_impact_radius_lowcloud, &
@@ -1646,7 +1650,7 @@
                                 i_cloud_q_innovation,i_ens_mean,DTsTmax, &
                                 i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check, &
                                 corp_howv, hwllp_howv, corp_gust, hwllp_gust, oerr_gust, i_howv_mask, &
-                                i_sfcrough_fgs
+                                i_sfcrough_fgs, corp_vis, hwllp_vis
 
 ! chem(options for gsi chem analysis) :
 !     berror_chem       - .true. when background  for chemical species that require

--- a/src/gsi/m_berror_stats_reg.f90
+++ b/src/gsi/m_berror_stats_reg.f90
@@ -314,6 +314,7 @@ end subroutine berror_read_bal_reg
       use radiance_mod, only: icloud_cv,n_clouds_fwd,cloud_names_fwd
       use chemmod, only: berror_fv3_cmaq_regional,berror_fv3_sd_regional
       use rapidrefresh_cldsurf_mod, only: corp_gust, hwllp_gust, l_rtma3d
+      use rapidrefresh_cldsurf_mod, only: corp_vis,  hwllp_vis
 
       implicit none
 
@@ -862,6 +863,28 @@ end subroutine berror_read_bal_reg
         do i=0,mlat+1
            hwllp(i,n)=hwll(i,1,nrf3_t)
         end do
+        if ( l_rtma3d ) then  ! For 3drtma only: allowing to change the stddev and 
+                              ! de-correlation length of bkgd error of visibility:
+                              !   corp_vis : set in namelist(if <=0, using default value above (3.0)
+                              !   hwllp_vis: set in namelist(if <=0, using default value above (value of t)
+                              !   Be aware that they are in transformed analysis g-space, not physical space.
+           if ( corp_vis  .gt. 0.0_r_kind ) then
+              corp(1:mlat,   n) = corp_vis
+              if (mype==0) write(6,'(1x,A,A,I5.5,A,F8.3)') &
+                           myname_,"@pe=",mype," (3drtma) set b_error stddev of visibility = ",corp_vis
+           else
+              if (mype==0) write(6,'(1x,A,A,I5.5,A,F8.3)') &
+                           myname_,"@pe=",mype," (3drtma) set b_error stddev of visibility (default) = ",three
+           end if
+           if ( hwllp_vis .gt. 0.0_r_kind ) then
+              hwllp(0:mlat+1,n) = hwllp_vis
+              if (mype==0) write(6,'(1x,A,A,I5.5,A,F12.3)') &
+                           myname_,"@pe=",mype," (3drtma) set b_error de-corr length of visibility = ",hwllp_vis
+           else
+              if (mype==0) write(6,'(1x,A,A,I5.5,A)') &
+                           myname_,"@pe=",mype," (3drtma) set b_error de-corr length of visibility is same as length of t."
+           end if
+        end if
      else if (n==nrf2_pblh) then
         do i=1,mlat
            corp(i,n)=500.0_r_kind

--- a/src/gsi/rapidrefresh_cldsurf_mod.f90
+++ b/src/gsi/rapidrefresh_cldsurf_mod.f90
@@ -225,6 +225,30 @@ module rapidrefresh_cldsurf_mod
 !                          = 0 : do not read surface roughness from firstguess,
 !                                and use the default value instead (default)
 !                          = 1 : read surface roughness from firstguess and use it in analysis
+!      corp_vis       - namelist real, static BE of visibility (standard error deviation)
+!                          note: 1. initialised to be an arbitary negative value, in order to skip this 
+!                                   negative value, instead to use value (3.0) which is set in subroutine 
+!                                   berror_read_wgt_reg as default.
+!                                2. (3drtma only) if a user-specified value (e.g., 3.0) is preferred 
+!                                   for corp_vis, in GSI namelist session "rapidrefresh_cldsurf",
+!                                   set "corp_vis=3.0,"
+!                                3. Nonlinear transform is used in GSI for analysis of visibility, so 
+!                                   be careful with that this visibility backtround error is in 
+!                                   TRANSFORMED ANALYSIS G-SPACE, not in physical space; 
+!      hwllp_vis      - namelist real, static BE de-correlation length scale of visibility
+!                          note: 1. initialised to be an arbitary negative value, in order to skip this 
+!                                   negative value, instead to use value (same value for t) set in
+!                                   subroutine berror_read_wgt_reg as default
+!                                2. (3drtma only) if a user-specified value (e.g., 100 km) is preferred 
+!                                   for hwllp_vis, in GSI namelist session "rapidrefresh_cldsurf",
+!                                   set "hwllp_vis=100000.0,"
+!                                3. Nonlinear transform is used in GSI for analysis of visibility, so 
+!                                   be careful with that this visibility backtround error de-correlation 
+!                                   scale is also in TRANSFORMED ANALYSIS G-SPACE, not in physical space; 
+!      i_vis_3dda     - integer, control the analysis of visibility in 3D analysis (either var or hybrid)
+!                          = 0 (vis-off: default) : no analysis of visibility in 3D analysis.
+!                          = 1 (vis-on) : if variable name "vis" is found in anavinfo,
+!                                          set it to be 1 to turn on analysis of visibility;
 !
 ! attributes:
 !   language: f90
@@ -302,6 +326,8 @@ module rapidrefresh_cldsurf_mod
   public :: corp_gust, hwllp_gust, oerr_gust
   public :: i_gust_3dda
   public :: i_sfcrough_fgs
+  public :: corp_vis, hwllp_vis
+  public :: i_vis_3dda
 
   logical l_hydrometeor_bkio
   real(r_kind)  dfi_radar_latent_heat_time_period
@@ -366,6 +392,8 @@ module rapidrefresh_cldsurf_mod
   real(r_kind)      :: corp_gust, hwllp_gust, oerr_gust
   integer(i_kind)   :: i_gust_3dda
   integer(i_kind)   :: i_sfcrough_fgs
+  real(r_kind)      :: corp_vis, hwllp_vis
+  integer(i_kind)   :: i_vis_3dda
 
 contains
 
@@ -503,6 +531,18 @@ contains
 
     i_sfcrough_fgs      = 0                           ! do not read surface roughness from firstguess (default)
 
+    corp_vis            = -1.50_r_kind                ! initialised as negative & void to be skipped, in order to use
+                                                      ! the value (3.0) set in sub berror_read_wgt_reg (as default).
+                                                      ! If user-specified value is preferred, set it in session
+                                                      ! "rapidrefresh_cldsurf" of GSI namelist file
+
+    hwllp_vis           = -90000.0_r_kind             ! initialised as a value, in order to skip this negative value
+                                                      ! and to use the value (used for t) set in sub berror_read_wgt_reg.
+                                                      ! If user-specified value is preferred, set it in session
+                                                      ! "rapidrefresh_cldsurf" of GSI namelist file
+
+    i_vis_3dda          = 0                           ! no analysis of visibility (vis) in 3D analysis (default)
+
 !-- searching for specific variable in state variable list (reading from anavinfo)
     do i2=1,ns2d
       if ( trim(svars2d(i2))=='howv' .or. trim(svars2d(i2))=='HOWV'   ) then
@@ -515,6 +555,12 @@ contains
         i_gust_3dda = 1
         if ( mype == 0 ) then
           write(6,'(1x,A,1x,A8,1x,A,1x,I4)')"init_rapidrefresh_cldsurf: anavinfo svars2d (state variable): ",trim(adjustl(svars2d(i2))), " is found in anavinfo, set i_gust_3dda = ", i_gust_3dda
+        end if
+      end if
+      if ( trim(svars2d(i2))=='vis' .or. trim(svars2d(i2))=='VIS'   ) then
+        i_vis_3dda = 1
+        if ( mype == 0 ) then
+          write(6,'(1x,A,1x,A8,1x,A,1x,I4)')"init_rapidrefresh_cldsurf: anavinfo svars2d (state variable): ",trim(adjustl(svars2d(i2))), " is found in anavinfo, set i_vis_3dda = ", i_vis_3dda
         end if
       end if
     end do ! i2 : looping over 2-D anasv

--- a/src/gsi/setupvis.f90
+++ b/src/gsi/setupvis.f90
@@ -677,9 +677,13 @@ subroutine setupvis(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
            call nc_diag_metadata("Errinv_Adjust",           errinv_adjst           )
            call nc_diag_metadata("Errinv_Final",            errinv_final           )
 
-           call nc_diag_metadata("Observation",                   data(ivis,i)     )
-           call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   ddiff            )
-           call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", data(ivis,i)-visges )
+           call nc_diag_metadata("Observation_transformed",       data(ivis,i)     )
+           call nc_diag_metadata("Obs_Minus_Forecast_adjusted_transformed",   ddiff               )
+           call nc_diag_metadata("Obs_Minus_Forecast_unadjusted_transformed", data(ivis,i)-visges )
+
+           call nc_diag_metadata("Observation",                   visobout         )
+           call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   visdiff          )
+
            call nc_diag_metadata("Dominant_Sfc_Type", data(idomsfc,i))
            call nc_diag_metadata("Model_Terrain",     data(izz,i))
            r_prvstg            = data(iprvd,i)


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

### **Description**

<!-- Please include relevant motivation and context. -->
**_Motivation_**
In current 3DRTMA, the analysis of visibility is actually a diagnostic variable, derived from hydrometeor  variables, the analysis of visibility has shown the immediate response to the cloud and precipitation impact, but it has very little response to the low visibility caused by sand dust or aerosols (see the real case example in Issue #871). But 2DRTMA could handle with dusty weather conditions in the analysis of visibility, since it directly analyze the observations of visibility. So it is decided to add the functionality of direct analysis of visibility in GSI 3D analysis for HRRR-based 3DRTMA.

**_Method_**
- The 2DRTMA developers (@ManuelPondeca-NOAA , @YanqiuZhu , @runhua) already implemented the direct analysis of visibility in GSI. And even in 3DRTMA, analysis of visibility is still a surface 2-D analysis as a same as in 2DRTMA, so most of the main algorithms (obs forward operator and its adjoint, obs/fgs error setup, non-linear transformation, ObsQC, etc.) would be adopted for analysis of visibility in 3D analysis.
- Main code work includes:
  - adding I/O for the visibility in firstguess file and analysis file
  - applying nonlinear transformation to visibility field after reading it from firstguess and the inverse transformation before output in analysis file;

<!-- Please include a summary of the change and which issue is fixed. -->
**_Summary of the Main Changes to GSI source code_**
        
  <details><summary>1. src/gsi/cplr_wrf_netcdf_interface.f90:</summary>
  <p>

- subroutine convert_netcdf_mass_wrf
  - reading visibility from netcdf format figrstguess file
  - applying max/min constraint to the firstguess of visibility, to prepare for the nonlinear transform.
  - dumping out the firstguess of visibility to intermediate binary file sigf03
- subroutine update_netcdf_mass_wrf
  - reading the updated visibility from binary siganl file
  - dumping out the analysis of visibility into netcdf format analysis file
  </p>
  </details>

  <details><summary>2. src/gsi/cplr_read_wrf_mass_guess.f90:</summary>
  <p>

  - subroutine read_wrf_mass_netcdf_guess_wrf
    - reading firstguess of visibility from binary file sigf03
    - applying non-linear transform to the firstguess of visibility
    - distributing the transformed 2-D visibility field to the local array all_loc on each PE;
  </p>
  </details>

  <details><summary>3. src/gsi/cplr_wrwrfmassa.f90:</summary>
  <p>
  
  - subroutine wrwrfmassa_netcdf_wrf: 
    - applying inverse nonlinear transform to the analyzed visibility (back to physical space)
    - gathering the analyzed visibility from each PE to PE0
    - dumping out the analysis of visibility to binary file siganl
  </p>
  </details>

  <details><summary>4. src/gsi/cplr_regional_io.f90:</summary>
  <p>

  - broadcasting the option i_vis_3dda to all PEs (if no visibility data is found in firstguess on PE0, then i_vis_3dda is set to be 0, and the code broadcasts the changed i_vis_3dda from PE0 to all other PEs.
  </p>
  </details>

  <details><summary>5. src/gsi/rapidrefresh_cldsurf_mod.f90:</summary>
  <p>

  - adding a few options related to visibility (corp_vis for background error of visibility, and hwllp_vis for background error de-correlation scale, they are both set for visibility in transformed g-space, not in physical space, and i_vis_3dda to control the off/off of direct analysis of visibility)
  </p>
  </details>

  <details><summary>6. src/gsi/gsimod.F90:</summary>
  <p>

  - adding corp_vis and hwllp_vis in GSI namelist;
  </p>
  </details>

  <details><summary>7. src/gsi/m_berror_stats_reg.f90:</summary>
  <p>

  - subroutine berror_read_wgt_reg:
    - adding code to set the background error and decorrelation scale (which are read in GSI namelist for 3DRTMA run) for visibility
  </p>
  </details>

  <details><summary>8. src/gsi/setupvis.f90:</summary>
  <p>

  - dumping out the original obs and departure of visibility in physical space into netcdf format diagnostic file (in original code, the dumped variables are actually the values in transformed g-space, not in physcial space)
  </p>
  </details>        

<!-- List any dependencies that are required for this change. -->
<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->
Fixes issue #871. 

### **Type of change**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### **How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

1.  GSI CTests:   the modified GSI code passes all the 6 regression tests in current GSI CTest suite on WCOSS2 (Cactus) and Hera. Because this newly-added functionality of direct analysis of visibility would be activated only when variable "vis" is found in "anavinfo" file, and the 2-D visibility filed exists in firstguess file. In most GSI applications (global, regional, etc.), visibility is NOT a standard analysis variable, so this functionality would not be used, and therefore this new functionality has no influence to the analyses of most common GSI applications, as what is shown in the GSI Ctest result..  And the following are the brief results of GSI Ctest on Hera and WCOSS2 (Cactus):
        <details><summary>GSI  CTest results on **_Hera_**</summary>
        <p>
(work-env2) [Gang.Zhao@hfe01:build] (feature/visibility_3drtma)$ ctest -N
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
  Test # 1: global_4denvar
  Test # 2: rtma
  Test # 3: rrfs_3denvar_rdasens
  Test # 4: hafs_4denvar_glbens
  Test # 5: hafs_3denvar_hybens
  Test # 6: global_enkf
Total Tests: 6
(work-env2) [Gang.Zhao@hfe01:build] (feature/visibility_3drtma)$ ctest -j 6
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test # 3: rrfs_3denvar_rdasens .............***Failed  741.75 sec
2/6 Test # 6: global_enkf ......................   Passed  1249.23 sec
3/6 Test # 2: rtma .............................   Passed  1273.37 sec
4/6 Test # 5: hafs_3denvar_hybens ..............   Passed  1293.19 sec
5/6 Test # 4: hafs_4denvar_glbens ..............   Passed  1409.98 sec
6/6 Test # 1: global_4denvar ...................   Passed  2450.65 sec
83% tests passed, 1 tests failed out of 6
Total Test time (real) = 2450.65 sec
The following tests FAILED:
          3 - rrfs_3denvar_rdasens (Failed)
Errors while running CTest
Output from these tests are in: /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
(work-env2) [Gang.Zhao@hfe01:build] (feature/visibility_3drtma)$ ctest -R rrfs_3denvar_rdasens
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
    Start 3: rrfs_3denvar_rdasens
1/1 Test # 3: rrfs_3denvar_rdasens .............   Passed  919.03 sec
100% tests passed, 0 tests failed out of 1
Total Test time (real) = 919.04 sec
        </p>
        </details> 
        <details><summary>GSI  CTest results on **_WCOSS2_**</summary>
        <p>
[gang.zhao@clogin04:build] (feature/visibility_3drtma)$ ctest -N
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
  Test # 1: global_4denvar
  Test # 2: rtma
  Test # 3: rrfs_3denvar_rdasens
  Test # 4: hafs_4denvar_glbens
  Test # 5: hafs_3denvar_hybens
  Test # 6: global_enkf
Total Tests: 6
[gang.zhao@clogin04:build] (feature/visibility_3drtma)$ ctest -j 6
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test # 3: rrfs_3denvar_rdasens .............   Passed  734.86 sec
2/6 Test # 2: rtma .............................   Passed  1037.17 sec
3/6 Test # 5: hafs_3denvar_hybens ..............   Passed  1226.28 sec
4/6 Test # 4: hafs_4denvar_glbens ..............***Failed  1412.67 sec
5/6 Test # 6: global_enkf ......................   Passed  1475.28 sec
6/6 Test # 1: global_4denvar ...................   Passed  1924.81 sec
83% tests passed, 1 tests failed out of 6
Total Test time (real) = 1924.83 sec
The following tests FAILED:
          4 - hafs_4denvar_glbens (Failed)
Errors while running CTest
Output from these tests are in: /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
[gang.zhao@clogin04:build] (feature/visibility_3drtma)$ ctest -R hafs_4denvar_glbens
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
    Start 4: hafs_4denvar_glbens
1/1 Test # 4: hafs_4denvar_glbens ..............   Passed  1345.82 sec
100% tests passed, 0 tests failed out of 1
Total Test time (real) = 1345.84 sec
        </p>
        </details>

2. The newly-added functionality of direct analysis of visibility has been tested with real-case data at 12Z:00 on 2025-03-15, which is the wind-blown sandstorm case mentioned in issue #871. As mentioned in this issue, with visibility diagnosed from cloud and precipitation only, the visibility analysis of 3DRTMA does not show the low visibility in the TX/OK/KS due to dusty weather condition (see the Figure 2 below). Then with the new function in GSI  3D analysis to directly analyze the visibility observations, the analysis of visibility does show the the significantly reduced visibility by the sand storm (See Figure 3 below), which is expected and similar to the analysis of 2DRTMA (see Figure 1 below) . See the following figures:

<details><summary>Figure 1. Analysis of Visibility with direct analysis of visibility in 2DRTMA</summary>
<p>

![vis_full_sfc_03150000](https://github.com/user-attachments/assets/593a018b-a5f6-4e24-b153-d905a9a64bdb)

</p>
</details>

<details><summary>Figure 2. Analysis of Visibility without direct analysis of visibility in GSI 3DVar for HRRR-3DRTMA</summary>
<p>

![vis_SC_sfc_03150000](https://github.com/user-attachments/assets/c919f148-bfd4-4f9f-a53d-ce5345936fd9)

</p>
</details>

<details><summary>Figure 3. Analysis of Visibility with direct analysis of visibility in GSI 3DVar for HRRR-3DRTMA</summary>
<p>

![GSI_SouthernPlain_FAI_of_VIS 000006](https://github.com/user-attachments/assets/47847965-05f1-40aa-9ffe-dc5bd461ff90)

</p>
</details>

### **Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published