### PR TITLE
Optimize global gsi for GFS v17

### DIFF
--- a/modulefiles/gsi_acorn.intel.lua
+++ b/modulefiles/gsi_acorn.intel.lua
@@ -1,15 +1,18 @@
 help([[
 ]])
 
-local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
+prepend_path("MODULEPATH", "/lfs/h1/hpc/support/daniel.kokron/Projects/hpc-stack/install/modulefiles/stack")
+
+local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.3.3"
 local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
-local craype_ver=os.getenv("craype_ver") or "2.7.8"
-local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
+local craype_ver=os.getenv("craype_ver") or "2.7.17"
+local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.19"
 local cmake_ver= os.getenv("cmake_ver") or "3.20.2"
 local python_ver=os.getenv("python_ver") or "3.8.6"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.0.10"
 
-local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
+local netcdf_ver=os.getenv("netcdf_ver") or "4.9.2"
+local netcdf_ver=os.getenv("hdf5_ver") or "1.14.5"
 local bufr_ver=os.getenv("bufr_ver") or "11.7.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
@@ -23,6 +26,8 @@ local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
 local crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.1"
 
+load(pathJoin("envvar", "1.0"))
+pushenv("HPC_OPT", "/lfs/h1/hpc/support/daniel.kokron/Projects/hpc-stack/install")
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
 load(pathJoin("intel", intel_ver))
 load(pathJoin("craype", craype_ver))
@@ -30,8 +35,13 @@ load(pathJoin("cray-mpich", cray_mpich_ver))
 load(pathJoin("cmake", cmake_ver))
 load(pathJoin("python", python_ver))
 
+load(pathJoin("hpc", "1.2.0"))
+load(pathJoin("hpc-intel", "19.1.3.304"))
+load(pathJoin("hpc-cray-mpich", "8.1.19"))
+
 load(pathJoin("prod_util", prod_util_ver))
 
+load(pathJoin("hdf5", hdf5_ver))
 load(pathJoin("netcdf", netcdf_ver))
 load(pathJoin("bufr", bufr_ver))
 load(pathJoin("bacio", bacio_ver))
@@ -50,5 +60,11 @@ append_path("MODULEPATH", "/lfs/h1/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack
 load(pathJoin("crtm", crtm_ver))
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20241022")
+-- pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h1/hpc/support/daniel.kokron/Projects/GSI/GFSv17/fix")
+
+setenv("CC", "cc")
+setenv("CXX", "CC")
+setenv("FC", "ftn")
+setenv("CMAKE_Platform", "acorn")
 
 whatis("Description: GSI environment on WCOSS2 Acorn")

--- a/modulefiles/gsi_acorn.intel.lua
+++ b/modulefiles/gsi_acorn.intel.lua
@@ -1,18 +1,15 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/lfs/h1/hpc/support/daniel.kokron/Projects/hpc-stack/install/modulefiles/stack")
-
-local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.3.3"
+local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
 local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
-local craype_ver=os.getenv("craype_ver") or "2.7.17"
-local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.19"
+local craype_ver=os.getenv("craype_ver") or "2.7.8"
+local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
 local cmake_ver= os.getenv("cmake_ver") or "3.20.2"
 local python_ver=os.getenv("python_ver") or "3.8.6"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.0.10"
 
-local netcdf_ver=os.getenv("netcdf_ver") or "4.9.2"
-local netcdf_ver=os.getenv("hdf5_ver") or "1.14.5"
+local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 local bufr_ver=os.getenv("bufr_ver") or "11.7.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
@@ -27,7 +24,6 @@ local crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.1"
 
 load(pathJoin("envvar", "1.0"))
-pushenv("HPC_OPT", "/lfs/h1/hpc/support/daniel.kokron/Projects/hpc-stack/install")
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
 load(pathJoin("intel", intel_ver))
 load(pathJoin("craype", craype_ver))
@@ -35,13 +31,8 @@ load(pathJoin("cray-mpich", cray_mpich_ver))
 load(pathJoin("cmake", cmake_ver))
 load(pathJoin("python", python_ver))
 
-load(pathJoin("hpc", "1.2.0"))
-load(pathJoin("hpc-intel", "19.1.3.304"))
-load(pathJoin("hpc-cray-mpich", "8.1.19"))
-
 load(pathJoin("prod_util", prod_util_ver))
 
-load(pathJoin("hdf5", hdf5_ver))
 load(pathJoin("netcdf", netcdf_ver))
 load(pathJoin("bufr", bufr_ver))
 load(pathJoin("bacio", bacio_ver))
@@ -60,11 +51,5 @@ append_path("MODULEPATH", "/lfs/h1/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack
 load(pathJoin("crtm", crtm_ver))
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20241022")
--- pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h1/hpc/support/daniel.kokron/Projects/GSI/GFSv17/fix")
-
-setenv("CC", "cc")
-setenv("CXX", "CC")
-setenv("FC", "ftn")
-setenv("CMAKE_Platform", "acorn")
 
 whatis("Description: GSI environment on WCOSS2 Acorn")

--- a/src/gsi/genstats_gps.f90
+++ b/src/gsi/genstats_gps.f90
@@ -260,7 +260,7 @@ subroutine genstats_gps(bwork,awork,toss_gps_sub,conv_diagsave,mype)
   use jfunc, only: jiter,miter,jiterstart
   use gsi_4dvar, only: nobs_bins
   use convinfo, only: nconvtype
-  use m_gpsrhs, only: rdiagbuf 
+  use m_gpsrhs, only: rdiagbuf
   implicit none
 
 ! Declare passed variables
@@ -318,7 +318,7 @@ subroutine genstats_gps(bwork,awork,toss_gps_sub,conv_diagsave,mype)
   integer(i_kind) :: nnz, nind,nobs,total_size,ind,prof_size
   type(gps_ob_type), pointer:: gpsptr
   type(gps_all_ob_type), pointer:: gps_allptr
-  
+
   save_jacobian = conv_diagsave .and. jiter==jiterstart .and. lobsdiag_forenkf
 
 !*******************************************************************************
@@ -394,6 +394,9 @@ subroutine genstats_gps(bwork,awork,toss_gps_sub,conv_diagsave,mype)
   !!!!!! Compute STD4060 for hybrid error model
   if (mype == 0) then
     STD4060(:) = 0.0_r_kind
+    !$omp parallel do default(none), schedule(dynamic,1), &
+    !$omp& private(ii,prof_size,profile_benda,profile_impact,indices,sorted_profile_benda,sorted_profile_impact,k), &
+    !$omp& shared(nprof_gps,array_prof,array_hght,array_qc,array_gps,STD4060)
     do ii=1,nprof_gps
       prof_size = count(((array_prof(:) == ii).and.(array_hght(:)>=40.E3).and.(array_hght(:)<=60.E3).and.(array_qc/=6.0_r_kind)))
       if (prof_size <= 15) then

--- a/src/gsi/gsisub.F90
+++ b/src/gsi/gsisub.F90
@@ -173,7 +173,7 @@ subroutine gsisub(init_pass,last_pass)
 
 ! Compute random number for precipitation forward model.  
   if(init_pass) then
-     call create_pcp_random(iadate,mype)
+     !call create_pcp_random(iadate,mype)
      if(print_verbose)then
         call tell('gsisub','returned from create_pcp_random()')
      end if

--- a/src/gsi/intall.f90
+++ b/src/gsi/intall.f90
@@ -192,7 +192,6 @@ subroutine intall(sval,sbias,rval,rbias)
   use gsi_bundlemod, only: gsi_bundle
   use gsi_bundlemod, only: assignment(=)
   use guess_grids, only: ntguessig,nfldsig
-  use mpl_allreducemod, only: mpl_allreduce
   use mpi, only: mpi_in_place,mpi_real16,mpi_sum,mpi_comm_world
 
   implicit none
@@ -293,14 +292,12 @@ subroutine intall(sval,sbias,rval,rbias)
 
 !   Put reduces together to minimize wait time
 !   First, use MPI to get global mean increment
-    !call mpl_allreduce(2*nobs_bins,qpvals=mass)
     call MPI_Allreduce(mpi_in_place, mass, 2*nobs_bins, mpi_real16, mpi_sum, mpi_comm_world, ierr)
 
   end if
 
 ! Sum over all processors for bias correction terms
 
-  !call mpl_allreduce(nrclen,qpvals=qpred)
   call MPI_Allreduce(mpi_in_place, qpred, nrclen, mpi_real16, mpi_sum, mpi_comm_world, ierr)
 
 

--- a/src/gsi/intall.f90
+++ b/src/gsi/intall.f90
@@ -193,6 +193,7 @@ subroutine intall(sval,sbias,rval,rbias)
   use gsi_bundlemod, only: assignment(=)
   use guess_grids, only: ntguessig,nfldsig
   use mpl_allreducemod, only: mpl_allreduce
+  use mpi, only: mpi_in_place,mpi_real16,mpi_sum,mpi_comm_world
 
   implicit none
 
@@ -205,7 +206,7 @@ subroutine intall(sval,sbias,rval,rbias)
   real(r_quad),dimension(2*nobs_bins) :: mass
 
 ! Declare local variables
-  integer(i_kind) :: ibin,ii,it,i
+  integer(i_kind) :: ibin,ii,it,i,ierr
 
 !******************************************************************************
 ! Initialize timer
@@ -292,13 +293,15 @@ subroutine intall(sval,sbias,rval,rbias)
 
 !   Put reduces together to minimize wait time
 !   First, use MPI to get global mean increment
-    call mpl_allreduce(2*nobs_bins,qpvals=mass)
+    !call mpl_allreduce(2*nobs_bins,qpvals=mass)
+    call MPI_Allreduce(mpi_in_place, mass, 2*nobs_bins, mpi_real16, mpi_sum, mpi_comm_world, ierr)
 
   end if
 
 ! Sum over all processors for bias correction terms
 
-  call mpl_allreduce(nrclen,qpvals=qpred)
+  !call mpl_allreduce(nrclen,qpvals=qpred)
+  call MPI_Allreduce(mpi_in_place, qpred, nrclen, mpi_real16, mpi_sum, mpi_comm_world, ierr)
 
 
 ! RHS for dry ps constraint: part 2

--- a/src/gsi/mod_vtrans.f90
+++ b/src/gsi/mod_vtrans.f90
@@ -875,6 +875,11 @@ subroutine special_eigvv(qmat0,hmat0,smat0,nmat,swww0,szzz0,swwwd0,szzzd0,nvmode
 
 !      iterative improvement to get eigvals, eigvects of qtildemat
 
+  !$omp parallel do default(none), &
+  !$omp& private(i,sum,j,eigval_this,iret,dist_to_closest_eigval, &
+  !$omp&   perturb_eigval,aminv,aminvt,err_aminv,noskip,istop,eigval_next), &
+  !$omp& shared(nvmodes_keep,szzz,szzzd,btemp,nmat,eigvals,qtildemat, &
+  !$omp&   swww,swwwd,print_verbose,zero_quad,one_quad)
   do i=1,nvmodes_keep
      szzz(:,i)=btemp(:,i)
      szzzd(:,i)=btemp(:,i)

--- a/src/gsi/pcgsoi.f90
+++ b/src/gsi/pcgsoi.f90
@@ -159,6 +159,7 @@ subroutine pcgsoi()
   use berror, only: vprecond
   use stpjomod, only: stpjo_setup
   use intradmod, only: setrad
+  use mpi, only: mpi_in_place,mpi_real16,mpi_sum,mpi_comm_world
   
 
   implicit none
@@ -170,7 +171,7 @@ subroutine pcgsoi()
 ! Declare local variables  
   logical iout_6,restart,end_iter,llprt,llouter
   character(5) step(2)
-  integer(i_kind) i,istep,iobs,ii,nprt
+  integer(i_kind) i,istep,iobs,ii,nprt,ierr
   real(r_kind) stp,b,converge
   real(r_kind) gsave,small_step,aindex
   real(r_kind) gnormx,penx,penalty,penaltynew
@@ -355,7 +356,8 @@ subroutine pcgsoi()
            xdiff%values(i)=vprecond(i)*gradx%values(i)
         end do
         dprod(2) = qdot_prod_sub(xdiff,grady)
-        call mpl_allreduce(4,qpvals=dprod)
+        !call mpl_allreduce(4,qpvals=dprod)
+        call MPI_Allreduce(MPI_IN_PLACE, dprod, 4, MPI_REAL16, MPI_SUM, MPI_COMM_WORLD, ierr)
 !       Two dot products in dprod(3) and dprod(4) should be same, but are slightly
 !       different due to round off, so use average.
         gnorm(2)=dprod(2)-0.5_r_quad*(dprod(3)+dprod(4))
@@ -371,7 +373,8 @@ subroutine pcgsoi()
            xdiff%values(i)=vprecond(i)*gradx%values(i)
         end do
         dprod(2) = qdot_prod_sub(xdiff,grady)
-        call mpl_allreduce(2,qpvals=dprod)
+        !call mpl_allreduce(2,qpvals=dprod)
+        call MPI_Allreduce(MPI_IN_PLACE, dprod, 2, MPI_REAL16, MPI_SUM, MPI_COMM_WORLD, ierr)
         if(print_diag_pcg) call prt_control_norms(grady,'grady')
         gnorm(2)=dprod(2)
         gnorm(3)=dprod(2)

--- a/src/gsi/pcpinfo.f90
+++ b/src/gsi/pcpinfo.f90
@@ -400,7 +400,7 @@ contains
      if(allocated(gross_pcp)) deallocate(gross_pcp)
      if(allocated(b_pcp))     deallocate(b_pcp)
      if(allocated(pg_pcp))    deallocate(pg_pcp)
-     deallocate(xkt2d)
+     if(allocated(xkt2d))     deallocate(xkt2d)
      return
   end subroutine destroy_pcp_random
   

--- a/src/gsi/prad_bias.f90
+++ b/src/gsi/prad_bias.f90
@@ -171,7 +171,6 @@ contains
   use radinfo, only: predx      ! intent(inout)
   use gsi_4dvar, only: nobs_bins
   use berror, only: varprd      ! intent(in)
-  use mpl_allreducemod, only: mpl_allreduce
   use timermod, only: timer_ini,timer_fnl
   use constants, only : zero,one,zero_quad
   use mpi, only: mpi_in_place,mpi_real8,mpi_real16,mpi_sum,mpi_comm_world
@@ -262,8 +261,6 @@ contains
 
 
 ! Collect data from all processors
-  !call mpl_allreduce(jpassive,rpvals=iobs)
-  !call mpl_allreduce(npred,jpassive,b)
   call MPI_Allreduce(mpi_in_place, iobs,       jpassive, mpi_real8, mpi_sum, mpi_comm_world, ier)
   call MPI_Allreduce(mpi_in_place,    b, npred*jpassive, mpi_real16, mpi_sum, mpi_comm_world, ier)
 
@@ -279,7 +276,6 @@ contains
 
 !    Collect data from all processors for each channel
      Atmp(:,:) = A(:,:,n)
-     !call mpl_allreduce(npred,npred,Atmp)
      call MPI_Allreduce(mpi_in_place, Atmp, npred*npred, mpi_real16, mpi_sum, mpi_comm_world, ier)
 
 !    Solve linear system

--- a/src/gsi/prad_bias.f90
+++ b/src/gsi/prad_bias.f90
@@ -174,11 +174,12 @@ contains
   use mpl_allreducemod, only: mpl_allreduce
   use timermod, only: timer_ini,timer_fnl
   use constants, only : zero,one,zero_quad
+  use mpi, only: mpi_in_place,mpi_real8,mpi_real16,mpi_sum,mpi_comm_world
   implicit none
 
   integer(i_kind),parameter :: nthreshold=100
   real(r_kind),parameter :: atiny=1.0e-10_r_kind
-  integer(i_kind) i,n,j,ii,jj,jpassive,ibin,ic,mp,mm,kpred
+  integer(i_kind) i,n,j,ii,jj,jpassive,ibin,ic,mp,mm,kpred,ier
   integer(i_kind),dimension(jpch_rad) :: icp
   integer(i_kind),dimension(npred)    :: iorder
   real(r_kind) varc
@@ -261,8 +262,10 @@ contains
 
 
 ! Collect data from all processors
-  call mpl_allreduce(jpassive,rpvals=iobs)
-  call mpl_allreduce(npred,jpassive,b)
+  !call mpl_allreduce(jpassive,rpvals=iobs)
+  !call mpl_allreduce(npred,jpassive,b)
+  call MPI_Allreduce(mpi_in_place, iobs,       jpassive, mpi_real8, mpi_sum, mpi_comm_world, ier)
+  call MPI_Allreduce(mpi_in_place,    b, npred*jpassive, mpi_real16, mpi_sum, mpi_comm_world, ier)
 
   do n = 1,jpassive
      if (iobs(n)<nthreshold) cycle
@@ -276,7 +279,8 @@ contains
 
 !    Collect data from all processors for each channel
      Atmp(:,:) = A(:,:,n)
-     call mpl_allreduce(npred,npred,Atmp)
+     !call mpl_allreduce(npred,npred,Atmp)
+     call MPI_Allreduce(mpi_in_place, Atmp, npred*npred, mpi_real16, mpi_sum, mpi_comm_world, ier)
 
 !    Solve linear system
      iorder=0

--- a/src/gsi/read_atms.f90
+++ b/src/gsi/read_atms.f90
@@ -659,7 +659,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 ! Second scan to determine which observation in a given bin is best to use
   good=0
   tb2=MPI_Wtime()
-  !$omp parallel do default(none), num_threads(8), schedule(dynamic,12), &
+  !$omp parallel do default(none), schedule(dynamic,12), &
   !$omp& firstprivate(ich1,ich2,ich3,ich16,ich17), &
   !$omp& private(bin,score,Obindx,iob,rsat,t4dv,dlon_earth,dlat_earth,crit1,it_mesh,ifov,lza, &
   !$omp&   satazi,solzen,solazi,bt_in,dlat_earth_deg,dlon_earth_deg, &

--- a/src/gsi/read_atms.f90
+++ b/src/gsi/read_atms.f90
@@ -195,14 +195,14 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   integer(i_kind) :: ithin_time,n_tbin
   integer(i_kind),pointer :: it_mesh => null()
   real(kind=8) :: time_beg,time_end,tb1,tb2,tb3,te1,te2,te3,walltime
-  integer(kind=4) :: good,bin,Obindx
+  integer(kind=4) :: good,bin,Obindx,maxPerBin
   integer,allocatable,dimension(:)   :: binCount
   integer,allocatable,dimension(:,:) :: binObs
   time_beg=MPI_Wtime()
 
 !**************************************************************************
 ! Initialize variables
-  write(6,'("read_atms: Enter ithin is " I8)') ithin
+  !write(6,'("read_atms: Enter ithin is " I8)') ithin
 
   maxinfo=31
   lnbufr = 15
@@ -534,7 +534,6 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   END IF
 
   allocate(binCount(itxmax))
-  allocate(binObs(500,itxmax))
 
 ! First scan to determine which obs fall into which bins
   tb2=MPI_Wtime()
@@ -590,12 +589,72 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 !    Map obs to thinning grid
      call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,it_mesh)
      binCount(itx2) = binCount(itx2)+1
-     binObs(binCount(itx2),itx2) = iob
   end do ObsLoop
+
+  maxPerBin=maxval(binCount)
+  write(6,'("read_atms: max number of obs in any bin " I10)') maxPerBin
+  write(6,'("read_atms: number of bins with any obs " I10)') count(mask=binCount>0)
+
+  allocate(binObs(maxPerBin,itxmax))
+  binObs(:,:)=0
+  binCount(:)=0
+
+  ObsLoop2: do iob=1,num_obs
+
+     t4dv       => t4dv_save(iob)
+     dlon_earth => dlon_earth_save(iob)
+     dlat_earth => dlat_earth_save(iob)
+     it_mesh    => it_mesh_save(iob)
+     ifov       => ifov_save(iob)
+
+!    Regional case
+     if(regional)then
+        call tll2xy(dlon_earth*deg2rad,dlat_earth*deg2rad,dlon,dlat,outside)
+        if(diagnostic_reg) then
+           call txy2ll(dlon,dlat,dlon00,dlat00)
+           ntest=ntest+1
+           cdist=sin(dlat_earth*deg2rad)*sin(dlat00)+cos(dlat_earth*deg2rad)*cos(dlat00)* &
+                (sin(dlon_earth*deg2rad)*sin(dlon00)+cos(dlon_earth*deg2rad)*cos(dlon00))
+           cdist=max(-one,min(cdist,one))
+           disterr=acos(cdist)*rad2deg
+           disterrmax=max(disterrmax,disterr)
+        end if
+!       Check to see if in domain
+        if(outside) cycle ObsLoop2
+     endif
+
+!    Check time window
+     if (l4dvar.or.l4densvar) then
+        if (t4dv<zero .OR. t4dv>winlen) cycle ObsLoop2
+     else
+        tdiff=t4dv+(iwinbgn-gstime)*r60inv
+        if(abs(tdiff) > twind) cycle ObsLoop2
+     endif
+!
+!    Check FOV and scan-edge usage
+     if (.not. use_edges .and. (ifov < radedge_min .OR. ifov > radedge_max )) &
+          cycle ObsLoop2
+
+     if (maxscan < 96) then
+       ! For ATMS when using the old style satang files,
+       ! we shift the FOV number down by three as we can only use
+       ! 90 of the 96 positions right now because of the scan bias limitation.
+       ifovmod=ifov-3
+       ! Check that ifov is not out of range of cbias dimension
+       if (ifovmod < 1 .OR. ifovmod > 90) cycle ObsLoop2
+     else
+       ! This line is for consistency with previous treatment
+       if (ifov < 4 .OR. ifov > 93) cycle ObsLoop2
+       ifovmod=ifov
+     endif
+
+!    Map obs to thinning grid
+     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,it_mesh)
+     binCount(itx2) = binCount(itx2)+1
+     binObs(binCount(itx2),itx2) = iob
+  end do ObsLoop2
   te2=MPI_Wtime()
   write(6,'("Walltime for read_atms: OBS loop " I10,f15.4)') num_obs, te2-tb2
-  write(6,'("read_atms: max number of obs in any bin " I10)') maxval(binCount)
-  write(6,'("read_atms: number of bins with any obs " I10)') count(mask=binCount>0)
 
 ! Second scan to determine which observation in a given bin is best to use
   good=0
@@ -623,7 +682,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
     if(binCount(bin) == 0) cycle BinLoop
      score=9.99e10_r_kind
 
-     ObsLoop2: do Obindx = 1,binCount(bin)
+     ObsLoop3: do Obindx = 1,binCount(bin)
 
        iob        = binObs(Obindx,bin)
        rsat       => rsat_save(iob)
@@ -663,7 +722,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
        ! DSK: We already know which bin (itx) this observation resides in so no need to recalculate.
        ! Could inline this map2tgrid2 call if I had local access to istart_val,glat,mlat,glon and mlon from satthin.
        call map2tgrid2(dlat_earth,dlon_earth,dist1,crit1,itx,ithin,itt,iuse,sis,score,it_mesh)
-       if(.not. iuse) cycle ObsLoop2
+       if(.not. iuse) cycle ObsLoop3
 
        if (maxscan < 96) then
          ! For ATMS when using the old style satang files, 
@@ -671,10 +730,10 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
          ! 90 of the 96 positions right now because of the scan bias limitation.
          ifovmod=ifov-3
          ! Check that ifov is not out of range of cbias dimension
-         !if (ifovmod < 1 .OR. ifovmod > 90) cycle ObsLoop2
+         !if (ifovmod < 1 .OR. ifovmod > 90) cycle ObsLoop3
        else
          ! This line is for consistency with previous treatment
-         !if (ifov < 4 .OR. ifov > 93) cycle ObsLoop2
+         !if (ifov < 4 .OR. ifov > 93) cycle ObsLoop3
          ifovmod=ifov
        endif
 
@@ -693,7 +752,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
                  j == ich16 .or. j == ich17)) critical_channels_missing = .true.
           endif
        end do
-       if (iskip >= nchanl) cycle ObsLoop2
+       if (iskip >= nchanl) cycle ObsLoop3
 
 !    Determine surface properties based on 
 !    sst and land/sea/ice mask   
@@ -717,7 +776,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 
        if (isfcalc == 1) then
           call fov_check(ifov,instr,ichan,valid)
-          if (.not. valid) cycle ObsLoop2
+          if (.not. valid) cycle ObsLoop3
 
 !         When isfcalc is one, calculate surface fields based on size/shape of fov.
 !         Otherwise, use bilinear method.
@@ -732,8 +791,8 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 
        crit1 = crit1 + rlndsea(isflg) + 10._r_kind*real(iskip,r_kind) + 0.01_r_kind * abs(zz)
        !call checkob(dist1,crit1,itx,iuse)
-       !if(.not. iuse)cycle ObsLoop2
-       if(crit1*dist1 > score) cycle ObsLoop2
+       !if(.not. iuse)cycle ObsLoop3
+       if(crit1*dist1 > score) cycle ObsLoop3
 
        if (critical_channels_missing) then
          pred=1.0e8_r_kind
@@ -791,11 +850,11 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 !      Compute "score" for observation.  All scores>=0.0.  Lowest score is "best"
        crit1 = crit1+pred 
        !call finalcheck(dist1,crit1,itx,iuse)
-       !if(.not. iuse)cycle ObsLoop2
+       !if(.not. iuse)cycle ObsLoop3
        if(crit1*dist1 < score)then
           score = crit1*dist1
        else
-          cycle ObsLoop2
+          cycle ObsLoop3
        end if
      
 !      interpolate NSST variables to Obs. location and get dtw, dtc, tz_tr
@@ -863,7 +922,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
        end do
        nrec(bin)=iob
        good=good+1
-     enddo ObsLoop2
+     enddo ObsLoop3
      score_crit(bin) = score
   end do BinLoop
   te2=MPI_Wtime()

--- a/src/gsi/read_atms.f90
+++ b/src/gsi/read_atms.f90
@@ -91,7 +91,6 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   use gsi_nstcouplermod, only: gsi_nstcoupler_skindepth,gsi_nstcoupler_deter
   use mpimod, only: npe
   use radiance_mod, only: rad_obs_type
-  !use mpi, only : MPI_Wtime,MPI_COMM_WORLD
 
   implicit none
 
@@ -196,11 +195,9 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   real(r_kind)    :: ptime,timeinflat,crit0,score
   integer(i_kind) :: ithin_time,n_tbin
   integer(i_kind),pointer :: it_mesh => null()
-  real(kind=8) :: time_beg,time_end,tb1,tb2,tb3,te1,te2,te3,walltime
   integer(kind=4) :: good,bin,bin2,Obindx,maxPerBin,numBinsWithObs
   integer(kind=4),allocatable,dimension(:)   :: binCount,binsWithObs,hash
   integer(kind=4),allocatable,dimension(:,:) :: binObs
-  !time_beg=MPI_Wtime()
 
 !**************************************************************************
 ! Initialize variables
@@ -370,7 +367,6 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   iob=1
 ! Big loop over standard data feed and possible rars/db data
 ! llll=1 normal feed, llll=2 RARS/EARS data, llll=3 DB/UW data
-  !tb1=MPI_Wtime()
   ears_db_loop: do llll= 1, 3
 
      if(llll == 1)then
@@ -508,8 +504,6 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
      call closbf(lnbufr)
      close(lnbufr)
   end do ears_db_loop
-  !te1=MPI_Wtime()
-  !write(6,'("Walltime for read_atms: EARS loop " f15.4)') te1-tb1
   deallocate(data1b8)
 
   num_obs = iob-1
@@ -539,7 +533,6 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   binCount(:)=0
 
 ! First scan to determine which obs fall into which bins
-  !tb2=MPI_Wtime()
   ObsLoop: do iob=1,num_obs
 
      t4dv       => t4dv_save(iob)
@@ -603,7 +596,6 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   allocate(hash(itxmax))
   hash=0
   do bin = 1,numBinsWithObs
-    !write(6,'("read_atms: Pack " 2I10)') bin,binsWithObs(bin)
     hash(binsWithObs(bin)) = bin
   enddo
 
@@ -666,16 +658,12 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 !    Map obs to thinning grid
      call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,it_mesh)
      binCount(itx2) = binCount(itx2)+1
-     !binObs(binCount(itx2),findloc(binsWithObs,itx2,dim=1)) = iob
      binObs(binCount(itx2),hash(itx2)) = iob
   end do ObsLoop2
   deallocate(hash)
-  !te2=MPI_Wtime()
-  !write(6,'("Walltime for read_atms: OBS loop " I10,f15.4)') num_obs, te2-tb2
 
 ! Second scan to determine which observation in a given bin is best to use
   good=0
-  !tb2=MPI_Wtime()
   !$omp parallel do default(none), schedule(dynamic,12), &
   !$omp& firstprivate(ich1,ich2,ich3,ich16,ich17), &
   !$omp& private(bin,score,bin2,Obindx,iob,rsat,t4dv,dlon_earth,dlat_earth,crit1,it_mesh,ifov,lza, &
@@ -943,11 +931,8 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
      score_crit(bin2) = score
   end do BinLoop
   !$omp end parallel do
-  !te2=MPI_Wtime()
 
-  !write(6,'("Walltime for read_atms: bin loop " f15.4)')  te2-tb2
   write(6,'("read_atms: Number of obs considered and accepted " 2I10)') num_obs, good
-  !write(6,'("read_atms: data_all checksum " f25.14)') sum(data_all(1:31,:))
   deallocate(binCount)
   deallocate(binObs)
   deallocate(binsWithObs)
@@ -1003,9 +988,6 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 
   if(diagnostic_reg.and.ntest>0) write(6,*)'READ_ATMS:  ',&
      'mype,ntest,disterrmax=',mype,ntest,disterrmax
-
-  !time_end=MPI_Wtime()
-  !write(6,'("Walltime for read_atms " f15.4)') time_end-time_beg
 
 ! End of routine
   return

--- a/src/gsi/read_atms.f90
+++ b/src/gsi/read_atms.f90
@@ -91,7 +91,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   use gsi_nstcouplermod, only: gsi_nstcoupler_skindepth,gsi_nstcoupler_deter
   use mpimod, only: npe
   use radiance_mod, only: rad_obs_type
-  use mpi, only : MPI_Wtime,MPI_COMM_WORLD
+  !use mpi, only : MPI_Wtime,MPI_COMM_WORLD
 
   implicit none
 
@@ -197,10 +197,10 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   integer(i_kind) :: ithin_time,n_tbin
   integer(i_kind),pointer :: it_mesh => null()
   real(kind=8) :: time_beg,time_end,tb1,tb2,tb3,te1,te2,te3,walltime
-  integer(kind=4) :: good,bin,Obindx,maxPerBin
-  integer,allocatable,dimension(:)   :: binCount
-  integer,allocatable,dimension(:,:) :: binObs
-  time_beg=MPI_Wtime()
+  integer(kind=4) :: good,bin,bin2,Obindx,maxPerBin,numBinsWithObs
+  integer(kind=4),allocatable,dimension(:)   :: binCount,binsWithObs,hash
+  integer(kind=4),allocatable,dimension(:,:) :: binObs
+  !time_beg=MPI_Wtime()
 
 !**************************************************************************
 ! Initialize variables
@@ -370,7 +370,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   iob=1
 ! Big loop over standard data feed and possible rars/db data
 ! llll=1 normal feed, llll=2 RARS/EARS data, llll=3 DB/UW data
-  tb1=MPI_Wtime()
+  !tb1=MPI_Wtime()
   ears_db_loop: do llll= 1, 3
 
      if(llll == 1)then
@@ -386,7 +386,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 
 !    Reopen unit to satellite bufr file
      open(lnbufr,file=trim(infile2),form='unformatted',status = 'old', &
-         iostat = ierr)
+         action='read', iostat = ierr)
      if(ierr /= 0) cycle ears_db_loop
 
      call openbf(lnbufr,'IN',lnbufr)
@@ -508,8 +508,8 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
      call closbf(lnbufr)
      close(lnbufr)
   end do ears_db_loop
-  te1=MPI_Wtime()
-  write(6,'("Walltime for read_atms: EARS loop " f15.4)') te1-tb1
+  !te1=MPI_Wtime()
+  !write(6,'("Walltime for read_atms: EARS loop " f15.4)') te1-tb1
   deallocate(data1b8)
 
   num_obs = iob-1
@@ -539,7 +539,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   binCount(:)=0
 
 ! First scan to determine which obs fall into which bins
-  tb2=MPI_Wtime()
+  !tb2=MPI_Wtime()
   ObsLoop: do iob=1,num_obs
 
      t4dv       => t4dv_save(iob)
@@ -595,10 +595,22 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   end do ObsLoop
 
   maxPerBin=maxval(binCount)
-  write(6,'("read_atms: max number of obs in any bin " I10)') maxPerBin
-  write(6,'("read_atms: number of bins with any obs " I10)') count(mask=binCount>0)
+  numBinsWithObs = count(mask=binCount>0)
+  ! Find the indices of positive elements
+  allocate(binsWithObs(numBinsWithObs))
+  binsWithObs = pack( (/ (i, i=1,size(binCount)) /), binCount > 0)
 
-  allocate(binObs(maxPerBin,itxmax))
+  allocate(hash(itxmax))
+  hash=0
+  do bin = 1,numBinsWithObs
+    !write(6,'("read_atms: Pack " 2I10)') bin,binsWithObs(bin)
+    hash(binsWithObs(bin)) = bin
+  enddo
+
+  write(6,'("read_atms: max number of obs in any bin " I10)') maxPerBin
+  write(6,'("read_atms: number of bins with any obs " I10)') numBinsWithObs
+
+  allocate(binObs(maxPerBin,numBinsWithObs))
   binObs(:,:)=0
   binCount(:)=0
 
@@ -654,38 +666,40 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 !    Map obs to thinning grid
      call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,it_mesh)
      binCount(itx2) = binCount(itx2)+1
-     binObs(binCount(itx2),itx2) = iob
+     !binObs(binCount(itx2),findloc(binsWithObs,itx2,dim=1)) = iob
+     binObs(binCount(itx2),hash(itx2)) = iob
   end do ObsLoop2
-  te2=MPI_Wtime()
-  write(6,'("Walltime for read_atms: OBS loop " I10,f15.4)') num_obs, te2-tb2
+  deallocate(hash)
+  !te2=MPI_Wtime()
+  !write(6,'("Walltime for read_atms: OBS loop " I10,f15.4)') num_obs, te2-tb2
 
 ! Second scan to determine which observation in a given bin is best to use
   good=0
-  tb2=MPI_Wtime()
+  !tb2=MPI_Wtime()
   !$omp parallel do default(none), schedule(dynamic,12), &
   !$omp& firstprivate(ich1,ich2,ich3,ich16,ich17), &
-  !$omp& private(bin,score,Obindx,iob,rsat,t4dv,dlon_earth,dlat_earth,crit1,it_mesh,ifov,lza, &
+  !$omp& private(bin,score,bin2,Obindx,iob,rsat,t4dv,dlon_earth,dlat_earth,crit1,it_mesh,ifov,lza, &
   !$omp&   satazi,solzen,solazi,bt_in,dlat_earth_deg,dlon_earth_deg, &
   !$omp&   dlon,dlat,outside,dlon00,dlat00,cdist, &
   !$omp&   disterr,disterrmax,tdiff,iuse,itt,itx,dist1, &
   !$omp&   ifovmod,iskip,critical_channels_missing,j,valid,isflg,idomsfc, &
   !$omp&   sfcpct,sty,vty,vfr,stp,sm,ff10,sfcr,zz,sn,ts,tsavg,pred,ch1,ch2,i, &
   !$omp&   ch3,ch16,cosza,qval,d0,tt,tref,dtw,dtc,tz_tr,panglr) &
-  !$omp& shared(itxmax,binCount,binObs,deg2rad,rad2deg,rlats,rlons,nlat,nlon,iwinbgn,gstime,r60inv,ithin,sis, &
+  !$omp& shared(numBinsWithObs,binCount,binObs,deg2rad,rad2deg,rlats,rlons,nlat,nlon,iwinbgn,gstime,r60inv,ithin,sis, &
   !$omp&   instr,ichan,expansion,ichan1,ichan2,ichan3,ichan16,ichan17,nadir,zob, &
   !$omp&   val_tovs,num_obs,rsat_save,t4dv_save,dlon_earth_save,dlat_earth_save, &
   !$omp&   crit1_save,it_mesh_save,ifov_save,lza_save,satazi_save,solzen_save, &
   !$omp&   solazi_save,bt_save,regional,diagnostic_reg,l4dvar,l4densvar, &
   !$omp&   winlen,twind,use_edges,radedge_min,radedge_max,maxscan,nchanl, &
   !$omp&   isfcalc,rlndsea,adp_anglebc,newpc4pred,radmod,d1,d2,maxinfo, &
-  !$omp&   ang_rad,cbias,air_rad,nst_gsi,start,step,data_all,dval_use,nrec,nreal,score_crit) &
+  !$omp&   ang_rad,cbias,air_rad,nst_gsi,start,step,data_all,dval_use,nrec,nreal,score_crit,binsWithObs) &
   !$omp& reduction(+:ntest,nread,good)
-  BinLoop: do bin = 1,itxmax
+  BinLoop: do bin = 1,numBinsWithObs
 
-    if(binCount(bin) == 0) cycle BinLoop
      score=9.99e10_r_kind
+     bin2 = binsWithObs(bin)
 
-     ObsLoop3: do Obindx = 1,binCount(bin)
+     ObsLoop3: do Obindx = 1,binCount(bin2)
 
        iob        = binObs(Obindx,bin)
        rsat       => rsat_save(iob)
@@ -876,64 +890,67 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 
 !      Load selected observation into data array
               
-       data_all(1 ,bin)= rsat                      ! satellite ID
-       data_all(2 ,bin)= t4dv                      ! time
-       data_all(3 ,bin)= dlon                      ! grid relative longitude
-       data_all(4 ,bin)= dlat                      ! grid relative latitude
-       data_all(5 ,bin)= lza                       ! local zenith angle
-       data_all(6 ,bin)= satazi                    ! local azimuth angle
-       data_all(7 ,bin)= panglr                    ! look angle
-       data_all(8 ,bin)= ifovmod                   ! scan position
-       data_all(9 ,bin)= solzen                    ! solar zenith angle
-       data_all(10,bin)= solazi                    ! solar azimuth angle
-       data_all(11,bin) = sfcpct(0)                ! sea percentage of
-       data_all(12,bin) = sfcpct(1)                ! land percentage
-       data_all(13,bin) = sfcpct(2)                ! sea ice percentage
-       data_all(14,bin) = sfcpct(3)                ! snow percentage
-       data_all(15,bin)= ts(0)                     ! ocean skin temperature
-       data_all(16,bin)= ts(1)                     ! land skin temperature
-       data_all(17,bin)= ts(2)                     ! ice skin temperature
-       data_all(18,bin)= ts(3)                     ! snow skin temperature
-       data_all(19,bin)= tsavg                     ! average skin temperature
-       data_all(20,bin)= vty                       ! vegetation type
-       data_all(21,bin)= vfr                       ! vegetation fraction
-       data_all(22,bin)= sty                       ! soil type
-       data_all(23,bin)= stp                       ! soil temperature
-       data_all(24,bin)= sm                        ! soil moisture
-       data_all(25,bin)= sn                        ! snow depth
-       data_all(26,bin)= zz                        ! surface height
-       data_all(27,bin)= idomsfc(1) + 0.001_r_kind ! dominate surface type
-       data_all(28,bin)= sfcr                      ! surface roughness
-       data_all(29,bin)= ff10                      ! ten meter wind factor
-       data_all(30,bin) = dlon_earth_deg           ! earth relative longitude (deg)
-       data_all(31,bin) = dlat_earth_deg           ! earth relative latitude (deg)
+       data_all(1 ,bin2)= rsat                      ! satellite ID
+       data_all(2 ,bin2)= t4dv                      ! time
+       data_all(3 ,bin2)= dlon                      ! grid relative longitude
+       data_all(4 ,bin2)= dlat                      ! grid relative latitude
+       data_all(5 ,bin2)= lza                       ! local zenith angle
+       data_all(6 ,bin2)= satazi                    ! local azimuth angle
+       data_all(7 ,bin2)= panglr                    ! look angle
+       data_all(8 ,bin2)= ifovmod                   ! scan position
+       data_all(9 ,bin2)= solzen                    ! solar zenith angle
+       data_all(10,bin2)= solazi                    ! solar azimuth angle
+       data_all(11,bin2) = sfcpct(0)                ! sea percentage of
+       data_all(12,bin2) = sfcpct(1)                ! land percentage
+       data_all(13,bin2) = sfcpct(2)                ! sea ice percentage
+       data_all(14,bin2) = sfcpct(3)                ! snow percentage
+       data_all(15,bin2)= ts(0)                     ! ocean skin temperature
+       data_all(16,bin2)= ts(1)                     ! land skin temperature
+       data_all(17,bin2)= ts(2)                     ! ice skin temperature
+       data_all(18,bin2)= ts(3)                     ! snow skin temperature
+       data_all(19,bin2)= tsavg                     ! average skin temperature
+       data_all(20,bin2)= vty                       ! vegetation type
+       data_all(21,bin2)= vfr                       ! vegetation fraction
+       data_all(22,bin2)= sty                       ! soil type
+       data_all(23,bin2)= stp                       ! soil temperature
+       data_all(24,bin2)= sm                        ! soil moisture
+       data_all(25,bin2)= sn                        ! snow depth
+       data_all(26,bin2)= zz                        ! surface height
+       data_all(27,bin2)= idomsfc(1) + 0.001_r_kind ! dominate surface type
+       data_all(28,bin2)= sfcr                      ! surface roughness
+       data_all(29,bin2)= ff10                      ! ten meter wind factor
+       data_all(30,bin2) = dlon_earth_deg           ! earth relative longitude (deg)
+       data_all(31,bin2) = dlat_earth_deg           ! earth relative latitude (deg)
      
        if(dval_use) then
-          data_all(32,bin)= val_tovs
-          data_all(33,bin)= itt
+          data_all(32,bin2)= val_tovs
+          data_all(33,bin2)= itt
        end if
      
        if(nst_gsi>0) then
-          data_all(maxinfo+1,bin) = tref            ! foundation temperature
-          data_all(maxinfo+2,bin) = dtw             ! dt_warm at zob
-          data_all(maxinfo+3,bin) = dtc             ! dt_cool at zob
-          data_all(maxinfo+4,bin) = tz_tr           ! d(Tz)/d(Tr)
+          data_all(maxinfo+1,bin2) = tref            ! foundation temperature
+          data_all(maxinfo+2,bin2) = dtw             ! dt_warm at zob
+          data_all(maxinfo+3,bin2) = dtc             ! dt_cool at zob
+          data_all(maxinfo+4,bin2) = tz_tr           ! d(Tz)/d(Tr)
        endif
 
        do i=1,nchanl
-          data_all(i+nreal,bin)=bt_in(i)
+          data_all(i+nreal,bin2)=bt_in(i)
        end do
-       nrec(bin)=iob
+       nrec(bin2)=iob
        good=good+1
      enddo ObsLoop3
-     score_crit(bin) = score
+     score_crit(bin2) = score
   end do BinLoop
-  te2=MPI_Wtime()
+  !$omp end parallel do
+  !te2=MPI_Wtime()
 
-  write(6,'("Walltime for read_atms: bin loop " 2I10,f15.4)') num_obs, good, te2-tb2
+  !write(6,'("Walltime for read_atms: bin loop " f15.4)')  te2-tb2
+  write(6,'("read_atms: Number of obs considered and accepted " 2I10)') num_obs, good
   !write(6,'("read_atms: data_all checksum " f25.14)') sum(data_all(1:31,:))
   deallocate(binCount)
   deallocate(binObs)
+  deallocate(binsWithObs)
 
 
   DEALLOCATE(iscan)
@@ -987,8 +1004,8 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   if(diagnostic_reg.and.ntest>0) write(6,*)'READ_ATMS:  ',&
      'mype,ntest,disterrmax=',mype,ntest,disterrmax
 
-  time_end=MPI_Wtime()
-  write(6,'("Walltime for read_atms " f15.4)') time_end-time_beg
+  !time_end=MPI_Wtime()
+  !write(6,'("Walltime for read_atms " f15.4)') time_end-time_beg
 
 ! End of routine
   return

--- a/src/gsi/read_atms.f90
+++ b/src/gsi/read_atms.f90
@@ -74,7 +74,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 !$$$
   use kinds, only: r_kind,r_double,i_kind
   use satthin, only: super_val,itxmax,makegrids,destroygrids,checkob, &
-      finalcheck,map2tgrid,score_crit
+      finalcheck,map2tgrid,score_crit,map2tgrid2,binit
   use satthin, only: radthin_time_info,tdiff2crit
   use obsmod,  only: time_window_max, ta2tb
   use radinfo, only: iuse_rad,newchn,cbias,nusis,jpch_rad,air_rad,ang_rad, &
@@ -91,6 +91,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   use gsi_nstcouplermod, only: gsi_nstcoupler_skindepth,gsi_nstcoupler_deter
   use mpimod, only: npe
   use radiance_mod, only: rad_obs_type
+  use mpi, only : MPI_Wtime,MPI_COMM_WORLD
 
   implicit none
 
@@ -138,7 +139,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   integer(i_kind) iret,idate,nchanl,n,idomsfc(1)
   integer(i_kind) ich1,ich2,ich8,ich15,ich16,ich17
   integer(i_kind) kidsat,maxinfo
-  integer(i_kind) nmind,itx,nreal,nele,itt,num_obs
+  integer(i_kind) nmind,itx,nreal,nele,itt,num_obs,itx2
   integer(i_kind) iskip,ichan2,ichan1,ichan16,ichan17
   integer(i_kind) lnbufr,ksatid,isflg,ichan3,ich3,ich4,ich6
   integer(i_kind) ilat,ilon, ifovmod, nadir
@@ -190,12 +191,18 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   real(r_kind) cdist,disterr,disterrmax,dlon00,dlat00
 
   logical :: critical_channels_missing
-  real(r_kind)    :: ptime,timeinflat,crit0
+  real(r_kind)    :: ptime,timeinflat,crit0,score
   integer(i_kind) :: ithin_time,n_tbin
   integer(i_kind),pointer :: it_mesh => null()
+  real(kind=8) :: time_beg,time_end,tb1,tb2,tb3,te1,te2,te3,walltime
+  integer(kind=4) :: good,bin,Obindx
+  integer,allocatable,dimension(:)   :: binCount
+  integer,allocatable,dimension(:,:) :: binObs
+  time_beg=MPI_Wtime()
 
 !**************************************************************************
 ! Initialize variables
+  write(6,'("read_atms: Enter ithin is " I8)') ithin
 
   maxinfo=31
   lnbufr = 15
@@ -290,6 +297,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   nreal = maxinfo + nstinfo
   nele  = nreal   + nchanl
   allocate(data_all(nele,itxmax),nrec(itxmax))
+  data_all=zero
   nrec=999999
 
 ! IFSCALC setup
@@ -360,6 +368,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   iob=1
 ! Big loop over standard data feed and possible rars/db data
 ! llll=1 normal feed, llll=2 RARS/EARS data, llll=3 DB/UW data
+  tb1=MPI_Wtime()
   ears_db_loop: do llll= 1, 3
 
      if(llll == 1)then
@@ -497,6 +506,8 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
      call closbf(lnbufr)
      close(lnbufr)
   end do ears_db_loop
+  te1=MPI_Wtime()
+  write(6,'("Walltime for read_atms: EARS loop " f15.4)') te1-tb1
   deallocate(data1b8)
 
   num_obs = iob-1
@@ -522,71 +533,49 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
      RETURN
   END IF
 
-! Complete Read_ATMS thinning and QC steps
+  allocate(binCount(itxmax))
+  allocate(binObs(500,itxmax))
 
-  ObsLoop: do iob = 1, num_obs  
+! First scan to determine which obs fall into which bins
+  tb2=MPI_Wtime()
+  ObsLoop: do iob=1,num_obs
 
-     rsat       => rsat_save(iob)
      t4dv       => t4dv_save(iob)
      dlon_earth => dlon_earth_save(iob)
      dlat_earth => dlat_earth_save(iob)
-     crit1      => crit1_save(iob)
      it_mesh    => it_mesh_save(iob)
      ifov       => ifov_save(iob)
-     lza        => lza_save(iob)
-     satazi     => satazi_save(iob)
-     solzen     => solzen_save(iob)
-     solazi     => solazi_save(iob)
-     bt_in      => bt_save(1:nchanl,iob)
-     
-     dlat_earth_deg = dlat_earth
-     dlon_earth_deg = dlon_earth
-     dlat_earth = dlat_earth*deg2rad
-     dlon_earth = dlon_earth*deg2rad   
 
 !    Regional case
      if(regional)then
-        call tll2xy(dlon_earth,dlat_earth,dlon,dlat,outside)
+        call tll2xy(dlon_earth*deg2rad,dlat_earth*deg2rad,dlon,dlat,outside)
         if(diagnostic_reg) then
            call txy2ll(dlon,dlat,dlon00,dlat00)
            ntest=ntest+1
-           cdist=sin(dlat_earth)*sin(dlat00)+cos(dlat_earth)*cos(dlat00)* &
-                (sin(dlon_earth)*sin(dlon00)+cos(dlon_earth)*cos(dlon00))
+           cdist=sin(dlat_earth*deg2rad)*sin(dlat00)+cos(dlat_earth*deg2rad)*cos(dlat00)* &
+                (sin(dlon_earth*deg2rad)*sin(dlon00)+cos(dlon_earth*deg2rad)*cos(dlon00))
            cdist=max(-one,min(cdist,one))
            disterr=acos(cdist)*rad2deg
            disterrmax=max(disterrmax,disterr)
         end if
-           
 !       Check to see if in domain
         if(outside) cycle ObsLoop
-           
-!    Global case
-     else
-        dlat=dlat_earth
-        dlon=dlon_earth
-        call grdcrd1(dlat,rlats,nlat,1)
-        call grdcrd1(dlon,rlons,nlon,1)
      endif
 
-! Check time window
+!    Check time window
      if (l4dvar.or.l4densvar) then
         if (t4dv<zero .OR. t4dv>winlen) cycle ObsLoop
      else
         tdiff=t4dv+(iwinbgn-gstime)*r60inv
         if(abs(tdiff) > twind) cycle ObsLoop
      endif
- 
-!    Map obs to thinning grid
-     call map2tgrid(dlat_earth,dlon_earth,dist1,crit1,itx,ithin,itt,iuse,sis,it_mesh=it_mesh)
-     if(.not. iuse)cycle ObsLoop
-
 !
 !    Check FOV and scan-edge usage
      if (.not. use_edges .and. (ifov < radedge_min .OR. ifov > radedge_max )) &
           cycle ObsLoop
 
      if (maxscan < 96) then
-       ! For ATMS when using the old style satang files, 
+       ! For ATMS when using the old style satang files,
        ! we shift the FOV number down by three as we can only use
        ! 90 of the 96 positions right now because of the scan bias limitation.
        ifovmod=ifov-3
@@ -597,23 +586,114 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
        if (ifov < 4 .OR. ifov > 93) cycle ObsLoop
        ifovmod=ifov
      endif
+ 
+!    Map obs to thinning grid
+     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,it_mesh)
+     binCount(itx2) = binCount(itx2)+1
+     binObs(binCount(itx2),itx2) = iob
+  end do ObsLoop
+  te2=MPI_Wtime()
+  write(6,'("Walltime for read_atms: OBS loop " I10,f15.4)') num_obs, te2-tb2
+  write(6,'("read_atms: max number of obs in any bin " I10)') maxval(binCount)
+  write(6,'("read_atms: number of bins with any obs " I10)') count(mask=binCount>0)
 
-     nread=nread+nchanl
+! Second scan to determine which observation in a given bin is best to use
+  good=0
+  tb2=MPI_Wtime()
+  !$omp parallel do default(none), num_threads(8), schedule(dynamic,12), &
+  !$omp& firstprivate(ich1,ich2,ich3,ich16,ich17), &
+  !$omp& private(bin,score,Obindx,iob,rsat,t4dv,dlon_earth,dlat_earth,crit1,it_mesh,ifov,lza, &
+  !$omp&   satazi,solzen,solazi,bt_in,dlat_earth_deg,dlon_earth_deg, &
+  !$omp&   dlon,dlat,outside,dlon00,dlat00,cdist, &
+  !$omp&   disterr,disterrmax,tdiff,iuse,itt,itx,dist1, &
+  !$omp&   ifovmod,iskip,critical_channels_missing,j,valid,isflg,idomsfc, &
+  !$omp&   sfcpct,sty,vty,vfr,stp,sm,ff10,sfcr,zz,sn,ts,tsavg,pred,ch1,ch2,i, &
+  !$omp&   ch3,ch16,cosza,qval,d0,tt,tref,dtw,dtc,tz_tr,panglr) &
+  !$omp& shared(itxmax,binCount,binObs,deg2rad,rad2deg,rlats,rlons,nlat,nlon,iwinbgn,gstime,r60inv,ithin,sis, &
+  !$omp&   instr,ichan,expansion,ichan1,ichan2,ichan3,ichan16,ichan17,nadir,zob, &
+  !$omp&   val_tovs,num_obs,rsat_save,t4dv_save,dlon_earth_save,dlat_earth_save, &
+  !$omp&   crit1_save,it_mesh_save,ifov_save,lza_save,satazi_save,solzen_save, &
+  !$omp&   solazi_save,bt_save,regional,diagnostic_reg,l4dvar,l4densvar, &
+  !$omp&   winlen,twind,use_edges,radedge_min,radedge_max,maxscan,nchanl, &
+  !$omp&   isfcalc,rlndsea,adp_anglebc,newpc4pred,radmod,d1,d2,maxinfo, &
+  !$omp&   ang_rad,cbias,air_rad,nst_gsi,start,step,data_all,dval_use,nrec,nreal,score_crit) &
+  !$omp& reduction(+:ntest,nread,good)
+  BinLoop: do bin = 1,itxmax
+
+    if(binCount(bin) == 0) cycle BinLoop
+     score=9.99e10_r_kind
+
+     ObsLoop2: do Obindx = 1,binCount(bin)
+
+       iob        = binObs(Obindx,bin)
+       rsat       => rsat_save(iob)
+       t4dv       => t4dv_save(iob)
+       dlon_earth => dlon_earth_save(iob)
+       dlat_earth => dlat_earth_save(iob)
+       crit1      => crit1_save(iob)
+       it_mesh    => it_mesh_save(iob)
+       ifov       => ifov_save(iob)
+       lza        => lza_save(iob)
+       satazi     => satazi_save(iob)
+       solzen     => solzen_save(iob)
+       solazi     => solazi_save(iob)
+       bt_in      => bt_save(1:nchanl,iob)
+
+       dlat_earth_deg = dlat_earth
+       dlon_earth_deg = dlon_earth
+       dlat_earth = dlat_earth*deg2rad
+       dlon_earth = dlon_earth*deg2rad
+
+!      Regional case
+       if(regional)then
+          call tll2xy(dlon_earth,dlat_earth,dlon,dlat,outside)
+          if(diagnostic_reg) then
+             call txy2ll(dlon,dlat,dlon00,dlat00)
+             ntest=ntest+1
+             cdist=sin(dlat_earth)*sin(dlat00)+cos(dlat_earth)*cos(dlat00)* &
+                  (sin(dlon_earth)*sin(dlon00)+cos(dlon_earth)*cos(dlon00))
+             cdist=max(-one,min(cdist,one))
+             disterr=acos(cdist)*rad2deg
+             disterrmax=max(disterrmax,disterr)
+          end if
+       endif
+
+!      Map obs to thinning grid
+       !call map2tgrid(dlat_earth,dlon_earth,dist1,crit1,itx,ithin,itt,iuse,sis,it_mesh=it_mesh)
+       ! DSK: We already know which bin (itx) this observation resides in so no need to recalculate.
+       ! Could inline this map2tgrid2 call if I had local access to istart_val,glat,mlat,glon and mlon from satthin.
+       call map2tgrid2(dlat_earth,dlon_earth,dist1,crit1,itx,ithin,itt,iuse,sis,score,it_mesh)
+       if(.not. iuse) cycle ObsLoop2
+
+       if (maxscan < 96) then
+         ! For ATMS when using the old style satang files, 
+         ! we shift the FOV number down by three as we can only use
+         ! 90 of the 96 positions right now because of the scan bias limitation.
+         ifovmod=ifov-3
+         ! Check that ifov is not out of range of cbias dimension
+         !if (ifovmod < 1 .OR. ifovmod > 90) cycle ObsLoop2
+       else
+         ! This line is for consistency with previous treatment
+         !if (ifov < 4 .OR. ifov > 93) cycle ObsLoop2
+         ifovmod=ifov
+       endif
+
+       nread=nread+nchanl
      
-!    Transfer observed brightness temperature to work array.  If any
-!    temperature exceeds limits, reset observation to "bad" value
-     iskip=0
-     critical_channels_missing = .false.
-     do j=1,nchanl
-        if (bt_in(j) < tbmin .or. bt_in(j) > tbmax) then
-           iskip = iskip + 1
-           
-!          Flag profiles where key channels are bad  
-           if((j == ich1 .or. j == ich2 .or. &
-                j == ich16 .or. j == ich17)) critical_channels_missing = .true.
-        endif
-     end do
-     if (iskip >= nchanl) cycle ObsLoop
+!      Transfer observed brightness temperature to work array.  If any
+!      temperature exceeds limits, reset observation to "bad" value
+       iskip=0
+       critical_channels_missing = .false.
+       do j=1,nchanl
+          if (bt_in(j) < tbmin .or. bt_in(j) > tbmax) then
+             iskip = iskip + 1
+             
+!            Flag profiles where key channels are bad  
+             if((j == ich1 .or. j == ich2 .or. &
+                 j == ich16 .or. j == ich17)) critical_channels_missing = .true.
+          endif
+       end do
+       if (iskip >= nchanl) cycle ObsLoop2
 
 !    Determine surface properties based on 
 !    sst and land/sea/ice mask   
@@ -625,157 +705,173 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 !               3 snow
 !               4 mixed                       
 
-!    FOV-based surface code requires fov number.  if out-of-range, then
-!    skip this ob.
+!      FOV-based surface code requires fov number.  if out-of-range, then
+!      skip this ob.
 
-     if (isfcalc == 1) then
-        call fov_check(ifov,instr,ichan,valid)
-        if (.not. valid) cycle ObsLoop
+       if(.not.regional)then 
+          dlat=dlat_earth
+          dlon=dlon_earth
+          call grdcrd1(dlat,rlats,nlat,1)
+          call grdcrd1(dlon,rlons,nlon,1)
+       endif
 
-!    When isfcalc is one, calculate surface fields based on size/shape of fov.
-!    Otherwise, use bilinear method.
+       if (isfcalc == 1) then
+          call fov_check(ifov,instr,ichan,valid)
+          if (.not. valid) cycle ObsLoop2
 
-        call deter_sfc_fov(fov_flag,ifov,instr,ichan,satazi,dlat_earth_deg,&
-             dlon_earth_deg,expansion,t4dv,isflg,idomsfc(1), &
-             sfcpct,vfr,sty,vty,stp,sm,ff10,sfcr,zz,sn,ts,tsavg)
-     else
-        call deter_sfc(dlat,dlon,dlat_earth,dlon_earth,t4dv,isflg, &
-             idomsfc(1),sfcpct,ts,tsavg,vty,vfr,sty,stp,sm,sn,zz,ff10,sfcr)
-     endif
+!         When isfcalc is one, calculate surface fields based on size/shape of fov.
+!         Otherwise, use bilinear method.
 
-     crit1 = crit1 + rlndsea(isflg) + 10._r_kind*real(iskip,r_kind) + 0.01_r_kind * abs(zz)
-     call checkob(dist1,crit1,itx,iuse)
-     if(.not. iuse)cycle ObsLoop
+          call deter_sfc_fov(fov_flag,ifov,instr,ichan,satazi,dlat_earth_deg,&
+               dlon_earth_deg,expansion,t4dv,isflg,idomsfc(1), &
+               sfcpct,vfr,sty,vty,stp,sm,ff10,sfcr,zz,sn,ts,tsavg)
+       else
+          call deter_sfc(dlat,dlon,dlat_earth,dlon_earth,t4dv,isflg, &
+               idomsfc(1),sfcpct,ts,tsavg,vty,vfr,sty,stp,sm,sn,zz,ff10,sfcr)
+       endif
 
-           if (critical_channels_missing) then
+       crit1 = crit1 + rlndsea(isflg) + 10._r_kind*real(iskip,r_kind) + 0.01_r_kind * abs(zz)
+       !call checkob(dist1,crit1,itx,iuse)
+       !if(.not. iuse)cycle ObsLoop2
+       if(crit1*dist1 > score) cycle ObsLoop2
 
-              pred=1.0e8_r_kind
+       if (critical_channels_missing) then
+         pred=1.0e8_r_kind
+       else
 
-           else
-
-!    Set data quality predictor
-!    Simply modify the AMSU-A-Type calculations and use them for all ATMS channels.
-!    Remove angle dependent pattern (not mean).
-              if (adp_anglebc .and. newpc4pred) then
-                 ch1 = bt_in(ich1)-ang_rad(ichan1)*cbias(ifovmod,ichan1)
-                 ch2 = bt_in(ich2)-ang_rad(ichan2)*cbias(ifovmod,ichan2)
-                 ch16= bt_in(ich16)-ang_rad(ichan16)*cbias(ifovmod,ichan16)
-              else
-                 ch1 = bt_in(ich1)-ang_rad(ichan1)*cbias(ifovmod,ichan1)+ &
-                      air_rad(ichan1)*cbias(nadir,ichan1)
-                 ch2 = bt_in(ich2)-ang_rad(ichan2)*cbias(ifovmod,ichan2)+ &
-                      air_rad(ichan2)*cbias(nadir,ichan2)   
-                 ch16= bt_in(ich16)-ang_rad(ichan16)*cbias(ifovmod,ichan16)+ &
-                      air_rad(ichan16)*cbias(nadir,ichan16)
-              end if
-              if (isflg == 0 .and. ch1<285.0_r_kind .and. ch2<285.0_r_kind) then
-                 cosza = cos(lza)
-                 if (radmod%lcloud_fwd) then
-                    qval=-113.2_r_kind+(2.41_r_kind-0.0049_r_kind*ch1)*ch1 +  &
-                               0.454_r_kind*ch2-ch16
-                    if (qval>=9.0_r_kind) then
-                       qval=1000.0_r_kind*qval
-                    else
-                       qval  = zero
-                    end if
-                    if (radmod%lprecip) qval=zero 
-                 else 
-                    d0    = 8.24_r_kind - 2.622_r_kind*cosza + 1.846_r_kind*cosza*cosza
-                    qval  = cosza*(d0+d1*log(285.0_r_kind-ch1)+d2*log(285.0_r_kind-ch2))
-                 endif
-                 pred  = max(zero,qval)*100.0_r_kind
-              else
+!        Set data quality predictor
+!        Simply modify the AMSU-A-Type calculations and use them for all ATMS channels.
+!        Remove angle dependent pattern (not mean).
+         if (adp_anglebc .and. newpc4pred) then
+            ch1 = bt_in(ich1)-ang_rad(ichan1)*cbias(ifovmod,ichan1)
+            ch2 = bt_in(ich2)-ang_rad(ichan2)*cbias(ifovmod,ichan2)
+            ch16= bt_in(ich16)-ang_rad(ichan16)*cbias(ifovmod,ichan16)
+         else
+            ch1 = bt_in(ich1)-ang_rad(ichan1)*cbias(ifovmod,ichan1)+ &
+                  air_rad(ichan1)*cbias(nadir,ichan1)
+            ch2 = bt_in(ich2)-ang_rad(ichan2)*cbias(ifovmod,ichan2)+ &
+                  air_rad(ichan2)*cbias(nadir,ichan2)   
+            ch16= bt_in(ich16)-ang_rad(ichan16)*cbias(ifovmod,ichan16)+ &
+                  air_rad(ichan16)*cbias(nadir,ichan16)
+         end if
+         if (isflg == 0 .and. ch1<285.0_r_kind .and. ch2<285.0_r_kind) then
+           cosza = cos(lza)
+           if (radmod%lcloud_fwd) then
+             qval=-113.2_r_kind+(2.41_r_kind-0.0049_r_kind*ch1)*ch1 + 0.454_r_kind*ch2-ch16
+             if (qval>=9.0_r_kind) then
+               qval=1000.0_r_kind*qval
+             else
+               qval  = zero
+             end if
+             if (radmod%lprecip) qval=zero 
+           else 
+             d0    = 8.24_r_kind - 2.622_r_kind*cosza + 1.846_r_kind*cosza*cosza
+             qval  = cosza*(d0+d1*log(285.0_r_kind-ch1)+d2*log(285.0_r_kind-ch2))
+           endif
+           pred  = max(zero,qval)*100.0_r_kind
+         else
 !          This is taken straight from AMSU-A even though Ch 3 has a different polarisation
 !          and ATMS Ch16 is at a slightly different frequency to AMSU-A Ch 15.
-                 if (adp_anglebc .and. newpc4pred) then
-                    ch3 = bt_in(ich3)-ang_rad(ichan3)*cbias(ifovmod,ichan3)
-                 else
-                    ch3  = bt_in(ich3)-ang_rad(ichan3)*cbias(ifovmod,ichan3)+ &
+           if (adp_anglebc .and. newpc4pred) then
+             ch3 = bt_in(ich3)-ang_rad(ichan3)*cbias(ifovmod,ichan3)
+           else
+             ch3  = bt_in(ich3)-ang_rad(ichan3)*cbias(ifovmod,ichan3)+ &
                          air_rad(ichan3)*cbias(nadir,ichan3)   
-                 end if
-                 pred = abs(ch1-ch16)
-                 if(ch1-ch16 >= three) then
-                    tt   = 168._r_kind-0.49_r_kind*ch16
-                    if(ch1 > 261._r_kind .or. ch1 >= tt .or. &
-                         (ch16 <= 273._r_kind))then
-                       pred = 100._r_kind
-                    end if
-                 end if
-              endif
            end if
+           pred = abs(ch1-ch16)
+           if(ch1-ch16 >= three) then
+             tt   = 168._r_kind-0.49_r_kind*ch16
+             if(ch1 > 261._r_kind .or. ch1 >= tt .or. (ch16 <= 273._r_kind))then
+               pred = 100._r_kind
+             end if
+           end if
+         endif
+       end if
 
-!    Compute "score" for observation.  All scores>=0.0.  Lowest score is "best"
-     crit1 = crit1+pred 
-     call finalcheck(dist1,crit1,itx,iuse)
-     if(.not. iuse)cycle ObsLoop
+!      Compute "score" for observation.  All scores>=0.0.  Lowest score is "best"
+       crit1 = crit1+pred 
+       !call finalcheck(dist1,crit1,itx,iuse)
+       !if(.not. iuse)cycle ObsLoop2
+       if(crit1*dist1 < score)then
+          score = crit1*dist1
+       else
+          cycle ObsLoop2
+       end if
      
-!    interpolate NSST variables to Obs. location and get dtw, dtc, tz_tr
-     if(nst_gsi>0) then
-        tref  = ts(0)
-        dtw   = zero
-        dtc   = zero
-        tz_tr = one
-        if(sfcpct(0)>zero) then
-           call gsi_nstcoupler_deter(dlat_earth,dlon_earth,t4dv,zob,tref,dtw,dtc,tz_tr)
-        endif
-     endif
+!      interpolate NSST variables to Obs. location and get dtw, dtc, tz_tr
+       if(nst_gsi>0) then
+          tref  = ts(0)
+          dtw   = zero
+          dtc   = zero
+          tz_tr = one
+          if(sfcpct(0)>zero) then
+             call gsi_nstcoupler_deter(dlat_earth,dlon_earth,t4dv,zob,tref,dtw,dtc,tz_tr)
+          endif
+       endif
 
-! Re-calculate look angle
-     panglr=(start+real(ifov-1,r_kind)*step)*deg2rad
+!      Re-calculate look angle
+       panglr=(start+real(ifov-1,r_kind)*step)*deg2rad
 
-
-!     Load selected observation into data array
+!      Load selected observation into data array
               
-     data_all(1 ,itx)= rsat                      ! satellite ID
-     data_all(2 ,itx)= t4dv                      ! time
-     data_all(3 ,itx)= dlon                      ! grid relative longitude
-     data_all(4 ,itx)= dlat                      ! grid relative latitude
-     data_all(5 ,itx)= lza                       ! local zenith angle
-     data_all(6 ,itx)= satazi                    ! local azimuth angle
-     data_all(7 ,itx)= panglr                    ! look angle
-     data_all(8 ,itx)= ifovmod                   ! scan position
-     data_all(9 ,itx)= solzen                    ! solar zenith angle
-     data_all(10,itx)= solazi                    ! solar azimuth angle
-     data_all(11,itx) = sfcpct(0)                ! sea percentage of
-     data_all(12,itx) = sfcpct(1)                ! land percentage
-     data_all(13,itx) = sfcpct(2)                ! sea ice percentage
-     data_all(14,itx) = sfcpct(3)                ! snow percentage
-     data_all(15,itx)= ts(0)                     ! ocean skin temperature
-     data_all(16,itx)= ts(1)                     ! land skin temperature
-     data_all(17,itx)= ts(2)                     ! ice skin temperature
-     data_all(18,itx)= ts(3)                     ! snow skin temperature
-     data_all(19,itx)= tsavg                     ! average skin temperature
-     data_all(20,itx)= vty                       ! vegetation type
-     data_all(21,itx)= vfr                       ! vegetation fraction
-     data_all(22,itx)= sty                       ! soil type
-     data_all(23,itx)= stp                       ! soil temperature
-     data_all(24,itx)= sm                        ! soil moisture
-     data_all(25,itx)= sn                        ! snow depth
-     data_all(26,itx)= zz                        ! surface height
-     data_all(27,itx)= idomsfc(1) + 0.001_r_kind ! dominate surface type
-     data_all(28,itx)= sfcr                      ! surface roughness
-     data_all(29,itx)= ff10                      ! ten meter wind factor
-     data_all(30,itx) = dlon_earth_deg           ! earth relative longitude (deg)
-     data_all(31,itx) = dlat_earth_deg           ! earth relative latitude (deg)
+       data_all(1 ,bin)= rsat                      ! satellite ID
+       data_all(2 ,bin)= t4dv                      ! time
+       data_all(3 ,bin)= dlon                      ! grid relative longitude
+       data_all(4 ,bin)= dlat                      ! grid relative latitude
+       data_all(5 ,bin)= lza                       ! local zenith angle
+       data_all(6 ,bin)= satazi                    ! local azimuth angle
+       data_all(7 ,bin)= panglr                    ! look angle
+       data_all(8 ,bin)= ifovmod                   ! scan position
+       data_all(9 ,bin)= solzen                    ! solar zenith angle
+       data_all(10,bin)= solazi                    ! solar azimuth angle
+       data_all(11,bin) = sfcpct(0)                ! sea percentage of
+       data_all(12,bin) = sfcpct(1)                ! land percentage
+       data_all(13,bin) = sfcpct(2)                ! sea ice percentage
+       data_all(14,bin) = sfcpct(3)                ! snow percentage
+       data_all(15,bin)= ts(0)                     ! ocean skin temperature
+       data_all(16,bin)= ts(1)                     ! land skin temperature
+       data_all(17,bin)= ts(2)                     ! ice skin temperature
+       data_all(18,bin)= ts(3)                     ! snow skin temperature
+       data_all(19,bin)= tsavg                     ! average skin temperature
+       data_all(20,bin)= vty                       ! vegetation type
+       data_all(21,bin)= vfr                       ! vegetation fraction
+       data_all(22,bin)= sty                       ! soil type
+       data_all(23,bin)= stp                       ! soil temperature
+       data_all(24,bin)= sm                        ! soil moisture
+       data_all(25,bin)= sn                        ! snow depth
+       data_all(26,bin)= zz                        ! surface height
+       data_all(27,bin)= idomsfc(1) + 0.001_r_kind ! dominate surface type
+       data_all(28,bin)= sfcr                      ! surface roughness
+       data_all(29,bin)= ff10                      ! ten meter wind factor
+       data_all(30,bin) = dlon_earth_deg           ! earth relative longitude (deg)
+       data_all(31,bin) = dlat_earth_deg           ! earth relative latitude (deg)
      
-     if(dval_use) then
-        data_all(32,itx)= val_tovs
-        data_all(33,itx)= itt
-     end if
+       if(dval_use) then
+          data_all(32,bin)= val_tovs
+          data_all(33,bin)= itt
+       end if
      
-     if(nst_gsi>0) then
-        data_all(maxinfo+1,itx) = tref            ! foundation temperature
-        data_all(maxinfo+2,itx) = dtw             ! dt_warm at zob
-        data_all(maxinfo+3,itx) = dtc             ! dt_cool at zob
-        data_all(maxinfo+4,itx) = tz_tr           ! d(Tz)/d(Tr)
-     endif
+       if(nst_gsi>0) then
+          data_all(maxinfo+1,bin) = tref            ! foundation temperature
+          data_all(maxinfo+2,bin) = dtw             ! dt_warm at zob
+          data_all(maxinfo+3,bin) = dtc             ! dt_cool at zob
+          data_all(maxinfo+4,bin) = tz_tr           ! d(Tz)/d(Tr)
+       endif
 
-     do i=1,nchanl
-        data_all(i+nreal,itx)=bt_in(i)
-     end do
-     nrec(itx)=iob
+       do i=1,nchanl
+          data_all(i+nreal,bin)=bt_in(i)
+       end do
+       nrec(bin)=iob
+       good=good+1
+     enddo ObsLoop2
+     score_crit(bin) = score
+  end do BinLoop
+  te2=MPI_Wtime()
 
-  end do ObsLoop
+  write(6,'("Walltime for read_atms: bin loop " 2I10,f15.4)') num_obs, good, te2-tb2
+  !write(6,'("read_atms: data_all checksum " f25.14)') sum(data_all(1:31,:))
+  deallocate(binCount)
+  deallocate(binObs)
 
 
   DEALLOCATE(iscan)
@@ -828,6 +924,9 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 
   if(diagnostic_reg.and.ntest>0) write(6,*)'READ_ATMS:  ',&
      'mype,ntest,disterrmax=',mype,ntest,disterrmax
+
+  time_end=MPI_Wtime()
+  write(6,'("Walltime for read_atms " f15.4)') time_end-time_beg
 
 ! End of routine
   return

--- a/src/gsi/read_atms.f90
+++ b/src/gsi/read_atms.f90
@@ -95,6 +95,8 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 
   implicit none
 
+  external:: stop2,openbf,ireadmg,ireadsb,ufbint,w3fs21,ufbrep,closbf,grdcrd1,combine_radobs,count_obs
+
 ! Declare passed variables
   character(len=*),intent(in   ) :: infile,obstype,jsatid
   character(len=20),intent(in  ) :: sis
@@ -534,6 +536,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   END IF
 
   allocate(binCount(itxmax))
+  binCount(:)=0
 
 ! First scan to determine which obs fall into which bins
   tb2=MPI_Wtime()

--- a/src/gsi/read_bufrtovs.f90
+++ b/src/gsi/read_bufrtovs.f90
@@ -130,8 +130,7 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
 !
 !$$$
   use kinds, only: r_kind,r_double,i_kind
-  use satthin, only: super_val,itxmax,makegrids,destroygrids,checkob, &
-      finalcheck,map2tgrid,score_crit
+  use satthin, only: super_val,itxmax,makegrids,destroygrids,score_crit,map2tgrid2,binit
   use satthin, only: radthin_time_info,tdiff2crit
   use obsmod, only: time_window_max, ta2tb
   use radinfo, only: iuse_rad,newchn,cbias,predx,nusis,jpch_rad,air_rad,ang_rad, &
@@ -154,7 +153,10 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   use mpimod, only: npe
   use radiance_mod, only: rad_obs_type
   use gsi_io, only: verbose
+  !use mpi, only : MPI_Wtime
   implicit none
+
+  external:: stop2,openbf,ireadmg,ireadsb,ufbint,w3fs21,ufbrep,closbf,grdcrd1,combine_radobs,count_obs
 
 ! Declare passed variables
   character(len=*),intent(in   ) :: infile,obstype,jsatid
@@ -180,6 +182,7 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   ! change from 13 to 14 for sacv
   integer(i_kind),parameter:: n1bhdr=14
   integer(i_kind),parameter:: n2bhdr=4
+  integer(i_kind),parameter:: maxobs = 500000
   real(r_kind),parameter:: r360=360.0_r_kind
   real(r_kind),parameter:: tbmin=50.0_r_kind
   real(r_kind),parameter:: tbmax=550.0_r_kind
@@ -193,12 +196,12 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   character(len=80):: hdr1b,hdr2b
 
   integer(i_kind) ireadsb,ireadmg,irec,next,nrec_startx
-  integer(i_kind) i,j,k,ifov,ntest,llll
+  integer(i_kind) i,j,k,ntest,iob,llll
   integer(i_kind) sacv
   integer(i_kind) iret,idate,nchanl,n,idomsfc(1)
   integer(i_kind) ich1,ich2,ich8,ich15,ich16,ich17
   integer(i_kind) kidsat,instrument,maxinfo
-  integer(i_kind) nmind,itx,nreal,nele,itt,ninstruments
+  integer(i_kind) nmind,itx,nreal,nele,itt,ninstruments,num_obs,itx2
   integer(i_kind) iskip,ichan2,ichan1,ichan15
   integer(i_kind) lnbufr,ksatid,ichan8,isflg,ichan3,ich3,ich4,ich6
   integer(i_kind) ilat,ilon,ifovmod
@@ -206,6 +209,8 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   integer(i_kind) instr,ichan
   integer(i_kind) error_status,irecx,ierr
   integer(i_kind) radedge_min, radedge_max
+  integer(i_kind), POINTER :: ifov
+  integer(i_kind), TARGET :: ifov_save(maxobs)
   integer(i_kind),allocatable,dimension(:)::nrec
   character(len=20),dimension(1):: sensorlist
 
@@ -219,13 +224,27 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   real(r_kind) :: zob,tref,dtw,dtc,tz_tr
 
   real(r_kind) pred, pred_water, pred_not_water
-  real(r_kind) rsat,dlat,panglr,dlon,rato,sstime,tdiff,t4dv
-  real(r_kind) dlon_earth_deg,dlat_earth_deg,sat_aziang
-  real(r_kind) dlon_earth,dlat_earth,r01
-  real(r_kind) crit1,step,start,ch8flg,dist1
-  real(r_kind) terrain,lza,df2,tt,lzaest
+  real(r_kind) dlat,dlon,rato,tdiff,sstime
+  real(r_kind) dlon_earth_deg,dlat_earth_deg,r01
+  real(r_kind) step,start,ch8flg,dist1
+  real(r_kind) terrain,df2,tt,lzaest
   real(r_kind),dimension(0:4):: rlndsea
   real(r_kind),allocatable,dimension(:,:):: data_all
+  real(r_kind), POINTER :: bt_in(:), crit1,rsat, t4dv, solzen, solazi
+  real(r_kind), POINTER :: dlon_earth,dlat_earth,satazi,lza,panglr
+
+  integer(i_kind), ALLOCATABLE, TARGET :: it_mesh_save(:)
+  real(r_kind), ALLOCATABLE, TARGET :: rsat_save(:)
+  real(r_kind), ALLOCATABLE, TARGET :: t4dv_save(:)
+  real(r_kind), ALLOCATABLE, TARGET :: dlon_earth_save(:)
+  real(r_kind), ALLOCATABLE, TARGET :: dlat_earth_save(:)
+  real(r_kind), ALLOCATABLE, TARGET :: crit1_save(:)
+  real(r_kind), ALLOCATABLE, TARGET :: lza_save(:)
+  real(r_kind), ALLOCATABLE, TARGET :: satazi_save(:)
+  real(r_kind), ALLOCATABLE, TARGET :: solzen_save(:)
+  real(r_kind), ALLOCATABLE, TARGET :: solazi_save(:)
+  real(r_kind), ALLOCATABLE, TARGET :: bt_save(:,:)
+  real(r_kind), ALLOCATABLE, TARGET :: panglr_save(:)
 
   real(crtm_kind),allocatable,dimension(:):: data1b4
   real(r_double),allocatable,dimension(:):: data1b8
@@ -234,8 +253,9 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
 
   real(r_kind) disterr,disterrmax,cdist,dlon00,dlat00
 
-  real(r_kind)    :: ptime,timeinflat,crit0
-  integer(i_kind) :: ithin_time,n_tbin,it_mesh
+  real(r_kind)    :: ptime,timeinflat,crit0,score
+  integer(i_kind) :: ithin_time,n_tbin
+  integer(i_kind),pointer :: it_mesh => null()
   logical :: critical_channels_missing,quiet
   logical :: print_verbose
 
@@ -243,6 +263,11 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   integer(i_kind) :: spc_coeff_versions
   character(len=80) :: spc_filename
   type(ACCoeff_type),dimension(3) :: accoeff_sets
+  real(kind=8) :: time_beg,time_end,tb1,tb2,te1,te2
+  integer(kind=4) :: good,bin,bin2,Obindx,maxPerBin,numBinsWithObs
+  integer,allocatable,dimension(:)   :: binCount,binsWithObs,hash
+  integer,allocatable,dimension(:,:) :: binObs
+  !time_beg=MPI_Wtime()
 
 !**************************************************************************
 ! Initialize variables
@@ -489,12 +514,28 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   hdr1b ='SAID FOVN YEAR MNTH DAYS HOUR MINU SECO CLAT CLON CLATH CLONH HOLS SACV'
   hdr2b ='SAZA SOZA BEARAZ SOLAZI'
   allocate(data_all(nele,itxmax),data1b8(nchanl),data1b4(nchanl),nrec(itxmax))
+  ALLOCATE(rsat_save(maxobs))
+  ALLOCATE(t4dv_save(maxobs))
+  ALLOCATE(dlon_earth_save(maxobs))
+  ALLOCATE(dlat_earth_save(maxobs))
+  ALLOCATE(crit1_save(maxobs))
+  ALLOCATE(it_mesh_save(maxobs))
+  ALLOCATE(lza_save(maxobs))
+  ALLOCATE(satazi_save(maxobs))
+  ALLOCATE(solzen_save(maxobs))
+  ALLOCATE(solazi_save(maxobs))
+  ALLOCATE(bt_save(nchanl,maxobs))
+  ALLOCATE(panglr_save(maxobs))
 
+  !data_all(:,:) = zero ! Only needed when calculating the checksum down below
   nrec = 999999
   next=0
   irec=0
+  good=0
+  iob=1
 ! Big loop over standard data feed and possible ears/db data
 ! llll=1 is normal feed, llll=2 EARS/RARS data, llll=3 DB/UW data)
+  !tb1=MPI_Wtime()
   ears_db_loop: do llll= 1, 3
 
      if(llll == 1)then
@@ -583,14 +624,27 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
 
 !    Loop to read bufr file
      irecx=0
-     read_subset: do while(ireadmg(lnbufr,subset,idate)>=0)
+     read_subset: do while(ireadmg(lnbufr,subset,idate)>=0 .and. iob < maxobs)
         irecx=irecx+1
         if(irecx < nrec_startx) cycle read_subset
         irec=irec+1
         next=next+1
         if(next == npe_sub)next=0
         if(next/=mype_sub)cycle read_subset
-        read_loop: do while (ireadsb(lnbufr)==0)
+        read_loop: do while (ireadsb(lnbufr)==0 .and. iob < maxobs)
+
+           rsat       => rsat_save(iob)
+           t4dv       => t4dv_save(iob)
+           dlon_earth => dlon_earth_save(iob)
+           dlat_earth => dlat_earth_save(iob)
+           crit1      => crit1_save(iob)
+           it_mesh    => it_mesh_save(iob)
+           ifov       => ifov_save(iob)
+           lza        => lza_save(iob)
+           satazi     => satazi_save(iob)
+           solzen     => solzen_save(iob)
+           solazi     => solazi_save(iob)
+           panglr     => panglr_save(iob)
 
 !          Read header record.  (llll=1 is normal feed, 2=EARS data, 3=DB data)
            call ufbint(lnbufr,bfr1bhdr,n1bhdr,1,iret,hdr1b)
@@ -623,34 +677,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
            end if
            if(dlon_earth<zero)  dlon_earth = dlon_earth+r360
            if(dlon_earth>=r360) dlon_earth = dlon_earth-r360
-           dlat_earth_deg = dlat_earth
-           dlon_earth_deg = dlon_earth
-           dlat_earth = dlat_earth*deg2rad
-           dlon_earth = dlon_earth*deg2rad
-
-!          Regional case
-           if(regional)then
-              call tll2xy(dlon_earth,dlat_earth,dlon,dlat,outside)
-              if(diagnostic_reg) then
-                 call txy2ll(dlon,dlat,dlon00,dlat00)
-                 ntest=ntest+1
-                 cdist=sin(dlat_earth)*sin(dlat00)+cos(dlat_earth)*cos(dlat00)* &
-                      (sin(dlon_earth)*sin(dlon00)+cos(dlon_earth)*cos(dlon00))
-                 cdist=max(-one,min(cdist,one))
-                 disterr=acos(cdist)*rad2deg
-                 disterrmax=max(disterrmax,disterr)
-              end if
-              
-!             Check to see if in domain
-              if(outside) cycle read_loop
-
-!          Global case
-           else
-              dlat=dlat_earth
-              dlon=dlon_earth
-              call grdcrd1(dlat,rlats,nlat,1)
-              call grdcrd1(dlon,rlons,nlon,1)
-           endif
 
 !          Extract date information.  If time outside window, skip this obs
            idate5(1) = bfr1bhdr(3) !year
@@ -676,8 +702,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
            if (llll >  1 ) crit0 = crit0 + r100 * real(llll,r_kind)
            timeinflat=two
            call tdiff2crit(tdiff,ptime,ithin_time,timeinflat,crit0,crit1,it_mesh)
-           call map2tgrid(dlat_earth,dlon_earth,dist1,crit1,itx,ithin,itt,iuse,sis,it_mesh=it_mesh)
-           if(.not. iuse)cycle read_loop
 
 !          Extract satellite antenna corrections version number
            if (llll > 1) then
@@ -723,12 +747,14 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
               cycle read_loop
            end if
 
-           sat_aziang=bfr2bhdr(3)
-           if (abs(sat_aziang) > r360) then
-              sat_aziang=zero
-!_RT              write(6,*) 'READ_BUFRTOVS: bad azimuth angle ',sat_aziang
-!_RT              cycle read_loop
+           satazi=bfr2bhdr(3)
+           if (abs(satazi) > r360) then
+              satazi=zero
+!_RT          write(6,*) 'READ_BUFRTOVS: bad azimuth angle ',satazi
+!_RT          cycle read_loop
            endif
+           solzen=bfr2bhdr(2)
+           solazi=bfr2bhdr(4)
 
 !          Read data record.  Increment data counter
 !          TMBR is actually the antenna temperature for most microwave sounders.
@@ -736,7 +762,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
 !          antenna temperature (remove_antcorr), to converting TMBR to
 !          brightness temperature (add_antcorr) and accepting TMBRST
 !
-
            if (ta2tb) then
 
               if (llll == 1) then
@@ -802,264 +827,463 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
 
            endif
 
-!          Transfer observed brightness temperature to work array.  If any
-!          temperature exceeds limits, reset observation to "bad" value
-           iskip=0 
-           critical_channels_missing = .false.
-           do j=1,nchanl
-              if (data1b8(j) < tbmin .or. data1b8(j) > tbmax) then
-                 iskip = iskip + 1
+           bt_save(1:nchanl,iob) = data1b8(1:nchanl)
+           iob=iob+1
 
-!                Flag profiles where key channels are bad  
-                 if(( msu  .and.  j == ich1) .or.                                 &
-                    (amsua .and. (j == ich1 .or. j == ich2 .or. j == ich3 .or.    &
-                                  j == ich4 .or. j == ich6 .or. j == ich15 )) .or.&
-                    (hirs  .and. (j == ich8 )) .or.                               &
-                    (amsub .and.  j == ich1) .or.                                 &
-                    (mhs   .and. (j == ich1 .or. j == ich2)) ) critical_channels_missing = .true.
-              endif
-           end do
-           if (iskip >= nchanl) cycle read_loop
-!          Map obs to thinning grid
-           crit1 = crit1 + 10._r_kind*real(iskip,r_kind)
-           call checkob(dist1,crit1,itx,iuse)
-           if(.not. iuse)cycle read_loop
-
-!          Determine surface properties based on 
-!          sst and land/sea/ice mask   
-!
-!          isflg    - surface flag
-!                     0 sea
-!                     1 land
-!                     2 sea ice
-!                     3 snow
-!                     4 mixed                       
-
-!          FOV-based surface code requires fov number.  if out-of-range, then
-!          skip this ob.
-
-           if (isfcalc == 1) then
-              call fov_check(ifov,instr,ichan,valid)
-              if (.not. valid) cycle read_loop
-
-!          When isfcalc is one, calculate surface fields based on size/shape of fov.
-!          Otherwise, use bilinear method.
-
-              call deter_sfc_fov(fov_flag,ifov,instr,ichan,sat_aziang,dlat_earth_deg,&
-                 dlon_earth_deg,expansion,t4dv,isflg,idomsfc(1), &
-                 sfcpct,vfr,sty,vty,stp,sm,ff10,sfcr,zz,sn,ts,tsavg)
-           else
-              call deter_sfc(dlat,dlon,dlat_earth,dlon_earth,t4dv,isflg, &
-                 idomsfc(1),sfcpct,ts,tsavg,vty,vfr,sty,stp,sm,sn,zz,ff10,sfcr)
-           endif
-
-
-           crit1 = crit1 + rlndsea(isflg) 
-           call checkob(dist1,crit1,itx,iuse)
-           if(.not. iuse)cycle read_loop
-
-
-           if (critical_channels_missing) then
-
-             pred=1.0e8_r_kind
-
-           else
-
-!             Set data quality predictor
-              if (msu) then
-                 if (newpc4pred) then
-                    ch1 = data1b8(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1)- &
-                         predx(1,ichan1)*air_rad(ichan1)
-                 else
-                    ch1 = data1b8(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1)- &
-                         r01*predx(1,ichan1)*air_rad(ichan1)
-                 end if
-                 ch1flg = tsavg-ch1
-                 if(isflg == 0)then
-                    pred = 100._r_kind-min(ch1flg,100.0_r_kind)
-                 else
-                    pred = abs(ch1flg)
-                 end if
-              else if (hirs) then
-                 if (newpc4pred) then
-                    ch8 = data1b8(ich8) -ang_rad(ichan8)*cbias(ifov,ichan8)- &
-                         predx(1,ichan8)*air_rad(ichan8)
-                 else
-                    ch8 = data1b8(ich8) -ang_rad(ichan8)*cbias(ifov,ichan8)- &
-                         r01*predx(1,ichan8)*air_rad(ichan8)
-                 end if
-                 ch8flg = tsavg-ch8
-                 pred   = 10.0_r_kind*max(zero,ch8flg)
-              else if (amsua) then
-!                Remove angle dependent pattern (not mean)
-                 if (adp_anglebc .and. newpc4pred) then
-                    ch1 = data1b8(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1) 
-                    ch2 = data1b8(ich2)-ang_rad(ichan2)*cbias(ifov,ichan2) 
-                    ch15= data1b8(ich15)-ang_rad(ichan15)*cbias(ifov,ichan15)
-                 else
-                    ch1 = data1b8(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1)+ &
-                         air_rad(ichan1)*cbias(15,ichan1)
-                    ch2 = data1b8(ich2)-ang_rad(ichan2)*cbias(ifov,ichan2)+ &
-                         air_rad(ichan2)*cbias(15,ichan2)   
-                    ch15= data1b8(ich15)-ang_rad(ichan15)*cbias(ifov,ichan15)
-                 end if
-                 if (isflg == 0 .and. ch1<285.0_r_kind .and. ch2<285.0_r_kind) then
-                    cosza = cos(lza)
-                    d0    = 8.24_r_kind - 2.622_r_kind*cosza + 1.846_r_kind*cosza*cosza                                 
-                    qval=cosza*(d0+d1*log(285.0_r_kind-ch1)+d2*log(285.0_r_kind-ch2))
-                    if (radmod%lcloud_fwd) then
-                       ! no preference in selecting clouds/precipitation
-                       ! qval=zero 
-                       ! favor non-precipitating clouds                                                   
-                       qval=-113.2_r_kind+(2.41_r_kind-0.0049_r_kind*ch1)*ch1 +  &         
-                            0.454_r_kind*ch2-ch15   
-                       if (qval>=9.0_r_kind) then
-                          qval=1000.0_r_kind*qval
-                       else
-                          qval=zero
-                       end if
-                       if (radmod%lprecip) qval=zero  
-                       ! favor thinner clouds
-                       ! cosza = cos(lza)
-                       ! d0= 8.24_r_kind - 2.622_r_kind*cosza + 1.846_r_kind*cosza*cosza
-                       ! qval=cosza*(d0+d1*log(285.0_r_kind-ch1)+d2*log(285.0_r_kind-ch2))
-                       ! if (qval>0.2_r_kind) then
-                       !    qval=1000.0_r_kind*qval
-                       ! else
-                       !    qval=zero
-                       ! end if
-                    end if
-                    pred  = max(zero,qval)*100.0_r_kind
-                 else
-                    if (adp_anglebc .and. newpc4pred) then
-                       ch3 = data1b8(ich3)-ang_rad(ichan3)*cbias(ifov,ichan3) 
-                       ch15 = data1b8(ich15)-ang_rad(ichan15)*cbias(ifov,ichan15) 
-                    else
-                       ch3  = data1b8(ich3)-ang_rad(ichan3)*cbias(ifov,ichan3)+ &
-                            air_rad(ichan3)*cbias(15,ichan3)   
-                       ch15 = data1b8(ich15)-ang_rad(ichan15)*cbias(ifov,ichan15)+ &
-                            air_rad(ichan15)*cbias(15,ichan15)
-                    end if
-                    pred = abs(ch1-ch15)
-                    if(ch1-ch15 >= three) then
-                       df2  = 5.10_r_kind +0.78_r_kind*ch1-0.96_r_kind*ch3
-                       tt   = 168._r_kind-0.49_r_kind*ch15
-                       if(ch1 > 261._r_kind .or. ch1 >= tt .or. & 
-                            (ch15 <= 273._r_kind .and. df2 >= 0.6_r_kind))then
-                          pred = 100._r_kind
-                       end if
-                    end if
-                 endif
-                 
-!                 sval=-113.2_r_kind+(2.41_r_kind-0.0049_r_kind*ch1)*ch1 +  &
-!                 0.454_r_kind*ch2-ch15
-                 
-              else if (amsub .or. mhs) then
-                 if (newpc4pred) then
-                    ch1 = data1b8(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1)- &
-                         predx(1,ichan1)*air_rad(ichan1)
-                    ch2 = data1b8(ich2)-ang_rad(ichan2)*cbias(ifov,ichan2)- &
-                         predx(1,ichan2)*air_rad(ichan2)
-                 else
-                    ch1 = data1b8(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1)- &
-                         r01*predx(1,ichan1)*air_rad(ichan1)
-                    ch2 = data1b8(ich2)-ang_rad(ichan2)*cbias(ifov,ichan2)- &
-                         r01*predx(1,ichan2)*air_rad(ichan2)
-                 end if
-                 pred_water = zero
-                 if(sfcpct(0) > zero)then
-                    cosza = cos(lza)
-                    if(ch2 < h300)then 
-                       pred_water = (0.13_r_kind*(ch1+33.58_r_kind*log(h300-ch2)- &
-                            341.17_r_kind))*five
-                    else
-                       pred_water = 100._r_kind
-                    end if
-                 end if
-                 pred_not_water = 42.72_r_kind + 0.85_r_kind*ch1-ch2
-                 pred = (sfcpct(0)*pred_water) + ((one-sfcpct(0))*pred_not_water)
-                 pred = max(zero,pred)
-                 
-              endif
-              
-           end if
-
-!          Compute "score" for observation.  All scores>=0.0.  Lowest score is "best"
-           crit1 = crit1+pred 
-           call finalcheck(dist1,crit1,itx,iuse)
-           if(.not. iuse)cycle read_loop
-
-!          interpolate NSST variables to Obs. location and get dtw, dtc, tz_tr
-           if(nst_gsi>0) then
-              tref  = ts(0)
-              dtw   = zero
-              dtc   = zero
-              tz_tr = one
-              if(sfcpct(0)>zero) then
-                 call gsi_nstcoupler_deter(dlat_earth,dlon_earth,t4dv,zob,tref,dtw,dtc,tz_tr)
-              endif
-           endif
-
-
-!          Load selected observation into data array
-              
-           data_all(1 ,itx)= rsat                      ! satellite ID
-           data_all(2 ,itx)= t4dv                      ! time
-           data_all(3 ,itx)= dlon                      ! grid relative longitude
-           data_all(4 ,itx)= dlat                      ! grid relative latitude
-           data_all(5 ,itx)= lza                       ! local zenith angle
-           data_all(6 ,itx)= bfr2bhdr(3)               ! local azimuth angle
-           data_all(7 ,itx)= panglr                    ! look angle
-           data_all(8 ,itx)= ifov                      ! scan position
-           data_all(9 ,itx)= bfr2bhdr(2)               ! solar zenith angle
-           data_all(10,itx)= bfr2bhdr(4)               ! solar azimuth angle
-           data_all(11,itx) = sfcpct(0)                ! sea percentage of
-           data_all(12,itx) = sfcpct(1)                ! land percentage
-           data_all(13,itx) = sfcpct(2)                ! sea ice percentage
-           data_all(14,itx) = sfcpct(3)                ! snow percentage
-           data_all(15,itx)= ts(0)                     ! ocean skin temperature
-           data_all(16,itx)= ts(1)                     ! land skin temperature
-           data_all(17,itx)= ts(2)                     ! ice skin temperature
-           data_all(18,itx)= ts(3)                     ! snow skin temperature
-           data_all(19,itx)= tsavg                     ! average skin temperature
-           data_all(20,itx)= vty                       ! vegetation type
-           data_all(21,itx)= vfr                       ! vegetation fraction
-           data_all(22,itx)= sty                       ! soil type
-           data_all(23,itx)= stp                       ! soil temperature
-           data_all(24,itx)= sm                        ! soil moisture
-           data_all(25,itx)= sn                        ! snow depth
-           data_all(26,itx)= zz                        ! surface height
-           data_all(27,itx)= idomsfc(1) + 0.001_r_kind ! dominate surface type
-           data_all(28,itx)= sfcr                      ! surface roughness
-           data_all(29,itx)= ff10                      ! ten meter wind factor
-           data_all(30,itx) = dlon_earth_deg           ! earth relative longitude (deg)
-           data_all(31,itx) = dlat_earth_deg           ! earth relative latitude (deg)
-
-           if(dval_use) then
-              data_all(32,itx)= val_tovs
-              data_all(33,itx)= itt
-           end if
-
-           if(nst_gsi>0) then
-              data_all(maxinfo+1,itx) = tref            ! foundation temperature
-              data_all(maxinfo+2,itx) = dtw             ! dt_warm at zob
-              data_all(maxinfo+3,itx) = dtc             ! dt_cool at zob
-              data_all(maxinfo+4,itx) = tz_tr           ! d(Tz)/d(Tr)
-           endif
-
-           do i=1,nchanl
-              data_all(i+nreal,itx)=data1b8(i)
-           end do
-           nrec(itx)=irec
-
-!       End of bufr read loops
-        enddo read_loop
-     enddo read_subset
+        end do read_loop
+     end do read_subset
      call closbf(lnbufr)
      close(lnbufr)
-
   end do ears_db_loop
-  deallocate(data1b8,data1b4)
+  !te1=MPI_Wtime()
+  !write(6,'("Walltime for read_bufrtovs: EARS loop " f15.4)') te1-tb1
+  deallocate(data1b8)
+  deallocate(data1b4)
+
+  num_obs = iob-1
+
+  if (num_obs <= 0) then
+     write(6,*) 'READ_BUFRTOVS: No BUFRTOVS Data were read in'
+     return
+  end if
+
+  allocate(binCount(itxmax))
+  binCount(:)=0
+
+! First scan to determine which obs fall into which bins
+  !tb2=MPI_Wtime()
+  ObsLoop: do iob = 1, num_obs
+
+     t4dv       => t4dv_save(iob)
+     dlon_earth => dlon_earth_save(iob)
+     dlat_earth => dlat_earth_save(iob)
+     it_mesh    => it_mesh_save(iob)
+     ifov       => ifov_save(iob)
+
+!    Regional case
+     if(regional)then
+        call tll2xy(dlon_earth*deg2rad,dlat_earth*deg2rad,dlon,dlat,outside)
+        if(diagnostic_reg) then
+           call txy2ll(dlon,dlat,dlon00,dlat00)
+           !ntest=ntest+1
+           cdist=sin(dlat_earth*deg2rad)*sin(dlat00)+cos(dlat_earth*deg2rad)*cos(dlat00)* &
+                (sin(dlon_earth*deg2rad)*sin(dlon00)+cos(dlon_earth*deg2rad)*cos(dlon00))
+           cdist=max(-one,min(cdist,one))
+           disterr=acos(cdist)*rad2deg
+           disterrmax=max(disterrmax,disterr)
+        end if
+!       Check to see if in domain
+        if(outside) cycle ObsLoop
+     endif
+
+!    Map obs to thinning grid
+     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,it_mesh)
+     binCount(itx2) = binCount(itx2)+1
+  end do ObsLoop
+
+  maxPerBin = maxval(binCount)
+  numBinsWithObs = count(mask=binCount>0)
+
+  ! Find thinning bins with at least one observation
+  ! Packing those bins into a dense vector allows us to greatly reduce
+  ! memory useage for binObs
+  allocate(binsWithObs(numBinsWithObs))
+  binsWithObs = pack( (/ (i, i=1,size(binCount)) /), binCount > 0)
+
+  ! Map between physical bin index and Packed index
+  allocate(hash(itxmax))
+  hash=0
+  do bin = 1,numBinsWithObs
+    !write(6,'("read_bufrtovs: Pack " 2I10)') bin,binsWithObs(bin)
+    hash(binsWithObs(bin)) = bin
+  enddo
+
+  write(6,'("read_bufrtovs: max number of obs in any bin " I10)') maxPerBin
+  write(6,'("read_bufrtovs: number of bins with any obs " I10)') numBinsWithObs
+
+  allocate(binObs(maxPerBin,numBinsWithObs))
+  binObs(:,:)=0
+  binCount(:)=0
+
+! Second scan to fill binObs
+  ObsLoop2: do iob=1,num_obs
+
+     t4dv       => t4dv_save(iob)
+     dlon_earth => dlon_earth_save(iob)
+     dlat_earth => dlat_earth_save(iob)
+     it_mesh    => it_mesh_save(iob)
+     ifov       => ifov_save(iob)
+
+!    Regional case
+     if(regional)then
+        call tll2xy(dlon_earth*deg2rad,dlat_earth*deg2rad,dlon,dlat,outside)
+        if(diagnostic_reg) then
+           call txy2ll(dlon,dlat,dlon00,dlat00)
+           !ntest=ntest+1
+           cdist=sin(dlat_earth*deg2rad)*sin(dlat00)+cos(dlat_earth*deg2rad)*cos(dlat00)* &
+                (sin(dlon_earth*deg2rad)*sin(dlon00)+cos(dlon_earth*deg2rad)*cos(dlon00))
+           cdist=max(-one,min(cdist,one))
+           disterr=acos(cdist)*rad2deg
+           disterrmax=max(disterrmax,disterr)
+        end if
+!       Check to see if in domain
+        if(outside) cycle ObsLoop2
+     endif
+!    Map obs to thinning grid
+     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,it_mesh)
+     binCount(itx2) = binCount(itx2)+1
+     binObs(binCount(itx2),hash(itx2)) = iob
+  end do ObsLoop2
+  deallocate(hash)
+  !te2=MPI_Wtime()
+  !write(6,'("Walltime for read_bufrtovs: OBS loop " I10,f15.4)') num_obs, te2-tb2
+
+! Third scan to determine which observation in a given bin is best to use
+  good=0
+  !tb2=MPI_Wtime()
+  !$omp parallel do default(none), schedule(dynamic,8), &
+  !$omp& firstprivate(ich1,ich2,ich3,ich4,ich6,ich8,ich15,ich16,ich17,r01), &
+  !$omp& private(bin,score,bin2,Obindx,iob,rsat,t4dv,dlon_earth,dlat_earth,crit1,it_mesh,ifov,lza, &
+  !$omp&   satazi,solzen,solazi,bt_in,dlat_earth_deg,dlon_earth_deg, &
+  !$omp&   dlon,dlat,outside,dlon00,dlat00,cdist, &
+  !$omp&   disterr,disterrmax,iuse,itt,itx,dist1,pred_water,pred_not_water, &
+  !$omp&   iskip,critical_channels_missing,j,valid,isflg,idomsfc, &
+  !$omp&   sfcpct,sty,vty,vfr,stp,sm,ff10,sfcr,zz,sn,ts,tsavg,pred,ch1,ch2,i, &
+  !$omp&   ch3,cosza,qval,d0,tt,tref,dtw,dtc,tz_tr,panglr,ch1flg,ch8,ch8flg,ch15,df2) &
+  !$omp& shared(numBinsWithObs,binCount,binObs,deg2rad,rad2deg,rlats,rlons,nlat,nlon,ithin,sis, &
+  !$omp&   instr,ichan,expansion,ichan1,ichan2,ichan3,ichan8,ichan15,zob,msu,amsua,hirs,amsub,mhs, &
+  !$omp&   val_tovs,num_obs,rsat_save,t4dv_save,dlon_earth_save,dlat_earth_save, &
+  !$omp&   crit1_save,it_mesh_save,ifov_save,lza_save,satazi_save,solzen_save, &
+  !$omp&   solazi_save,bt_save,panglr_save,regional,diagnostic_reg,l4dvar,l4densvar, &
+  !$omp&   nchanl,predx,isfcalc,rlndsea,adp_anglebc,newpc4pred,radmod,d1,d2,maxinfo, &
+  !$omp&   ang_rad,cbias,air_rad,nst_gsi,data_all,dval_use,nrec,nreal,score_crit,binsWithObs) &
+  !$omp& reduction(+:ntest,good)
+  BinLoop: do bin = 1,numBinsWithObs
+
+     score=9.99e10_r_kind
+     bin2 = binsWithObs(bin)
+
+     ObsLoop3: do Obindx = 1,binCount(bin2)
+
+       iob        = binObs(Obindx,bin)
+       rsat       => rsat_save(iob)
+       t4dv       => t4dv_save(iob)
+       dlon_earth => dlon_earth_save(iob)
+       dlat_earth => dlat_earth_save(iob)
+       crit1      => crit1_save(iob)
+       it_mesh    => it_mesh_save(iob)
+       ifov       => ifov_save(iob)
+       lza        => lza_save(iob)
+       satazi     => satazi_save(iob)
+       solzen     => solzen_save(iob)
+       solazi     => solazi_save(iob)
+       bt_in      => bt_save(1:nchanl,iob)
+       panglr     => panglr_save(iob)
+
+       dlat_earth_deg = dlat_earth
+       dlon_earth_deg = dlon_earth
+       dlat_earth = dlat_earth*deg2rad
+       dlon_earth = dlon_earth*deg2rad
+
+!      Regional case
+       if(regional)then
+          call tll2xy(dlon_earth,dlat_earth,dlon,dlat,outside)
+          if(diagnostic_reg) then
+             call txy2ll(dlon,dlat,dlon00,dlat00)
+             ntest=ntest+1
+             cdist=sin(dlat_earth)*sin(dlat00)+cos(dlat_earth)*cos(dlat00)* &
+                  (sin(dlon_earth)*sin(dlon00)+cos(dlon_earth)*cos(dlon00))
+             cdist=max(-one,min(cdist,one))
+             disterr=acos(cdist)*rad2deg
+             disterrmax=max(disterrmax,disterr)
+          end if
+       endif
+
+!      Map obs to thinning grid
+       call map2tgrid2(dlat_earth,dlon_earth,dist1,crit1,itx,ithin,itt,iuse,sis,score,it_mesh)
+       if(.not. iuse) cycle ObsLoop3
+
+!      Transfer observed brightness temperature to work array.  If any
+!      temperature exceeds limits, reset observation to "bad" value
+       iskip=0
+       critical_channels_missing = .false.
+       do j=1,nchanl
+          if (bt_in(j) < tbmin .or. bt_in(j) > tbmax) then
+             iskip = iskip + 1
+
+!            Flag profiles where key channels are bad
+             if(( msu  .and.  j == ich1) .or.                                 &
+                (amsua .and. (j == ich1 .or. j == ich2 .or. j == ich3 .or.    &
+                              j == ich4 .or. j == ich6 .or. j == ich15 )) .or.&
+                (hirs  .and. (j == ich8 )) .or.                               &
+                (amsub .and.  j == ich1) .or.                                 &
+                (mhs   .and. (j == ich1 .or. j == ich2)) ) critical_channels_missing = .true.
+          endif
+       end do
+       if (iskip >= nchanl) cycle ObsLoop3
+
+       crit1 = crit1 + 10._r_kind*real(iskip,r_kind)
+       !call checkob(dist1,crit1,itx,iuse)
+       !if(.not. iuse)cycle ObsLoop3
+       if(crit1*dist1 > score) cycle ObsLoop3
+
+!      Global case
+       if(.not.regional) then
+          dlat=dlat_earth
+          dlon=dlon_earth
+          call grdcrd1(dlat,rlats,nlat,1)
+          call grdcrd1(dlon,rlons,nlon,1)
+       endif
+
+!      Determine surface properties based on
+!      sst and land/sea/ice mask
+!
+!      isflg    - surface flag
+!                 0 sea
+!                 1 land
+!                 2 sea ice
+!                 3 snow
+!                 4 mixed
+
+!      FOV-based surface code requires fov number.  if out-of-range, then
+!      skip this ob.
+
+       if (isfcalc == 1) then
+          call fov_check(ifov,instr,ichan,valid)
+          if (.not. valid) cycle ObsLoop3
+
+!         When isfcalc is one, calculate surface fields based on size/shape of fov.
+!         Otherwise, use bilinear method.
+
+          call deter_sfc_fov(fov_flag,ifov,instr,ichan,satazi,dlat_earth_deg,&
+               dlon_earth_deg,expansion,t4dv,isflg,idomsfc(1), &
+               sfcpct,vfr,sty,vty,stp,sm,ff10,sfcr,zz,sn,ts,tsavg)
+       else
+          call deter_sfc(dlat,dlon,dlat_earth,dlon_earth,t4dv,isflg, &
+               idomsfc(1),sfcpct,ts,tsavg,vty,vfr,sty,stp,sm,sn,zz,ff10,sfcr)
+       endif
+
+       crit1 = crit1 + rlndsea(isflg)
+       !call checkob(dist1,crit1,itx,iuse)
+       !if(.not. iuse)cycle ObsLoop3
+       if(crit1*dist1 > score) cycle ObsLoop3
+
+       if (critical_channels_missing) then
+          pred=1.0e8_r_kind
+       else
+
+!         Set data quality predictor
+          if (msu) then
+            if (newpc4pred) then
+              ch1 = bt_in(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1)- &
+              predx(1,ichan1)*air_rad(ichan1)
+            else
+              ch1 = bt_in(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1)- &
+              r01*predx(1,ichan1)*air_rad(ichan1)
+            end if
+            ch1flg = tsavg-ch1
+            if(isflg == 0)then
+              pred = 100._r_kind-min(ch1flg,100.0_r_kind)
+            else
+              pred = abs(ch1flg)
+            end if
+          else if (hirs) then
+            if (newpc4pred) then
+              ch8 = bt_in(ich8) -ang_rad(ichan8)*cbias(ifov,ichan8)- &
+              predx(1,ichan8)*air_rad(ichan8)
+            else
+              ch8 = bt_in(ich8) -ang_rad(ichan8)*cbias(ifov,ichan8)- &
+              r01*predx(1,ichan8)*air_rad(ichan8)
+            end if
+             ch8flg = tsavg-ch8
+             pred   = 10.0_r_kind*max(zero,ch8flg)
+          else if (amsua) then
+!           Remove angle dependent pattern (not mean)
+            if (adp_anglebc .and. newpc4pred) then
+              ch1 = bt_in(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1)
+              ch2 = bt_in(ich2)-ang_rad(ichan2)*cbias(ifov,ichan2)
+              ch15= bt_in(ich15)-ang_rad(ichan15)*cbias(ifov,ichan15)
+            else
+              ch1 = bt_in(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1)+ &
+                    air_rad(ichan1)*cbias(15,ichan1)
+              ch2 = bt_in(ich2)-ang_rad(ichan2)*cbias(ifov,ichan2)+ &
+                    air_rad(ichan2)*cbias(15,ichan2)
+              ch15= bt_in(ich15)-ang_rad(ichan15)*cbias(ifov,ichan15)
+            end if
+            if (isflg == 0 .and. ch1<285.0_r_kind .and. ch2<285.0_r_kind) then
+              cosza = cos(lza)
+              d0    = 8.24_r_kind - 2.622_r_kind*cosza + 1.846_r_kind*cosza*cosza
+              qval=cosza*(d0+d1*log(285.0_r_kind-ch1)+d2*log(285.0_r_kind-ch2))
+              if (radmod%lcloud_fwd) then
+                ! no preference in selecting clouds/precipitation
+                ! qval=zero
+                ! favor non-precipitating clouds
+                qval=-113.2_r_kind+(2.41_r_kind-0.0049_r_kind*ch1)*ch1 +  &
+                      0.454_r_kind*ch2-ch15
+                if (qval>=9.0_r_kind) then
+                  qval=1000.0_r_kind*qval
+                else
+                  qval=zero
+                end if
+                if (radmod%lprecip) qval=zero
+                ! favor thinner clouds
+                ! cosza = cos(lza)
+                ! d0= 8.24_r_kind - 2.622_r_kind*cosza + 1.846_r_kind*cosza*cosza
+                ! qval=cosza*(d0+d1*log(285.0_r_kind-ch1)+d2*log(285.0_r_kind-ch2))
+                ! if (qval>0.2_r_kind) then
+                !    qval=1000.0_r_kind*qval
+                ! else
+                !    qval=zero
+                ! end if
+              end if
+              pred  = max(zero,qval)*100.0_r_kind
+            else
+              if (adp_anglebc .and. newpc4pred) then
+                ch3 = bt_in(ich3)-ang_rad(ichan3)*cbias(ifov,ichan3)
+                ch15 = bt_in(ich15)-ang_rad(ichan15)*cbias(ifov,ichan15)
+              else
+                ch3  = bt_in(ich3)-ang_rad(ichan3)*cbias(ifov,ichan3)+ &
+                       air_rad(ichan3)*cbias(15,ichan3)
+                ch15 = bt_in(ich15)-ang_rad(ichan15)*cbias(ifov,ichan15)+ &
+                       air_rad(ichan15)*cbias(15,ichan15)
+              end if
+              pred = abs(ch1-ch15)
+              if(ch1-ch15 >= three) then
+                df2  = 5.10_r_kind +0.78_r_kind*ch1-0.96_r_kind*ch3
+                tt   = 168._r_kind-0.49_r_kind*ch15
+                if(ch1 > 261._r_kind .or. ch1 >= tt .or. &
+                         (ch15 <= 273._r_kind .and. df2 >= 0.6_r_kind))then
+                  pred = 100._r_kind
+                end if
+              end if
+            endif
+!           sval=-113.2_r_kind+(2.41_r_kind-0.0049_r_kind*ch1)*ch1 +  &
+!           0.454_r_kind*ch2-ch15
+          else if (amsub .or. mhs) then
+            if (newpc4pred) then
+              ch1 = bt_in(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1)- &
+                   predx(1,ichan1)*air_rad(ichan1)
+              ch2 = bt_in(ich2)-ang_rad(ichan2)*cbias(ifov,ichan2)- &
+                   predx(1,ichan2)*air_rad(ichan2)
+            else
+              ch1 = bt_in(ich1)-ang_rad(ichan1)*cbias(ifov,ichan1)- &
+                   r01*predx(1,ichan1)*air_rad(ichan1)
+              ch2 = bt_in(ich2)-ang_rad(ichan2)*cbias(ifov,ichan2)- &
+                   r01*predx(1,ichan2)*air_rad(ichan2)
+            end if
+            pred_water = zero
+            if(sfcpct(0) > zero)then
+              cosza = cos(lza)
+              if(ch2 < h300)then 
+                pred_water = (0.13_r_kind*(ch1+33.58_r_kind*log(h300-ch2)- &
+                  341.17_r_kind))*five
+              else
+                pred_water = 100._r_kind
+              end if
+            end if
+            pred_not_water = 42.72_r_kind + 0.85_r_kind*ch1-ch2
+            pred = (sfcpct(0)*pred_water) + ((one-sfcpct(0))*pred_not_water)
+            pred = max(zero,pred)
+          endif
+       end if
+
+!      Compute "score" for observation.  All scores>=0.0.  Lowest score is "best"
+       crit1 = crit1+pred 
+       !call finalcheck(dist1,crit1,itx,iuse)
+       !if(.not. iuse)cycle ObsLoop3
+       if(crit1*dist1 < score)then
+          score = crit1*dist1
+       else
+          cycle ObsLoop3
+       end if
+
+!      interpolate NSST variables to Obs. location and get dtw, dtc, tz_tr
+       if(nst_gsi>0) then
+          tref  = ts(0)
+          dtw   = zero
+          dtc   = zero
+          tz_tr = one
+          if(sfcpct(0)>zero) then
+             call gsi_nstcoupler_deter(dlat_earth,dlon_earth,t4dv,zob,tref,dtw,dtc,tz_tr)
+          endif
+       endif
+
+  !    Load selected observation into data array
+       data_all(1 ,bin2)= rsat                      ! satellite ID
+       data_all(2 ,bin2)= t4dv                      ! time
+       data_all(3 ,bin2)= dlon                      ! grid relative longitude
+       data_all(4 ,bin2)= dlat                      ! grid relative latitude
+       data_all(5 ,bin2)= lza                       ! local zenith angle
+       data_all(6 ,bin2)= satazi                    ! local azimuth angle
+       data_all(7 ,bin2)= panglr                    ! look angle
+       data_all(8 ,bin2)= ifov                      ! scan position
+       data_all(9 ,bin2)= solzen                    ! solar zenith angle
+       data_all(10,bin2)= solazi                    ! solar azimuth angle
+       data_all(11,bin2) = sfcpct(0)                ! sea percentage of
+       data_all(12,bin2) = sfcpct(1)                ! land percentage
+       data_all(13,bin2) = sfcpct(2)                ! sea ice percentage
+       data_all(14,bin2) = sfcpct(3)                ! snow percentage
+       data_all(15,bin2)= ts(0)                     ! ocean skin temperature
+       data_all(16,bin2)= ts(1)                     ! land skin temperature
+       data_all(17,bin2)= ts(2)                     ! ice skin temperature
+       data_all(18,bin2)= ts(3)                     ! snow skin temperature
+       data_all(19,bin2)= tsavg                     ! average skin temperature
+       data_all(20,bin2)= vty                       ! vegetation type
+       data_all(21,bin2)= vfr                       ! vegetation fraction
+       data_all(22,bin2)= sty                       ! soil type
+       data_all(23,bin2)= stp                       ! soil temperature
+       data_all(24,bin2)= sm                        ! soil moisture
+       data_all(25,bin2)= sn                        ! snow depth
+       data_all(26,bin2)= zz                        ! surface height
+       data_all(27,bin2)= idomsfc(1) + 0.001_r_kind ! dominate surface type
+       data_all(28,bin2)= sfcr                      ! surface roughness
+       data_all(29,bin2)= ff10                      ! ten meter wind factor
+       data_all(30,bin2) = dlon_earth_deg           ! earth relative longitude (deg)
+       data_all(31,bin2) = dlat_earth_deg           ! earth relative latitude (deg)
+
+       if(dval_use) then
+          data_all(32,bin2)= val_tovs
+          data_all(33,bin2)= itt
+       end if
+
+       if(nst_gsi>0) then
+          data_all(maxinfo+1,bin2) = tref            ! foundation temperature
+          data_all(maxinfo+2,bin2) = dtw             ! dt_warm at zob
+          data_all(maxinfo+3,bin2) = dtc             ! dt_cool at zob
+          data_all(maxinfo+4,bin2) = tz_tr           ! d(Tz)/d(Tr)
+       endif
+
+       do i=1,nchanl
+          data_all(i+nreal,bin2)=bt_in(i)
+       end do
+       nrec(bin2)=iob
+       good=good+1
+     enddo ObsLoop3
+     score_crit(bin2) = score
+  end do BinLoop
+  !te2=MPI_Wtime()
+
+  write(6,'("read_bufrtovs: Number of obs considered and accepted " 2I10)') num_obs, good
+  !write(6,'("Walltime for read_bufrtovs: bin loop " f15.4)') te2-tb2
+  !write(6,'("read_bufrtovs: data_all checksum " f25.14)') sum(data_all(1:31,:))
+  deallocate(binCount)
+  deallocate(binObs)
+  deallocate(binsWithObs)
+
+
+! DEAllocate I/O arrays
+  DEALLOCATE(rsat_save)
+  DEALLOCATE(t4dv_save)
+  DEALLOCATE(dlon_earth_save)
+  DEALLOCATE(dlat_earth_save)
+  DEALLOCATE(crit1_save)
+  DEALLOCATE(it_mesh_save)
+  DEALLOCATE(lza_save)
+  DEALLOCATE(satazi_save)
+  DEALLOCATE(solzen_save)
+  DEALLOCATE(solazi_save)
+  DEALLOCATE(bt_save)
+  DEALLOCATE(panglr_save)
 
   call combine_radobs(mype_sub,mype_root,npe_sub,mpi_comm_sub,&
      nele,itxmax,nread,ndata,data_all,score_crit,nrec)
@@ -1090,12 +1314,15 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
 
 ! Deallocate satthin arrays
   call destroygrids
- 
+
 ! Deallocate FOV surface code arrays and nullify pointers.
   if (isfcalc == 1) call fov_cleanup
 
   if(diagnostic_reg.and.ntest>0) write(6,*)'READ_BUFRTOVS:  ',&
      'mype,ntest,disterrmax=',mype,ntest,disterrmax
+
+  !time_end=MPI_Wtime()
+  !write(6,'("Walltime for read_bufrtovs " f15.4)') time_end-time_beg
 
 ! End of routine
   return

--- a/src/gsi/read_bufrtovs.f90
+++ b/src/gsi/read_bufrtovs.f90
@@ -153,7 +153,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   use mpimod, only: npe
   use radiance_mod, only: rad_obs_type
   use gsi_io, only: verbose
-  !use mpi, only : MPI_Wtime
   implicit none
 
   external:: stop2,openbf,ireadmg,ireadsb,ufbint,w3fs21,ufbrep,closbf,grdcrd1,combine_radobs,count_obs
@@ -263,11 +262,9 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   integer(i_kind) :: spc_coeff_versions
   character(len=80) :: spc_filename
   type(ACCoeff_type),dimension(3) :: accoeff_sets
-  real(kind=8) :: time_beg,time_end,tb1,tb2,te1,te2
   integer(kind=4) :: good,bin,bin2,Obindx,maxPerBin,numBinsWithObs
   integer,allocatable,dimension(:)   :: binCount,binsWithObs,hash
   integer,allocatable,dimension(:,:) :: binObs
-  !time_beg=MPI_Wtime()
 
 !**************************************************************************
 ! Initialize variables
@@ -527,7 +524,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   ALLOCATE(bt_save(nchanl,maxobs))
   ALLOCATE(panglr_save(maxobs))
 
-  !data_all(:,:) = zero ! Only needed when calculating the checksum down below
   nrec = 999999
   next=0
   irec=0
@@ -535,7 +531,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   iob=1
 ! Big loop over standard data feed and possible ears/db data
 ! llll=1 is normal feed, llll=2 EARS/RARS data, llll=3 DB/UW data)
-  !tb1=MPI_Wtime()
   ears_db_loop: do llll= 1, 3
 
      if(llll == 1)then
@@ -835,8 +830,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
      call closbf(lnbufr)
      close(lnbufr)
   end do ears_db_loop
-  !te1=MPI_Wtime()
-  !write(6,'("Walltime for read_bufrtovs: EARS loop " f15.4)') te1-tb1
   deallocate(data1b8)
   deallocate(data1b4)
 
@@ -851,7 +844,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   binCount(:)=0
 
 ! First scan to determine which obs fall into which bins
-  !tb2=MPI_Wtime()
   ObsLoop: do iob = 1, num_obs
 
      t4dv       => t4dv_save(iob)
@@ -865,7 +857,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
         call tll2xy(dlon_earth*deg2rad,dlat_earth*deg2rad,dlon,dlat,outside)
         if(diagnostic_reg) then
            call txy2ll(dlon,dlat,dlon00,dlat00)
-           !ntest=ntest+1
            cdist=sin(dlat_earth*deg2rad)*sin(dlat00)+cos(dlat_earth*deg2rad)*cos(dlat00)* &
                 (sin(dlon_earth*deg2rad)*sin(dlon00)+cos(dlon_earth*deg2rad)*cos(dlon00))
            cdist=max(-one,min(cdist,one))
@@ -894,7 +885,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   allocate(hash(itxmax))
   hash=0
   do bin = 1,numBinsWithObs
-    !write(6,'("read_bufrtovs: Pack " 2I10)') bin,binsWithObs(bin)
     hash(binsWithObs(bin)) = bin
   enddo
 
@@ -919,7 +909,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
         call tll2xy(dlon_earth*deg2rad,dlat_earth*deg2rad,dlon,dlat,outside)
         if(diagnostic_reg) then
            call txy2ll(dlon,dlat,dlon00,dlat00)
-           !ntest=ntest+1
            cdist=sin(dlat_earth*deg2rad)*sin(dlat00)+cos(dlat_earth*deg2rad)*cos(dlat00)* &
                 (sin(dlon_earth*deg2rad)*sin(dlon00)+cos(dlon_earth*deg2rad)*cos(dlon00))
            cdist=max(-one,min(cdist,one))
@@ -935,12 +924,9 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
      binObs(binCount(itx2),hash(itx2)) = iob
   end do ObsLoop2
   deallocate(hash)
-  !te2=MPI_Wtime()
-  !write(6,'("Walltime for read_bufrtovs: OBS loop " I10,f15.4)') num_obs, te2-tb2
 
 ! Third scan to determine which observation in a given bin is best to use
   good=0
-  !tb2=MPI_Wtime()
   !$omp parallel do default(none), schedule(dynamic,8), &
   !$omp& firstprivate(ich1,ich2,ich3,ich4,ich6,ich8,ich15,ich16,ich17,r01), &
   !$omp& private(bin,score,bin2,Obindx,iob,rsat,t4dv,dlon_earth,dlat_earth,crit1,it_mesh,ifov,lza, &
@@ -1261,11 +1247,8 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
      enddo ObsLoop3
      score_crit(bin2) = score
   end do BinLoop
-  !te2=MPI_Wtime()
 
   write(6,'("read_bufrtovs: Number of obs considered and accepted " 2I10)') num_obs, good
-  !write(6,'("Walltime for read_bufrtovs: bin loop " f15.4)') te2-tb2
-  !write(6,'("read_bufrtovs: data_all checksum " f25.14)') sum(data_all(1:31,:))
   deallocate(binCount)
   deallocate(binObs)
   deallocate(binsWithObs)
@@ -1320,9 +1303,6 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
 
   if(diagnostic_reg.and.ntest>0) write(6,*)'READ_BUFRTOVS:  ',&
      'mype,ntest,disterrmax=',mype,ntest,disterrmax
-
-  !time_end=MPI_Wtime()
-  !write(6,'("Walltime for read_bufrtovs " f15.4)') time_end-time_beg
 
 ! End of routine
   return

--- a/src/gsi/read_cris.f90
+++ b/src/gsi/read_cris.f90
@@ -455,6 +455,7 @@ subroutine read_cris(mype,val_cris,ithin,isfcalc,rmesh,jsatid,gstime,&
 ! Big loop to read data file
   next=0
   irec=0
+  data_all(:,:)=zero
   nrec = 999999
 ! Big loop over standard data feed and possible rars/db data
 ! llll=1 is normal feed, llll=2 RARS data, llll=3 DB/UW data)

--- a/src/gsi/read_iasi.f90
+++ b/src/gsi/read_iasi.f90
@@ -441,6 +441,7 @@ subroutine read_iasi(mype,val_iasi,ithin,isfcalc,rmesh,jsatid,gstime,&
 ! Big loop to read data file
   next=0
   irec=0
+  data_all(:,:)=zero
   nrec=999999
 ! Big loop over standard data feed and possible rars/db data
 ! llll=1 is normal feed, llll=2 RARS/EARS data, llll=3 DB/UW data)

--- a/src/gsi/satthin.F90
+++ b/src/gsi/satthin.F90
@@ -145,7 +145,7 @@ module satthin
   public :: makegrids
   public :: getsfc
   public :: get_hsst
-  public :: map2tgrid
+  public :: map2tgrid,map2tgrid2,binit
   public :: destroygrids
   public :: destroy_sfc
   public :: indexx
@@ -478,6 +478,7 @@ contains
        icount(j) = .true.
        score_crit(j) = 9.99e10_r_kind
     end do
+    write(6,'("makegrids: use_all and itxmax set to " L,I8)') use_all,itxmax
 
     return
   end subroutine makegrids
@@ -1085,6 +1086,179 @@ contains
 
     return
   end subroutine map2tgrid
+
+  subroutine map2tgrid2(dlat_earth,dlon_earth,dist1,crit1,itx,ithin,itt,iuse,sis, &
+                        score,it_mesh)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    map2tgrid
+!     prgmmr:    derber      org: np2                 date: 2006-05-03
+!
+! abstract:  This routine maps observations to the thinning grid.
+!
+! program history log:
+!   2006-05-03  derber (created from map2grids)
+!   2006-09-13  treadon - set itx=1 for the case use_all=.true.
+!   2013-01-26  parrish - change from grdcrd to grdcrd1 (to allow successful debug compile on WCOSS)
+!
+!   input argument list:
+!     dlat_earth - earth relative observation latitude (radians)
+!     dlon_earth - earth relative observation longitude (radians)
+!     crit1      - quality indicator for observation (smaller = better)
+!     ithin      - number of obs to retain per thinning grid box
+!     sis        - sensor/instrument/satellite
+!     it_mesh    - time meth id
+!
+!   output argument list:
+!     itx   - combined (i,j) index of observation on thinning grid
+!     itt   - superobs thinning counter
+!     iuse  - .true. if observation should be used
+!
+!
+! attributes:
+!   language: f90
+!   machine:  ibm rs/6000 sp
+!
+!$$$
+    use constants, only: one, half
+    !use omp_lib
+    implicit none
+
+    logical        ,intent(  out) :: iuse
+    integer(i_kind),intent(in   ) :: ithin
+    integer(i_kind),intent(  out) :: itt,itx
+    real(r_kind)   ,intent(in   ) :: dlat_earth,dlon_earth,score
+    real(r_kind)   ,intent(inout) :: crit1
+    real(r_kind)   ,intent(  out) :: dist1
+    character(20)  ,intent(in   ) :: sis
+    integer(i_kind),intent(in   ), optional :: it_mesh
+
+    integer(i_kind) ix,iy
+    real(r_kind) dlat1,dlon1,dx,dy,dxx,dyy
+
+
+!   If using all data (no thinning), simply return to calling routine
+    if(use_all .or. ithin <= 0)then
+       iuse=.true.
+       itt=1
+       dist1=one
+       if(itx_all < itxmax) then
+          itx_all=itx_all+1
+       else
+          iuse = .false.
+          write(6,*)'MAP2TGRID2:  ndata > maxobs when reading data for ',sis,itxmax
+       end if
+       itx=itx_all
+       return
+    end if
+
+!   Compute (i,j) indices of coarse mesh grid (grid number 1) which
+!   contains the current observation.
+    dlat1=dlat_earth
+    dlon1=dlon_earth
+
+    call grdcrd1(dlat1,glat,mlat,1)
+    iy=int(dlat1)
+    dy=dlat1-iy
+    iy=max(1,min(iy,mlat))
+
+    call grdcrd1(dlon1,glon(1,iy),mlon(iy),1)
+    ix=int(dlon1)
+    dx=dlon1-ix
+    ix=max(1,min(ix,mlon(iy)))
+
+    dxx=half-min(dx,one-dx)
+    dyy=half-min(dy,one-dy)
+    dist1=dxx*dxx+dyy*dyy+half
+    itx=hll(ix,iy)
+!   time mesh
+    if( present(it_mesh)  ) then
+       itx=itx+it_mesh*itxmax0
+    endif
+    itt=istart_val(ithin)+itx
+    if(ithin == 0) itt=0
+
+!   Increment obs counter on coarse mesh grid.  Also accumulate observation
+!   score and distance functions
+
+!   ratio=1.e9
+!   if ( dx > zero ) ratio=dy/dx
+!   dista=sin(two*atan(ratio))
+!   distb=sin(pi*dx)                !dista+distb is max at grid box center
+!   dist1=one - quarter*(dista + distb)  !dist1 is min at grid box center and
+                                    !ranges from 1 (at corners)to
+                                    !.5 (at center of box)
+    iuse=.true.
+    if(dist1*crit1 > score) iuse=.false.
+
+    return
+  end subroutine map2tgrid2
+
+  subroutine binit(dlat_earth,dlon_earth,itx,it_mesh)
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    binit
+!     prgmmr:    derber      org: np2                 date: 2006-05-03
+!
+! abstract:  This routine maps observations to the thinning grid.
+!
+! program history log:
+!   2006-05-03  derber (created from map2grids)
+!
+!   input argument list:
+!     dlat_earth - earth relative observation latitude (radians)
+!     dlon_earth - earth relative observation longitude (radians)
+!     it_mesh    - time meth id
+!
+!   output argument list:
+!     itx   - combined (i,j) index of observation on thinning grid
+!$$$
+    implicit none
+
+    integer(i_kind),intent(  out) :: itx
+    real(r_kind)   ,intent(in   ) :: dlat_earth,dlon_earth
+    integer(i_kind),intent(in   ), optional :: it_mesh
+
+    integer(i_kind) ix,iy
+    real(r_kind) dlat1,dlon1
+
+
+!   If using all data (no thinning), simply return to calling routine
+!    if(use_all .or. ithin <= 0)then
+!       !iuse=.true.
+!       !itt=1
+!       !dist1=one
+!       if(itx_all < itxmax) then
+!          itx_all=itx_all+1
+!       else
+!          !iuse = .false.
+!          !write(6,*)'MAP2TGRID2:  ndata > maxobs when reading data for ',sis,itxmax
+!       end if
+!       itx=itx_all
+!       return
+!    end if
+
+!   Compute (i,j) indices of coarse mesh grid (grid number 1) which
+!   contains the current observation.
+    dlat1=dlat_earth
+    dlon1=dlon_earth
+
+    call grdcrd1(dlat1,glat,mlat,1)
+    iy=int(dlat1)
+    iy=max(1,min(iy,mlat))
+
+    call grdcrd1(dlon1,glon(1,iy),mlon(iy),1)
+    ix=int(dlon1)
+    ix=max(1,min(ix,mlon(iy)))
+
+    itx=hll(ix,iy)
+!   time mesh
+    if( present(it_mesh)  ) then
+       itx=itx+it_mesh*itxmax0
+    endif
+
+    return
+  end subroutine binit
 
   subroutine checkob(dist1,crit1,itx,iuse)
 !$$$  subprogram documentation block

--- a/src/gsi/satthin.F90
+++ b/src/gsi/satthin.F90
@@ -478,7 +478,6 @@ contains
        icount(j) = .true.
        score_crit(j) = 9.99e10_r_kind
     end do
-    write(6,'("makegrids: use_all and itxmax set to " L,I8)') use_all,itxmax
 
     return
   end subroutine makegrids

--- a/src/gsi/setupbend.f90
+++ b/src/gsi/setupbend.f90
@@ -184,6 +184,7 @@ subroutine setupbend(obsLL,odiagLL, &
   use gsi_bundlemod, only : gsi_bundlegetpointer
   use gsi_metguess_mod, only : gsi_metguess_get,gsi_metguess_bundle
   use sparsearr, only: sparr2, new, size, writearray
+  use mpi, only : MPI_Wtime
   implicit none
 
 ! Declare passed variables
@@ -273,6 +274,9 @@ subroutine setupbend(obsLL,odiagLL, &
 
   type(obsLList),pointer,dimension(:):: gpshead
   logical:: commdat
+  real(kind=8) :: time_beg,time_end,tb1,tb2,tb3,te1,te2,te3,walltime
+  time_beg=MPI_Wtime()
+
   gpshead => obsLL(:)
 
   save_jacobian = conv_diagsave .and. jiter==jiterstart .and. lobsdiag_forenkf
@@ -442,9 +446,33 @@ subroutine setupbend(obsLL,odiagLL, &
   k4=n_c-n_a
 
 ! A loop over all obs.
+  tb1=MPI_Wtime()
   call dtime_setup()
-  loopoverobs1: &
-  do i=1,nobs ! loop over obs 
+
+  !$omp parallel do default(none), schedule(dynamic,8), &
+  !$omp& firstprivate(itime,iuse,jiter,ilate,ilat,ilon,iroc,igeoid,ihgt,ikxx, &
+  !$omp&   nsig,n_a,n_b,k4,ier,isatid,iptid,igps,iprof,gpstop,commgpstop, &
+  !$omp&   deg2rad,mype,ilone,ilsw,ilswflag,nsig_up,grids_dim,rsig_up,ds, &
+  !$omp&   eccentricity,tiny_r_kind), &
+  !$omp& private(i,dtime,obs_check,in_curbin,in_anybin,sin2,dlat,dlon, &
+  !$omp&   rocprof,unprof,ikx,prsltmp,tges,qges,hges,zsges,termg,termr, &
+  !$omp&   termrg,qc_layer_SR,count_SR,top_layer_SR,bot_layer_SR,k,zges, &
+  !$omp&   qmean,tmean,fact,pw,pressure,nrefges1,nrefges2,nrefges3, &
+  !$omp&   irefges,ref_rad,qges_o,alt,grad_mod, &
+  !$omp&   hob,satellite_id,transmitter_id, &
+  !$omp&   kprof,dpressure,ihob,k1,k2,delz,trefges,qrefges, &
+  !$omp&   commdat,d_ref_rad,q_w,ref_rad_s,hob_s,w4,dw4,ddnj,kk,ref_rad_out, &
+  !$omp&   dbend,j,ddbend,cgrossuse,cermaxuse,cerminuse,obserror, &
+  !$omp&   obserrlm,residual,ratio,cutoff,cutoff1,cutoff2,cutoff3,cutoff4, &
+  !$omp&   cutoff12,cutoff23,cutoff34), &
+  !$omp& shared(nobs,data,muse,tpdpres,ges_lnprsi,hrdifsig,nfldsig, &
+  !$omp&   prsltmp_o,nrefges,grav,gp2gm,rges,tges_o,eps,luse,ictype, &
+  !$omp&   n_q,n_p,n_t,fv,nsigstart,ges_tv,ges_q,geop_hgti,ges_z, &
+  !$omp&   error,error_adjst,rsig,ratio_errors,qcfail_one,cdiagbuf, &
+  !$omp&   rdiagbuf,qcfail,xj,dbend_loc,qcfail_three,cgross,time_offset,nsig_ext, &
+  !$omp&   cermax,cermin,qcfail_seven,qcfail_five,qcfail_six,qcfail_two,grid_s), &
+  !$omp& reduction(+:nobs_out,awork), reduction(max:toss_gps_sub,hob_s_top)
+  loopoverobs1: do i=1,nobs ! loop over obs
      dtime=data(itime,i)
      obs_check=.false. 
 
@@ -463,16 +491,11 @@ subroutine setupbend(obsLL,odiagLL, &
 
 !    Interpolate log(pres),temperature,specific humidity, 
 !    corrected geopotential heights and topography to obs location
-     call tintrp2a1(ges_lnprsi,prsltmp,dlat,dlon,dtime,hrdifsig,&
-          nsig+1,mype,nfldsig)
-     call tintrp2a1(ges_tv,tges,dlat,dlon,dtime,hrdifsig,&
-          nsig,mype,nfldsig)
-     call tintrp2a1(ges_q,qges,dlat,dlon,dtime,hrdifsig,&
-          nsig,mype,nfldsig)
-     call tintrp2a1(geop_hgti,hges,dlat,dlon,dtime,hrdifsig,&
-          nsig+1,mype,nfldsig)
-     call tintrp2a11(ges_z,zsges,dlat,dlon,dtime,hrdifsig,&
-          mype,nfldsig)
+     call tintrp2a1(ges_lnprsi,prsltmp,dlat,dlon,dtime,hrdifsig,nsig+1,mype,nfldsig)
+     call tintrp2a1(    ges_tv,   tges,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+     call tintrp2a1(     ges_q,   qges,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+     call tintrp2a1( geop_hgti,   hges,dlat,dlon,dtime,hrdifsig,nsig+1,mype,nfldsig)
+     call tintrp2a11(    ges_z,  zsges,dlat,dlon,dtime,hrdifsig,mype,nfldsig)
 
      prsltmp_o(1:nsig,i)=prsltmp(1:nsig) ! needed in minimization
 
@@ -498,7 +521,7 @@ subroutine setupbend(obsLL,odiagLL, &
      top_layer_SR=0
      bot_layer_SR=0
 
-!$omp parallel do  schedule(dynamic,1) private(k,qmean,tmean,fact,pw,pressure,nrefges1,nrefges2,nrefges3)
+     !!dir$ ivdep
      do k=1,nsig 
         zges(k) = (termr*hges(k)) / (termrg-hges(k))  ! eq (23) at interface (topo corrected)
         gp2gm(k,i)= termr/(termrg-hges(k))+((termr*hges(k))/(termrg-hges(k))**2)
@@ -585,9 +608,11 @@ subroutine setupbend(obsLL,odiagLL, &
 
 !    Save some diagnostic information
 !    occultation identification
-     satellite_id         = data(isatid,i) ! receiver occ id
-     transmitter_id       = data(iptid,i)  ! transmitter occ id
-     write(cdiagbuf(i),'(2(i4.4))') satellite_id,transmitter_id
+     !satellite_id         = data(isatid,i) ! receiver occ id
+     !transmitter_id       = data(iptid,i)  ! transmitter occ id
+     !!$omp critical
+     !write(cdiagbuf(i),'(2(i4.4))') satellite_id,transmitter_id
+     !!$omp end critical
 
      rdiagbuf(:,i)         = zero
 
@@ -854,6 +879,10 @@ subroutine setupbend(obsLL,odiagLL, &
      end if ! obs inside the vertical grid
 
   end do loopoverobs1 ! end of loop over observations
+  !$omp end parallel do
+  te1=MPI_Wtime()
+  write(6,'("Walltime for setupbend: First obs loop " f15.4)') te1-tb1
+  write(6,'("setupbend: Number of obs considered and accepted " 2I10)') nobs, count(mask=muse/=.false.)
 
   if (nobs_out>=1) then
      write(6,*)'WARNING GPSRO:',nobs_out,'obs outside integration grid. Increase nsig_ext to',&
@@ -889,6 +918,7 @@ subroutine setupbend(obsLL,odiagLL, &
   endif ! (last_pass)
 
 ! Loop to load arrays used in statistics output
+  tb1=MPI_Wtime()
   call dtime_setup()
   do i=1,nobs
      dtime=data(itime,i)
@@ -999,6 +1029,9 @@ subroutine setupbend(obsLL,odiagLL, &
         gps_alltail(ibin)%head%type     = data(ikxx,i)
         gps_alltail(ibin)%head%luse     = luse(i) ! logical
         gps_alltail(ibin)%head%muse     = muse(i) ! logical
+        satellite_id         = data(isatid,i) ! receiver occ id
+        transmitter_id       = data(iptid,i)  ! transmitter occ id
+        write(cdiagbuf(i),'(2(i4.4))') satellite_id,transmitter_id
         gps_alltail(ibin)%head%cdiag    = cdiagbuf(i)
 
 !       Fill obs diagnostics structure
@@ -1228,6 +1261,8 @@ subroutine setupbend(obsLL,odiagLL, &
         gps_alltail(ibin)%head%muse     = muse(i) ! logical
      endif ! (last_pass)
   end do ! i=1,nobs
+  te1=MPI_Wtime()
+  write(6,'("Walltime for setupbend: Second obs loop " f15.4)') te1-tb1
   deallocate(ddnj,grid_s,ref_rad_s)
   ! Release memory of local guess arrays
   call final_vars_
@@ -1239,6 +1274,9 @@ subroutine setupbend(obsLL,odiagLL, &
 
   call gpsrhs_unaliases(is)
   if(last_pass) call gpsrhs_dealloc(is)
+
+  time_end=MPI_Wtime()
+  write(6,'("Walltime for setupbend: Total " f15.4)') time_end-time_beg
 
   return
   contains

--- a/src/gsi/setupbend.f90
+++ b/src/gsi/setupbend.f90
@@ -184,7 +184,6 @@ subroutine setupbend(obsLL,odiagLL, &
   use gsi_bundlemod, only : gsi_bundlegetpointer
   use gsi_metguess_mod, only : gsi_metguess_get,gsi_metguess_bundle
   use sparsearr, only: sparr2, new, size, writearray
-  use mpi, only : MPI_Wtime
   implicit none
 
 ! Declare passed variables
@@ -274,8 +273,6 @@ subroutine setupbend(obsLL,odiagLL, &
 
   type(obsLList),pointer,dimension(:):: gpshead
   logical:: commdat
-  real(kind=8) :: time_beg,time_end,tb1,tb2,tb3,te1,te2,te3,walltime
-  time_beg=MPI_Wtime()
 
   gpshead => obsLL(:)
 
@@ -446,7 +443,6 @@ subroutine setupbend(obsLL,odiagLL, &
   k4=n_c-n_a
 
 ! A loop over all obs.
-  tb1=MPI_Wtime()
   call dtime_setup()
 
   !$omp parallel do default(none), schedule(dynamic,1), &
@@ -880,8 +876,6 @@ subroutine setupbend(obsLL,odiagLL, &
 
   end do loopoverobs1 ! end of loop over observations
   !$omp end parallel do
-  te1=MPI_Wtime()
-  write(6,'("Walltime for setupbend: First obs loop " f15.4)') te1-tb1
   write(6,'("setupbend: Number of obs considered and accepted " 2I10)') nobs, count(mask=muse/=.false.)
 
   if (nobs_out>=1) then
@@ -918,7 +912,6 @@ subroutine setupbend(obsLL,odiagLL, &
   endif ! (last_pass)
 
 ! Loop to load arrays used in statistics output
-  tb1=MPI_Wtime()
   call dtime_setup()
   do i=1,nobs
      dtime=data(itime,i)
@@ -1261,8 +1254,6 @@ subroutine setupbend(obsLL,odiagLL, &
         gps_alltail(ibin)%head%muse     = muse(i) ! logical
      endif ! (last_pass)
   end do ! i=1,nobs
-  te1=MPI_Wtime()
-  write(6,'("Walltime for setupbend: Second obs loop " f15.4)') te1-tb1
   deallocate(ddnj,grid_s,ref_rad_s)
   ! Release memory of local guess arrays
   call final_vars_
@@ -1274,9 +1265,6 @@ subroutine setupbend(obsLL,odiagLL, &
 
   call gpsrhs_unaliases(is)
   if(last_pass) call gpsrhs_dealloc(is)
-
-  time_end=MPI_Wtime()
-  write(6,'("Walltime for setupbend: Total " f15.4)') time_end-time_beg
 
   return
   contains

--- a/src/gsi/setupbend.f90
+++ b/src/gsi/setupbend.f90
@@ -449,7 +449,7 @@ subroutine setupbend(obsLL,odiagLL, &
   tb1=MPI_Wtime()
   call dtime_setup()
 
-  !$omp parallel do default(none), schedule(dynamic,8), &
+  !$omp parallel do default(none), schedule(dynamic,1), &
   !$omp& firstprivate(itime,iuse,jiter,ilate,ilat,ilon,iroc,igeoid,ihgt,ikxx, &
   !$omp&   nsig,n_a,n_b,k4,ier,isatid,iptid,igps,iprof,gpstop,commgpstop, &
   !$omp&   deg2rad,mype,ilone,ilsw,ilswflag,nsig_up,grids_dim,rsig_up,ds, &

--- a/src/gsi/setuprhsall.f90
+++ b/src/gsi/setuprhsall.f90
@@ -569,8 +569,6 @@ subroutine setuprhsall(ndata,mype,init_pass,last_pass)
 
 ! Collect information for preconditioning
   if (newpc4pred) then
-     !call mpl_allreduce(jpch_rad,rpvals=ostats)
-     !call mpl_allreduce(npred,jpch_rad,rstats)
      call MPI_Allreduce(mpi_in_place, ostats, jpch_rad, mpi_rtype, mpi_sum, mpi_comm_world, ier)
      call MPI_Allreduce(mpi_in_place, rstats, npred*jpch_rad, mpi_real16, mpi_sum, mpi_comm_world, ier)
   end if
@@ -579,8 +577,6 @@ subroutine setuprhsall(ndata,mype,init_pass,last_pass)
   if (aircraft_t_bc_pof .or. aircraft_t_bc) then
 !    call mpl_allreduce(npredt,max_tail,ostats_t)
 !    call mpl_allreduce(npredt,max_tail,rstats_t)
-     !call mpl_allreduce(npredt,ntail,ostats_t)
-     !call mpl_allreduce(npredt,ntail,rstats_t)
      call MPI_Allreduce(mpi_in_place, ostats_t, npredt*ntail, mpi_real16, mpi_sum, mpi_comm_world, ier)
      call MPI_Allreduce(mpi_in_place, rstats_t, npredt*ntail, mpi_real16, mpi_sum, mpi_comm_world, ier)
   end if

--- a/src/gsi/setuprhsall.f90
+++ b/src/gsi/setuprhsall.f90
@@ -139,7 +139,7 @@ subroutine setuprhsall(ndata,mype,init_pass,last_pass)
   use ozinfo, only: mype_oz,jpch_oz,ihave_oz
   use coinfo, only: mype_co,jpch_co,ihave_co
   use lightinfo, only: mype_light
-  use mpimod, only: ierror,mpi_comm_world,mpi_rtype,mpi_sum
+  use mpimod, only: ierror,mpi_comm_world,mpi_rtype,mpi_sum,mpi_real16
   use gridmod, only: twodvar_regional,wrf_mass_regional,nems_nmmb_regional
   use gridmod, only: cmaq_regional,fv3_regional
   use gsi_4dvar, only: nobs_bins,l4dvar
@@ -196,6 +196,7 @@ subroutine setuprhsall(ndata,mype,init_pass,last_pass)
   use mpeu_util, only: basename
 
   use directDA_radaruse_mod, only: l_use_dbz_directDA
+  use mpi, only: mpi_in_place
 
   implicit none
 
@@ -568,16 +569,20 @@ subroutine setuprhsall(ndata,mype,init_pass,last_pass)
 
 ! Collect information for preconditioning
   if (newpc4pred) then
-     call mpl_allreduce(jpch_rad,rpvals=ostats)
-     call mpl_allreduce(npred,jpch_rad,rstats)
+     !call mpl_allreduce(jpch_rad,rpvals=ostats)
+     !call mpl_allreduce(npred,jpch_rad,rstats)
+     call MPI_Allreduce(mpi_in_place, ostats, jpch_rad, mpi_rtype, mpi_sum, mpi_comm_world, ier)
+     call MPI_Allreduce(mpi_in_place, rstats, npred*jpch_rad, mpi_real16, mpi_sum, mpi_comm_world, ier)
   end if
 
 ! Collect information for aircraft data
   if (aircraft_t_bc_pof .or. aircraft_t_bc) then
 !    call mpl_allreduce(npredt,max_tail,ostats_t)
 !    call mpl_allreduce(npredt,max_tail,rstats_t)
-     call mpl_allreduce(npredt,ntail,ostats_t)
-     call mpl_allreduce(npredt,ntail,rstats_t)
+     !call mpl_allreduce(npredt,ntail,ostats_t)
+     !call mpl_allreduce(npredt,ntail,rstats_t)
+     call MPI_Allreduce(mpi_in_place, ostats_t, npredt*ntail, mpi_real16, mpi_sum, mpi_comm_world, ier)
+     call MPI_Allreduce(mpi_in_place, rstats_t, npredt*ntail, mpi_real16, mpi_sum, mpi_comm_world, ier)
   end if
 
 ! Collect satellite and precip. statistics


### PR DESCRIPTION
This PR relates to issue #859 which tracks the discussion of numerous changes to improve parallelism and performance of the global GSI.

Some highlights include
1. added OpenMP parallelism to read_atms.f90, read_bufrtovs.f90 and setupbend.f90
2. replaced mpl_allreduce() calls with standard MPI_Allreduce() in intall.f90, setuprhsall.f90
3. comment initialization of pcp arrays

Item two above might raise some alarms.

Resolves #859

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Potentially breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
I have run a global case on acorn and found zero-diff numerics when comparing "cost,grad,step,b,step?" in the stdout files.  The working directory for my control/baseline is at alogin02:/lfs/h1/hpc/support/daniel.kokron/Projects/GSI/ptmp

The builtin regression test hangs for me on acorn and cactus so I am unable to run those tests.

@RussTreadon-NOAA  has run GDAS and GFS global cases.  Results from those runs are documented in the issue thread.

**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published