### PR TITLE
Add capability to run AutoQC package for 3D-RTMA/URMA

### DIFF
--- a/src/gsi/gsd_terrain_match_surfTobs.f90
+++ b/src/gsi/gsd_terrain_match_surfTobs.f90
@@ -87,7 +87,7 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
      iqtflg=nint(cdata_all(9,iobsout)) == 0
 
 !here starts surface data correction   DEDE 28 April 2009
-     if(kx==181.or.kx==187.or.kx==188) then
+     if(kx==181.or.kx==187) then
         toe     = cdata_all(1,iobsout)
         dlon    = cdata_all(2,iobsout)
         dlat    = cdata_all(3,iobsout)

--- a/src/gsi/gsd_terrain_match_surfTobs.f90
+++ b/src/gsi/gsd_terrain_match_surfTobs.f90
@@ -87,7 +87,7 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
      iqtflg=nint(cdata_all(9,iobsout)) == 0
 
 !here starts surface data correction   DEDE 28 April 2009
-     if(kx==181.or.kx==187) then
+     if(kx==181.or.kx==187.or.kx==188) then
         toe     = cdata_all(1,iobsout)
         dlon    = cdata_all(2,iobsout)
         dlat    = cdata_all(3,iobsout)

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -92,7 +92,7 @@
   use qcmod, only: dfact,dfact1,create_qcvars,destroy_qcvars,&
       erradar_inflate,tdrerr_inflate,use_poq7,qc_satwnds,&
       init_qcvars,vadfile,noiqc,c_varqc,gps_jacqc,qc_noirjaco3,qc_noirjaco3_pole,&
-      buddycheck_t,buddydiag_save,njqc,vqc,nvqc,hub_norm,vadwnd_l2rw_qc, &
+      buddycheck_t,buddydiag_save,njqc,vqc,nvqc,hub_norm,vadwnd_l2rw_qc,sfcwndob_biasc,&
       pvis,pcldch,scale_cv,estvisoe,estcldchoe,vis_thres,cldch_thres,cao_check, &
       cris_cads, iasi_cads, iasing_cads, airs_cads
   use qcmod, only: troflg,lat_c,nrand
@@ -507,6 +507,8 @@
 !  01-07-2022 Hu        Add fv3_io_layout_y to let fv3lam interface read/write subdomain restart
 !                       files. The fv3_io_layout_y needs to match fv3lam model
 !                       option io_layout(2).
+!  2022-04-15  pondeca  add "logical sfcwndob_biasc" for surface wind bias  correction
+!                       based on a modified Kalman-Bucy filter
 !  05-24-2022 H.Wang    Add PM2.5 and AOD DA for regional FV3-CMAQ (RRFS-CMAQ).
 !                       GSI will perform aerosol analysis when 
 !                           1. laeroana_fv3cmaq =  .true.
@@ -1007,6 +1009,8 @@
 !     closest_obs- when true, choose the timely closest surface observation from
 !     multiple observations at a station.  Currently only applied to Ceiling
 !     height and visibility.
+!     sfcwndob_biasc - When true, apply a bias-correction scheme for surface winds
+!                      based on a modified Kalman-Bucy filter
 !     pvis   - power parameter in nonlinear transformation for vis 
 !     pcldch - power parameter in nonlinear transformation for cldch
 !     scale_cv - scaling constant in meter
@@ -1074,7 +1078,7 @@
        vadfile,noiqc,c_varqc,blacklst,use_poq7,hilbert_curve,tcp_refps,tcp_width,&
        tcp_ermin,tcp_ermax,gps_jacqc,qc_noirjaco3,qc_noirjaco3_pole,qc_satwnds,njqc,vqc,nvqc,hub_norm,troflg,lat_c,nrand,&
        aircraft_t_bc_pof,aircraft_t_bc,aircraft_t_bc_ext,biaspredt,upd_aircraft,cleanup_tail,&
-       hdist_aircraft,buddycheck_t,buddydiag_save,vadwnd_l2rw_qc,ompslp_mult_fact,  &
+       hdist_aircraft,buddycheck_t,buddydiag_save,vadwnd_l2rw_qc,ompslp_mult_fact,sfcwndob_biasc,&
        pvis,pcldch,scale_cv,estvisoe,estcldchoe,vis_thres,cldch_thres,cld_det_dec2bin, &
        q_doe_a_136,q_doe_a_137,q_doe_b_136,q_doe_b_137, &
        t_doe_a_136,t_doe_a_137,t_doe_b_136,t_doe_b_137, &

--- a/src/gsi/qcmod.f90
+++ b/src/gsi/qcmod.f90
@@ -79,6 +79,8 @@ module qcmod
 !   2019-09-29  X.Su   - add troflg and lat_c for hilbert curve tunning
 !   2019-04-19  eliu    - add QC flag for cold-air outbreak 
 !   2021-04-29  Jung/Collard - Fix numerics for emissivity check
+!   2022-04-15  pondeca - add "logical sfcwndob_biasc" for surface wind bias correction
+!                         based on a modified Kalman-Bucy filter
 !
 ! subroutines included:
 !   sub init_qcvars
@@ -206,6 +208,7 @@ module qcmod
   public :: lat_c
   public :: nrand 
   public :: airs_cads, cris_cads, iasi_cads, iasing_cads
+  public :: sfcwndob_biasc
 
   logical nlnqc_iter,njqc,vqc,nvqc,hub_norm
   logical noiqc
@@ -222,6 +225,7 @@ module qcmod
   logical troflg
   logical cao_check
   logical airs_cads, cris_cads, iasi_cads, iasing_cads
+  logical sfcwndob_biasc
 
   character(10):: vadfile
   integer(i_kind) npres_print
@@ -450,6 +454,7 @@ contains
                            !  obs run through the buddy check
 
     vadwnd_l2rw_qc=.true.  ! When false, DO NOT run the vadwnd qc on level 2 radial wind obs.
+    sfcwndob_biasc=.false. ! When false, do not apply the bias-correction scheme for surface winds
     pvis=one
     pcldch=one
     scale_cv=one

--- a/src/gsi/rapidrefresh_cldsurf_mod.f90
+++ b/src/gsi/rapidrefresh_cldsurf_mod.f90
@@ -123,6 +123,8 @@ module rapidrefresh_cldsurf_mod
 !                          rejection list
 !                         =0 . EMC method (default)
 !                         =1 . GSD method
+!                         =2 . expansion of GSD method to include provider/subprovider
+!                              based criteria and diurnal accept lists
 !      i_lightpcp        - options for how to deal with light precipitation
 !                         =0 . don't add light precipitation (default)
 !                         =1 . add light precipitation in warm section

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -1832,8 +1832,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  qm=sstq
               else if(gustob) then
                  gustqm=0
-                 if ( i_gsdsfc_uselist/=1 .and. i_gsdsfc_uselist/=2 .and. .not.l_rtma3d)  then
-                    if (kx==188 .or. kx==288 .or. kx==195 .or. kx==295 ) &
+                 if (i_gsdsfc_uselist/=2 ) &
                     call get_gustqm(kx,c_station_id,c_prvstg,c_sprvstg,gustqm)
                  endif
                  qm=gustqm
@@ -2069,7 +2068,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                                             obsdat(5,k),obsdat(6,k),usage)
                  endif
 
-                 if ((l_rtma3d .or. twodvar_regional) .and. i_gsdsfc_uselist/=1) then
+                 if (l_rtma3d .or. twodvar_regional) then
                     call tll2xy(dlon_earth,dlat_earth,x_obs,y_obs,outside_obs)
                     if ((trim(obstype)=='t' .or. trim(obstype)=='q') .and. .not.outside_obs) then
                        call valley_adjustment(x_obs,y_obs,usage)

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -148,6 +148,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
 !
 !   2020-05-04  wu      - no rotate_wind for fv3_regional
 !   2020-09-05  CAPS(C. Tong) - add flag for new vadwind obs to assimilate around the analysis time only
+!   2022-04-16  pondeca - add bias correction multiplicative factor windbiasfact
 !   2023-03-23  draper  - add code for processing T2m and q2m for global system
 !   2023-07-30  zhao    - added code to extract obs of significant wave height (howvob) from bufr record 
 !                         in prepbufr file for 3D analysis
@@ -206,7 +207,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
   use gsi_4dvar, only: l4dvar,l4densvar,time_4dvar,winlen,thin4d
   use convthin, only: make3grids,map3grids_m,del3grids,use_all
   use convthin_time, only: make3grids_tm,map3grids_m_tm,del3grids_tm,use_all_tm
-  use qcmod, only: errormod,errormod_aircraft,noiqc,newvad,njqc
+  use qcmod, only: errormod,errormod_aircraft,noiqc,newvad,njqc,sfcwndob_biasc
   use qcmod, only: pvis,pcldch,scale_cv,estvisoe,estcldchoe,vis_thres,cldch_thres
   use qcmod, only: nrand
   use nltransf, only: nltransf_forward
@@ -214,6 +215,8 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
   use blacklist, only : blkstns,blkkx,ibcnt
   use sfcobsqc,only: init_rjlists,get_usagerj,get_gustqm,destroy_rjlists
   use sfcobsqc,only: init_gsd_sfcuselist,apply_gsd_sfcuselist,destroy_gsd_sfcuselist                       
+  use sfcobsqc,only: init_sfcuselist,apply_sfcuselist,destroy_sfcuselist
+  use sfcobsqc,only: get_wbias_afactor
   use windht,only: init_windht_lists,readin_windht_list,destroy_windht_lists,find_wind_height
   use hilbertcurve,only: init_hilbertcurve, accum_hilbertcurve, &
                          apply_hilbertcurve,destroy_hilbertcurve
@@ -330,7 +333,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
   integer(i_kind) idummy1,idummy2,glret,lindx !glret>0 means GLERL code exists.Others are dummy variables
   real(r_kind) time,timex,time_drift,timeobs,toff,t4dv,zeps
   real(r_kind) qtflg,tdry,rmesh,ediff,usage,ediff_ps,ediff_q,ediff_t,ediff_uv,ediff_pw
-  real(r_kind) u0,v0,uob,vob,dx,dy,dx1,dy1,w00,w10,w01,w11
+  real(r_kind) u0,v0,uob,vob,rgustob,dx,dy,dx1,dy1,w00,w10,w01,w11
   real(r_kind) qoe,qobcon,pwoe,pwmerr,dlnpob,ppb,poe,gustoe,visoe,qmaxerr
   real(r_kind) toe,woe,errout,oelev,dlat,dlon,sstoe,dlat_earth,dlon_earth
   real(r_kind) tdoe,mxtmoe,mitmoe,pmoe,howvoe,cldchoe
@@ -356,6 +359,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
   real(r_kind) :: tempvis,visout
   real(r_kind) :: tempcldch,cldchout
   real(r_kind) :: windsensht
+  real(r_kind) :: windbiasfact
 
   real(r_double) rstation_id,qcmark_huge
   real(r_double) vtcd,glcd !virtual temp program code and GLERL program code
@@ -496,7 +500,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
      iqm = 10
      iuse = 12
   else if(uvob) then 
-     nreal=26
+     nreal=27
      iqm = 12
      iuse = 14
   else if(spdob) then
@@ -524,7 +528,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
      iqm = 11
      iuse = 13
   else if(gustob) then
-     nreal=21
+     nreal=22
      iqm = 11
      iuse = 12
   else if(visob) then
@@ -889,6 +893,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
   call init_rjlists
   call init_aircraft_rjlists
   if(i_gsdsfc_uselist==1) call init_gsd_sfcuselist
+  if(i_gsdsfc_uselist==2) call init_sfcuselist
 
   if (lhilbert) call init_hilbertcurve(maxobs)
 
@@ -1823,8 +1828,10 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  qm=sstq
               else if(gustob) then
                  gustqm=0
-                 if (kx==188 .or. kx==288 .or. kx==195 .or. kx==295 ) &
-                 call get_gustqm(kx,c_station_id,c_prvstg,c_sprvstg,gustqm)
+                 if (i_gsdsfc_uselist==0) then
+                   !if (kx==188 .or. kx==288 .or. kx==195 .or. kx==295 ) &
+                    call get_gustqm(kx,c_station_id,c_prvstg,c_sprvstg,gustqm)
+                 endif
                  if ( l_rtma3d ) gustqm = 0  ! skipping get_gustqm for 3drtma run (missing list file)
                  qm=gustqm
               else if(visob) then
@@ -2044,11 +2051,19 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  usage=100._r_kind
               end if
 
+              windbiasfact=one
+
               if (sfctype) then 
                  if (i_gsdsfc_uselist==1 ) then
                     if (kx==188 .or. kx==195 .or. kx==288.or.kx==295)  &
                     call apply_gsd_sfcuselist(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
                                             usage)
+                 elseif (i_gsdsfc_uselist==2 ) then
+                    if (kx==188 .or. kx==195 .or. kx==288.or.kx==295) then
+                       call apply_sfcuselist(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
+                                               dlon_earth,dlat_earth,usage)
+                       if (gustob .and. usage>=r6) gustqm=r10
+                    endif
                  else
                     call get_usagerj(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
                                             dlon_earth,dlat_earth,idate,t4dv-toff,      &
@@ -2058,6 +2073,11 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  if (twodvar_regional)  then
                     if ( kx==288.or.kx==295 .or. (gustob .and. (kx==188.or.kx==195)) )  then
                        call find_wind_height(c_prvstg,c_sprvstg,windsensht,kcount)
+                    endif
+                 endif
+                 if (sfcwndob_biasc) then
+                    if ( kx==288.or.kx==295 .or. (gustob .and. (kx==188.or.kx==195)) )  then
+                       call get_wbias_afactor(kx,obstype,c_station_id,c_prvstg,c_sprvstg,windbiasfact)
                     endif
                  endif
                  if(i_gsdqc==2) then  ! filter bad 2-m dew point and  0 mesonet wind obs
@@ -2312,6 +2332,12 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                     end if
                  endif
 
+                 if (sfcwndob_biasc) then
+                    if (kx==288.or.kx==295)  then
+                        uob=uob*windbiasfact
+                        vob=vob*windbiasfact
+                    endif 
+                 endif
 
                  cdata_all(1,iout)=woe                     ! wind error
                  cdata_all(2,iout)=dlon                    ! grid relative longitude
@@ -2341,9 +2367,10 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(24,iout)=obsdat(10,k)           ! cat
                  cdata_all(25,iout)=var_jb(5,k)            ! non linear qc parameter
                  cdata_all(26,iout)=one                    ! hilbert curve weight, modified later 
+                 cdata_all(27,iout)=windbiasfact           ! bias correction factor
                  if(perturb_obs)then
-                    cdata_all(27,iout)=ran01dom()*perturb_fact ! u perturbation
-                    cdata_all(28,iout)=ran01dom()*perturb_fact ! v perturbation
+                    cdata_all(28,iout)=ran01dom()*perturb_fact ! u perturbation
+                    cdata_all(29,iout)=ran01dom()*perturb_fact ! v perturbation
                  endif
  
               else if(spdob) then 
@@ -2576,14 +2603,23 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                       selev=zero
                    end if
 
+                   uob=obsdat(5,k)
+                   vob=obsdat(6,k)
+                   rgustob=obsdat(8,k)
+
                    if ((kx==188).or.(kx==288) .or.(kx==195) .or.(kx==295)) then
 !                     gustoe=2.5
                       gustoe=1.0
                       if ( l_rtma3d .and. oerr_gust > 0.0_r_kind ) gustoe = oerr_gust
-                      windcorr=abs(obsdat(5,k))<1.0 .and. abs(obsdat(6,k))<1.0 .and. obsdat(8,k)>10.0
+                      if (sfcwndob_biasc) then
+                         uob=uob*windbiasfact
+                         vob=vob*windbiasfact
+                         rgustob=rgustob*windbiasfact
+                      endif
+                      windcorr=abs(uob)<1.0 .and. abs(vob)<1.0 .and. rgustob>10.0
                       if (windcorr) gustoe=gustoe*1.5_r_kind
 
-                      if (abs(obsdat(8,k)-sqrt(obsdat(5,k)**2+obsdat(6,k)**2))<1.5) then
+                      if (abs(rgustob-sqrt(uob**2+vob**2))<1.5) then
                          gustoe=gustoe*1.5_r_kind
                       end if
                    end if
@@ -2595,7 +2631,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(3,iout)=dlat                    ! grid relative latitude
                  cdata_all(4,iout)=dlnpob                  ! ln(pressure in cb)
                  cdata_all(5,iout)=oelev                   ! observation height
-                 cdata_all(6,iout)=obsdat(8,k)             ! wind gusts obs
+                 cdata_all(6,iout)=rgustob                 ! wind gusts obs
                  cdata_all(7,iout)=rstation_id             ! station id
                  cdata_all(8,iout)=t4dv                    ! time
                  cdata_all(9,iout)=nc                      ! type
@@ -2612,6 +2648,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  cdata_all(19,iout)=selev                  ! station elevation (m)
                  cdata_all(20,iout)=r_prvstg(1,1)          ! provider name
                  cdata_all(21,iout)=r_sprvstg(1,1)         ! subprovider name
+                 cdata_all(22,iout)=windbiasfact           ! bias correction factor
 
 !             Visibility
               else if(visob) then
@@ -3302,6 +3339,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
   call destroy_rjlists
   call destroy_aircraft_rjlists
   if(i_gsdsfc_uselist==1) call destroy_gsd_sfcuselist
+  if(i_gsdsfc_uselist==2) call destroy_sfcuselist
   if (lhilbert) call destroy_hilbertcurve
   if (twodvar_regional) then
      call destroy_ndfdgrid

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -2086,6 +2086,8 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  if (sfcwndob_biasc) then
                     if ( kx==288.or.kx==295 .or. (gustob .and. (kx==188.or.kx==195)) )  then
                        call get_wbias_afactor(kx,obstype,c_station_id,c_prvstg,c_sprvstg,windbiasfact)
+                    endif
+                 endif
                  !retrieve wind sensor height for mesonet gustob only when running 3DRTMA
                  if (l_rtma3d)  then
                     if ( gustob .and. (kx==188.or.kx==195) )  then

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -2075,7 +2075,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                                             obsdat(5,k),obsdat(6,k),usage)
                  endif
 
-                 if (l_rtma3d .and. (i_gsdsfc_uselist==1.or.i_gsdsfc_uselist==2)) then
+                 if ((l_rtma3d .or. twodvar_regional) .and. (i_gsdsfc_uselist==1.or.i_gsdsfc_uselist==2)) then
                     call tll2xy(dlon_earth,dlat_earth,x_obs,y_obs,outside_obs)
                     if ((trim(obstype)=='t' .or. trim(obstype)=='q') .and. .not.outside_obs) then
                        call valley_adjustment(x_obs,y_obs,usage)

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -1832,11 +1832,10 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                  qm=sstq
               else if(gustob) then
                  gustqm=0
-                 if (i_gsdsfc_uselist==0) then
-                   !if (kx==188 .or. kx==288 .or. kx==195 .or. kx==295 ) &
+                 if ( i_gsdsfc_uselist/=1 .and. i_gsdsfc_uselist/=2 .and. .not.l_rtma3d)  then
+                    if (kx==188 .or. kx==288 .or. kx==195 .or. kx==295 ) &
                     call get_gustqm(kx,c_station_id,c_prvstg,c_sprvstg,gustqm)
                  endif
-                 if ( l_rtma3d ) gustqm = 0  ! skipping get_gustqm for 3drtma run (missing list file)
                  qm=gustqm
               else if(visob) then
                  visqm=0    ! need to fix this later
@@ -2062,7 +2061,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                     if (kx==188 .or. kx==195 .or. kx==288.or.kx==295) then
                        call apply_sfcuselist(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
                                                dlon_earth,dlat_earth,usage)
-                       if (gustob .and. usage>=r6) gustqm=r10
+                       if (gustob .and. usage>=r6) then ; gustqm=r10 ; qm=gustqm ; endif
                     endif
                  else
                     call get_usagerj(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
@@ -2070,7 +2069,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                                             obsdat(5,k),obsdat(6,k),usage)
                  endif
 
-                 if ((l_rtma3d .or. twodvar_regional) .and. (i_gsdsfc_uselist==1.or.i_gsdsfc_uselist==2)) then
+                 if ((l_rtma3d .or. twodvar_regional) .and. i_gsdsfc_uselist/=1) then
                     call tll2xy(dlon_earth,dlat_earth,x_obs,y_obs,outside_obs)
                     if ((trim(obstype)=='t' .or. trim(obstype)=='q') .and. .not.outside_obs) then
                        call valley_adjustment(x_obs,y_obs,usage)

--- a/src/gsi/read_prepbufr.f90
+++ b/src/gsi/read_prepbufr.f90
@@ -1833,8 +1833,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
               else if(gustob) then
                  gustqm=0
                  if (i_gsdsfc_uselist/=2 ) &
-                    call get_gustqm(kx,c_station_id,c_prvstg,c_sprvstg,gustqm)
-                 endif
+                 call get_gustqm(kx,c_station_id,c_prvstg,c_sprvstg,gustqm)
                  qm=gustqm
               else if(visob) then
                  visqm=0    ! need to fix this later

--- a/src/gsi/read_satwnd.f90
+++ b/src/gsi/read_satwnd.f90
@@ -78,6 +78,8 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
 !   2021-07-25 Genkova  - added code for Metop-B/C winds in new BUFR,NC005081  !
 !   2022-01-20 Genkova  - added missing station_id for polar winds
 !   2022-01-20 Genkova  - added code for Meteosat and Himawari AMVs in new BUFR
+!   2022-04-16  pondeca - write bias correction multiplicative factor, windbiasfact,
+!                         to diagnostic file. value is set to one.
 !   2022-12-10 Bi  - added code for CIMSS enhanced AMVs in new BUFR
 !   2025-02-10 Woollen - refactored to specify processing paths for satwind data via lookup table
 !   
@@ -213,6 +215,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
 ! real(r_kind) ppb1,ppb2,uob1,vob1
   real(r_kind) tsavg,ff10,sfcr,sstime,gstime,zz
   real(r_kind) crit1,timedif,xmesh,pmesh,ptime
+  real(r_kind) windbiasfact
   real(r_kind),dimension(nsig):: presl
   
   real(r_double) zangl 
@@ -284,7 +287,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
 ! Set lower limits for observation errors
   werrmin=one
   nsattype=0
-  nreal=26
+  nreal=27
   if(perturb_obs ) nreal=nreal+2
   ntread=1
   ntmatch=0
@@ -1252,6 +1255,9 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                  vdisterrmax=max(vdisterrmax,disterr)
               end if
            endif
+
+           windbiasfact=one
+
            cdata_all(1,iout)=woe                  ! wind error
            cdata_all(2,iout)=dlon                 ! grid relative longitude
            cdata_all(3,iout)=dlat                 ! grid relative latitude
@@ -1277,10 +1283,11 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
            cdata_all(23,iout)=r_sprvstg(1,1)      ! subprovider name
            cdata_all(25,iout)=var_jb              ! non linear qc parameter
            cdata_all(26,iout)=one                 ! hilbert curve weight
+           cdata_all(27,iout)=windbiasfact        ! bias correction factor
 
            if(perturb_obs)then
-              cdata_all(27,iout)=ran01dom()*perturb_fact ! u perturbation
-              cdata_all(28,iout)=ran01dom()*perturb_fact ! v perturbation
+              cdata_all(28,iout)=ran01dom()*perturb_fact ! u perturbation
+              cdata_all(29,iout)=ran01dom()*perturb_fact ! v perturbation
            endif
 
 

--- a/src/gsi/setupgust.f90
+++ b/src/gsi/setupgust.f90
@@ -43,6 +43,8 @@ subroutine setupgust(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diag
 !                         rather than assuming station height is 10 m AGL.
 !   2019-08-12  zhang/levine/pondeca -  add option to adjust 10-m background wind with the help of
 !                                       similarity in twodvar_regional applications
+!   2022-04-16  pondeca - write bias correction multiplicative factor for mesonet
+!                         winds, windbiasfact, to diagnostic file
 !
 !   input argument list:
 !     lunin    - unit from which to read observations
@@ -148,6 +150,7 @@ subroutine setupgust(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diag
   integer(i_kind) l,mm1
   integer(i_kind) itype
   integer(i_kind) idomsfc,iskint,iff10,isfcr
+  integer(i_kind) ibiascor
 
   logical msonetob
   
@@ -213,6 +216,7 @@ subroutine setupgust(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diag
   istnelv=19  ! index of station elevation (m)
   iprvd=20    ! index of provider
   isprvd=21   ! index of subprovider
+  ibiascor=22 ! index of multiplicative factor for ob bias correction
 
   mm1=mype+1
   scale=one
@@ -268,7 +272,7 @@ subroutine setupgust(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diag
   if(conv_diagsave)then
      ii=0
      nchar=1
-     ioff0=22
+     ioff0=23
      nreal=ioff0
      if (lobsdiagsave) nreal=nreal+4*miter+1
      allocate(cdiagbuf(nobs),rdiagbuf(nreal,nobs))
@@ -789,6 +793,7 @@ contains
 
         rdiagbuf(21,ii) = data(idomsfc,i)    ! dominate surface type
         rdiagbuf(22,ii) = zsges              ! model terrain at ob location
+        rdiagbuf(23,ii) = data(ibiascor,i)   ! bias correction a-factor
         r_prvstg        = data(iprvd,i)
         cprvstg(ii)     = c_prvstg           ! provider name
         r_sprvstg       = data(isprvd,i)
@@ -853,6 +858,7 @@ contains
  
            call nc_diag_metadata("Dominant_Sfc_Type", data(idomsfc,i)              )
            call nc_diag_metadata("Model_Terrain",     zsges                        )
+           call nc_diag_metadata("bias_correction_a_factor", sngl(data(ibiascor,i)))
            r_prvstg            = data(iprvd,i)
            call nc_diag_metadata("Provider_Name",     c_prvstg                     )    
            r_sprvstg           = data(isprvd,i)

--- a/src/gsi/setupuwnd10m.f90
+++ b/src/gsi/setupuwnd10m.f90
@@ -32,6 +32,8 @@ subroutine setupuwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
 !   2018-01-08  pondeca - addd option l_closeobs to use closest obs to analysis
 !                                     time in analysis
 !   2020-05-04  wu   - no rotate_wind for fv3_regional
+!   2022-04-16  pondeca - write bias correction multiplicative factor for mesonet
+!                         winds, windbiasfact, to diagnostic file
 !
 !   input argument list:
 !     lunin    - unit from which to read observations
@@ -145,6 +147,7 @@ subroutine setupuwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
   integer(i_kind) i,nchar,nreal,k,ii,ikxx,nn,isli,ibin,ioff,ioff0,jj,itype
   integer(i_kind) l,mm1
   integer(i_kind) idomsfc,iskint,iff10,isfcr
+  integer(i_kind) ibiascor
   
   logical,dimension(nobs):: luse,muse
   integer(i_kind),dimension(nobs):: ioid ! initial (pre-distribution) obs ID
@@ -219,6 +222,7 @@ subroutine setupuwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
   izz=21      ! index of surface height
   iprvd=22    ! index of provider
   isprvd=23   ! index of subprovider
+  ibiascor=26 ! index of multiplicative factor for ob bias correction
 
   mm1=mype+1
   scale=one
@@ -277,7 +281,7 @@ subroutine setupuwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
      ioff0=23
      nreal=ioff0
      if (lobsdiagsave) nreal=nreal+4*miter+1
-     if (twodvar_regional) then; nreal=nreal+2; allocate(cprvstg(nobs),csprvstg(nobs)); endif
+     if (twodvar_regional) then; nreal=nreal+3; allocate(cprvstg(nobs),csprvstg(nobs)); endif
      if (binary_diag) allocate(cdiagbuf(nobs),rdiagbuf(nreal,nobs))
      if (netcdf_diag) call init_netcdf_diag_
   end if
@@ -954,6 +958,7 @@ subroutine setupuwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
            cprvstg(ii)     = c_prvstg               ! provider name
            r_sprvstg       = data(isprvd,i)
            csprvstg(ii)    = c_sprvstg              ! subprovider name
+           rdiagbuf(ioff+3,ii) = data(ibiascor,i)      !bias correction a-factor
         endif
  
   end subroutine contents_binary_diag_
@@ -1048,6 +1053,7 @@ subroutine setupuwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
            cprvstg(ii)     = c_prvstg               ! provider name
            r_sprvstg       = data(isprvd,i)
            csprvstg(ii)    = c_sprvstg              ! subprovider name
+           call nc_diag_metadata("bias_correction_a_factor", sngl(data(ibiascor,i))    )
         endif
   
   end subroutine contents_netcdf_diag_

--- a/src/gsi/setupvwnd10m.f90
+++ b/src/gsi/setupvwnd10m.f90
@@ -32,6 +32,8 @@ subroutine setupvwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
 !   2018-01-08  pondeca - addd option l_closeobs to use closest obs to analysis
 !                                     time in analysis
 !   2020-05-04  wu   - no rotate_wind for fv3_regional
+!   2022-04-16  pondeca - write bias correction multiplicative factor for mesonet
+!                         winds, windbiasfact, to diagnostic file
 !
 !   input argument list:
 !     lunin    - unit from which to read observations
@@ -145,6 +147,7 @@ subroutine setupvwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
   integer(i_kind) i,nchar,nreal,k,ii,ikxx,nn,isli,ibin,ioff,ioff0,jj,itype
   integer(i_kind) l,mm1
   integer(i_kind) idomsfc,iskint,iff10,isfcr
+  integer(i_kind) ibiascor
   
   logical,dimension(nobs):: luse,muse
   integer(i_kind),dimension(nobs):: ioid ! initial (pre-distribution) obs ID
@@ -219,6 +222,7 @@ subroutine setupvwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
   izz=21      ! index of surface height
   iprvd=22    ! index of provider
   isprvd=23   ! index of subprovider
+  ibiascor=26 ! index of multiplicative factor for ob bias correction
 
   mm1=mype+1
   scale=one
@@ -277,7 +281,7 @@ subroutine setupvwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
      ioff0=23
      nreal=ioff0
      if (lobsdiagsave) nreal=nreal+4*miter+1
-     if (twodvar_regional) then; nreal=nreal+2; allocate(cprvstg(nobs),csprvstg(nobs)); endif
+     if (twodvar_regional) then; nreal=nreal+3; allocate(cprvstg(nobs),csprvstg(nobs)); endif
      if (binary_diag) allocate(cdiagbuf(nobs),rdiagbuf(nreal,nobs))
      if (netcdf_diag) call init_netcdf_diag_
   end if
@@ -954,6 +958,7 @@ subroutine setupvwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
            cprvstg(ii)     = c_prvstg               ! provider name
            r_sprvstg       = data(isprvd,i)
            csprvstg(ii)    = c_sprvstg              ! subprovider name
+           rdiagbuf(ioff+3,ii) = data(ibiascor,i)      !bias correction a-factor
         endif
  
   end subroutine contents_binary_diag_
@@ -1048,6 +1053,7 @@ subroutine setupvwnd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
            cprvstg(ii)     = c_prvstg               ! provider name
            r_sprvstg       = data(isprvd,i)
            csprvstg(ii)    = c_sprvstg              ! subprovider name
+           call nc_diag_metadata("bias_correction_a_factor", sngl(data(ibiascor,i))    )
         endif
   
   end subroutine contents_netcdf_diag_

--- a/src/gsi/setupw.f90
+++ b/src/gsi/setupw.f90
@@ -223,6 +223,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 !                         information in diagonostic file, which is used
 !                         in offline observation quality control program (AutoObsQC) 
 !                         for 3D-RTMA (if l_obsprvdiag is true).
+!   2022-04-16  pondeca - write bias correction multiplicative factor for mesonet winds, windbiasfact, to diagnostic file
 !
 ! REMARKS:
 !   language: f90
@@ -294,6 +295,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   integer(i_kind) izz,iprvd,isprvd
   integer(i_kind) idomsfc,isfcr,iskint,iff10
   integer(i_kind) ibb,ikk,ihil,idddd
+  integer(i_kind) ibiascor
 
   integer(i_kind) num_bad_ikx,iprev_station
 
@@ -384,8 +386,9 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   icat=24     ! index of data level category
   ijb=25      ! index of non linear qc parameter
   ihil=26     ! index of  hilbert curve weight
-  iptrbu=27   ! index of u perturbation
-  iptrbv=28   ! index of v perturbation
+  ibiascor=27 ! index of multiplicative factor for ob bias correction
+  iptrbu=28   ! index of u perturbation
+  iptrbv=29   ! index of v perturbation
 
   mm1=mype+1
   scale=one
@@ -405,7 +408,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
      nreal=ioff0
      if (lobsdiagsave) nreal=nreal+7*miter+2
      if (twodvar_regional .or. l_obsprvdiag) then
-       nreal=nreal+2                           ! account for idomsfc,izz
+       nreal=nreal+3                           ! account for idomsfc,izz
        allocate(cprvstg(nobs),csprvstg(nobs))  ! obs provider info
      endif
      if (save_jacobian) then
@@ -1757,6 +1760,8 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            cprvstg(ii)         = c_prvstg        ! provider name
            r_sprvstg           = data(isprvd,i)
            csprvstg(ii)        = c_sprvstg       ! subprovider name
+           ioff = ioff + 1
+           rdiagbuf(ioff,ii) = data(ibiascor,i)  !bias correction a-factor
         endif
 
         if (save_jacobian) then
@@ -1854,6 +1859,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_metadata("Provider_Name",     c_prvstg                     )
               r_sprvstg           = data(isprvd,i)
               call nc_diag_metadata("Subprovider_Name",  c_sprvstg                    )
+              call nc_diag_metadata("bias_correction_a_factor", sngl(data(ibiascor,i))   )
            endif
            if (save_jacobian) then
               call nc_diag_data2d("u_Observation_Operator_Jacobian_stind", dhx_dx_u%st_ind)

--- a/src/gsi/setupwspd10m.f90
+++ b/src/gsi/setupwspd10m.f90
@@ -38,6 +38,8 @@ subroutine setupwspd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
 !                          This is to account for mesonets with sensor height < 10 m.
 !   2019-08-12  zhang/levine/pondeca -  add option to adjust 10-m bckg wind with the help of
 !                                       similarity theory in twodvar_regional applications
+!   2022-04-16  pondeca - write bias correction multiplicative factor for mesonet
+!                         winds, windbiasfact, to diagnostic file
 !
 !   input argument list:
 !     lunin    - unit from which to read observations
@@ -156,6 +158,7 @@ subroutine setupwspd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
   integer(i_kind) iz,u_ind,v_ind
   integer(i_kind) l,mm1
   integer(i_kind) idomsfc,iskint,iff10,isfcr
+  integer(i_kind) ibiascor
   
   logical,dimension(nobs):: luse,muse
   integer(i_kind),dimension(nobs):: ioid ! initial (pre-distribution) obs ID
@@ -233,6 +236,7 @@ subroutine setupwspd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
   izz=21      ! index of surface height
   iprvd=22    ! index of provider
   isprvd=23   ! index of subprovider
+  ibiascor=26 ! index of multiplicative factor for ob bias correction
 
   mm1=mype+1
   scale=one
@@ -280,7 +284,7 @@ subroutine setupwspd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
      ioff0=20
      nreal=ioff0
      if (lobsdiagsave) nreal=nreal+4*miter+1
-     if (twodvar_regional) then; nreal=nreal+2; allocate(cprvstg(nobs),csprvstg(nobs)); endif
+     if (twodvar_regional) then; nreal=nreal+3; allocate(cprvstg(nobs),csprvstg(nobs)); endif
      allocate(cdiagbuf(nobs),rdiagbuf(nreal,nobs))
      if(netcdf_diag) call init_netcdf_diag_
   end if
@@ -1140,6 +1144,7 @@ subroutine setupwspd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
            cprvstg(ii)     = c_prvstg               ! provider name
            r_sprvstg       = data(isprvd,i)
            csprvstg(ii)    = c_sprvstg              ! subprovider name
+           rdiagbuf(ioff+3,ii) = data(ibiascor,i)   !bias correction a-factor
         endif
   end subroutine contents_binary_diag_
   subroutine contents_netcdf_diag_(odiag)
@@ -1197,6 +1202,7 @@ subroutine setupwspd10m(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_d
               call nc_diag_metadata("Provider_Name",     c_prvstg                     )    
               r_sprvstg           = data(isprvd,i)
               call nc_diag_metadata("Subprovider_Name",  c_sprvstg                    )
+              call nc_diag_metadata("bias_correction_a_factor", sngl(data(ibiascor,i))   )
            endif
   end subroutine contents_netcdf_diag_
 

--- a/src/gsi/sfcobsqc.f90
+++ b/src/gsi/sfcobsqc.f90
@@ -1298,26 +1298,28 @@ subroutine get_gustqm(kx,c_station_id,c_prvstg,c_sprvstg,gustqm)
   integer(i_kind) m
   character(8)  ch8
 
-  if (kx==188 .or. kx==288 .or. kx==195 .or. kx==295 ) gustqm=9
-  if (listexist) then
-     do m=1,nprov
-        if (cprovider(m)(1:7)=='allprvs' .or. &
-           (c_prvstg(1:8) == cprovider(m)(1:8) .and. (c_sprvstg(1:8) == cprovider(m)(9:16)  &
-                                               .or. cprovider(m)(9:16) == 'allsprvs')) ) then
-           gustqm=0
-           exit
-         endif
-     enddo
+  if (kx==188 .or. kx==288 .or. kx==195 .or. kx==295 ) then
+    gustqm=9
+    if (listexist) then
+       do m=1,nprov
+          if (cprovider(m)(1:7)=='allprvs' .or. &
+             (c_prvstg(1:8) == cprovider(m)(1:8) .and. (c_sprvstg(1:8) == cprovider(m)(9:16)  &
+                                                 .or. cprovider(m)(9:16) == 'allsprvs')) ) then
+             gustqm=0
+             exit
+           endif
+       enddo
+    endif
+    if (listexist2) then
+       do m=1,nsta_mesowind_use
+          if (c_station_id(1:5) == csta_winduse(m)(1:5)) then
+             gustqm=0
+             exit
+           endif
+       enddo
+    endif
   endif
-  if (listexist2) then
-     do m=1,nsta_mesowind_use
-        if (c_station_id(1:5) == csta_winduse(m)(1:5)) then
-           gustqm=0
-           exit
-         endif
-     enddo
-  endif
-
+  
   if(wlistexist ) then
      do m=1,nwrjs
         ch8(1:8)=w_rjlist(m)(1:8)

--- a/src/gsi/sfcobsqc.f90
+++ b/src/gsi/sfcobsqc.f90
@@ -988,7 +988,6 @@ subroutine get_usagerj(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
 
   use constants, only: zero_single
   use gridmod, only: twodvar_regional,tll2xy
-  use ndfdgrids, only: valley_adjustment
 
   implicit none
 
@@ -1235,9 +1234,7 @@ subroutine get_usagerj(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
             do m=1,nwbaccpts(ibin)
               ch8(1:8)=csta_windbin(m,ibin)(1:8)
               nlen=len_trim(ch8)
-              nlen2=0
-              do k=1,8 ; if (c_station_id(k:k)==cblank) exit ; nlen2=nlen2+1 ; enddo
-              if (nlen==nlen2 .and. c_station_id(1:nlen)==ch8(1:nlen)) then
+              if (c_station_id(1:nlen)==ch8(1:nlen)) then
                 usage_rj=usage_rj0
                 exit
               endif
@@ -1279,11 +1276,6 @@ subroutine get_usagerj(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
         enddo
      endif
   end if
-
-  if (twodvar_regional) then
-     call tll2xy(dlon,dlat,xob,yob,outside)
-     if ((obstype=='t' .or. obstype=='q') .and. .not.outside) call valley_adjustment(xob,yob,usage_rj)
-  endif
 end subroutine get_usagerj
 
 

--- a/src/gsi/sfcobsqc.f90
+++ b/src/gsi/sfcobsqc.f90
@@ -533,7 +533,6 @@ subroutine apply_sfcuselist(kx,obstype,c_station_id_in,c_prvstg_in,c_sprvstg_in,
 !$$$ end documentation block
 
   use gridmod, only: twodvar_regional,tll2xy
-  use ndfdgrids, only: valley_adjustment
   implicit none
 
   integer(i_kind),intent(in   ) :: kx
@@ -684,10 +683,6 @@ subroutine apply_sfcuselist(kx,obstype,c_station_id_in,c_prvstg_in,c_sprvstg_in,
      enddo
   end if
 
-  if (twodvar_regional) then
-     call tll2xy(dlon,dlat,xob,yob,outside)
-     if ((obstype=='t' .or. obstype=='q') .and. .not.outside) call valley_adjustment(xob,yob,usage_rj)
-  endif
 !
   kx_save=kx
   obstype_save=obstype

--- a/src/gsi/sfcobsqc.f90
+++ b/src/gsi/sfcobsqc.f90
@@ -22,11 +22,13 @@ module sfcobsqc
 !   2014-10-01  Xue - add GSD surface data uselist
 !   2015-07-10  pondeca - add reject list for cldch
 !   2018-03-14  pondeca - add station accept list for mesonet visibility
+!   2022-04-16  pondeca - add get_wbias_afactor
 !
 ! subroutines included:
 !   sub init_rjlists
 !   sub get_usagerj
 !   sub get_gustqm
+!   sub get_wbias_afactor
 !   readin_rjlists
 !   sub destroy_rjlists
 !
@@ -53,6 +55,8 @@ module sfcobsqc
   character(80),allocatable,dimension(:)::q_day_rjlist,q_night_rjlist
   character(8),allocatable,dimension(:,:)::csta_windbin
   character(80),allocatable,dimension(:)::csta_visuse
+  character(150),allocatable,dimension(:)::windbiasafactor
+  character(16),allocatable,dimension(:,:)::cprvsubprv_wbias
 
   integer(i_kind) sfcuselist_nt_use
   character(8),allocatable,dimension(:)::sfcuselist_use_id
@@ -61,12 +65,26 @@ module sfcobsqc
   character(1),allocatable,dimension(:)::td_use_sfcuselist
 
   integer(i_kind) nprov,nwrjs,ntrjs,nprjs,nqrjs,nsta_mesowind_use,nsta_mesovis_use
+  integer(i_kind) nsta_windbiascor
   integer(i_kind) ntdrjs,nmxtmrjs,nmitmrjs,npmslrjs,nhowvrjs,&
                   nlcbasrjs,ntcamtrjs,ncldchrjs
+  integer(i_kind) nprov_wind,nprov_gust,nt_sfcuse
   integer(i_kind) ntrjs_day,ntrjs_night
   integer(i_kind) nqrjs_day,nqrjs_night
   integer(i_kind) nbins
   integer(i_kind),allocatable,dimension(:)::nwbaccpts
+
+  integer(i_kind) nprvcount_wbias,mmax_wbias,ncountall_wbias
+  integer(i_kind),allocatable,dimension(:,:):: nmbegin_wbias,nmlast_wbias
+
+  integer(i_kind) kx_save
+  real(r_kind),save::usage_rj_save
+  character(16),allocatable,dimension(:)::cprovider_wind
+  character(16),allocatable,dimension(:)::cprovider_gust
+  character(8),allocatable,dimension(:,:):: sfcuselist_stninfo
+  character(1),allocatable,dimension(:,:):: sfcuselist_useflg
+  character(10),save::obstype_save
+  character(8),save::cstation_save,cprovider_save,csprovider_save
 
   logical gsdsfclistexist
   logical gsdsfcproviderlistexist
@@ -90,6 +108,11 @@ module sfcobsqc
   logical q_night_listexist
   logical wbinlistexist
   logical vis_uselistexist
+  logical windbiascorlist
+
+  logical sfc_uselistexist
+  logical sfcprovider_windlistexist
+  logical sfcprovider_gustlistexist
 
   public init_rjlists
   public get_usagerj
@@ -97,11 +120,17 @@ module sfcobsqc
   public readin_rjlists
   public get_sunangle
   public get_wbinid
+  public readin_wbiaslist
+  public get_wbias_afactor
   public destroy_rjlists
 
   public init_gsd_sfcuselist
   public apply_gsd_sfcuselist
   public destroy_gsd_sfcuselist
+
+  public init_sfcuselist
+  public apply_sfcuselist
+  public destroy_sfcuselist
 
   logical :: verbose = .false.
 contains
@@ -332,6 +361,342 @@ subroutine apply_gsd_sfcuselist(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
    end if
 
 end subroutine apply_gsd_sfcuselist
+
+subroutine init_sfcuselist
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    init_sfcuselist
+!   prgmmr:
+!
+! abstract: read in GSD surface observation uselist 
+!
+! program history log:
+!   2024-02-26  pondeca - initial code
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+  use mpimod, only: mype
+
+  implicit none
+
+!Declare local parameters
+  character(1),parameter::cblank=' ' 
+  character(8),parameter::cblank8='        ' 
+
+!Declare local variables
+  integer(i_kind) use_unit,n,nskip
+  character(150) cstring
+  character(80) clistname
+
+  integer(i_kind), parameter::nmetadata=3 !order is station id, prv, sprv
+  integer(i_kind), parameter::nparm=5     !order is: w,t,td,gust,ps
+
+  data use_unit / 777_i_kind /
+!**************************************************************************
+  if (mype==0) verbose =.true.
+  inquire(file='sfcobs_uselist.txt',exist=sfc_uselistexist)
+  if(sfc_uselistexist) then
+    open (use_unit,file='sfcobs_uselist.txt',form='formatted')
+    nskip=0
+    nt_sfcuse=0
+    read_use: do
+      read(use_unit,'(a150)',end=7745) cstring
+      if(cstring(1:1) == ';') then ;  nskip=nskip+1 ; cycle read_use ; endif    ! skip comments marked as ;
+      nt_sfcuse=nt_sfcuse+1
+    end do read_use
+7745 continue
+    if (verbose) print*,'in init_sfcuselist,nskip,nt_sfcuse=',nskip,nt_sfcuse
+
+    allocate ( sfcuselist_stninfo  (max(1,nt_sfcuse),nmetadata) )
+    allocate ( sfcuselist_useflg   (max(1,nt_sfcuse),nparm) )
+
+    rewind(use_unit)
+    do n=1,nskip
+      read(use_unit,'(a150)') cstring
+    enddo
+
+    do n=1,nt_sfcuse
+       read(use_unit,'(a150)',end=7745) cstring
+
+       sfcuselist_stninfo  (n,1)(1:8) = cstring(1:8)
+       sfcuselist_stninfo  (n,2)(1:8) = cstring(10:17)
+       sfcuselist_stninfo  (n,3)(1:8) = cstring(19:26) 
+       if (trim(sfcuselist_stninfo(n,3))=="EMPTY") sfcuselist_stninfo(n,3)=cblank8
+
+       sfcuselist_useflg   (n,1)(1:1) = cstring(45:45)
+       sfcuselist_useflg   (n,2)(1:1) = cstring(47:47)
+       sfcuselist_useflg   (n,3)(1:1) = cstring(49:49)
+       sfcuselist_useflg   (n,4)(1:1) = cstring(51:51)
+       sfcuselist_useflg   (n,5)(1:1) = cstring(53:53)
+    enddo
+  endif
+  close(use_unit)
+
+  if(verbose) then 
+     print*,' -----sample accept list printing-----'
+     print*,'sfcuselist_stninfo(n,:),sfcuselist_useflg(n,:)'
+    do n=1,min(15,nt_sfcuse)
+       print'(3(1x,a8),5(1x,a1))',sfcuselist_stninfo(n,1),&
+                                  sfcuselist_stninfo(n,2),&
+                                  sfcuselist_stninfo(n,3),&
+                                  sfcuselist_useflg(n,1),&
+                                  sfcuselist_useflg(n,2),&
+                                  sfcuselist_useflg(n,3),&
+                                  sfcuselist_useflg(n,4),&
+                                  sfcuselist_useflg(n,5)
+    enddo
+  endif
+
+  allocate(cprovider_wind(500))
+  allocate(cprovider_gust(500))
+
+!==> Read mesonet provider names from the uselist for uv
+  clistname='sfcobs_windprovider.txt'
+  call readin_rjlists(clistname,sfcprovider_windlistexist,cprovider_wind,500,nprov_wind)
+  if(verbose)&
+    print*,'mesonetproviderlist/uv: providerlist,nprov_wind=',sfcprovider_windlistexist,nprov_wind
+
+!==> Read mesonet provider names from the uselist for gust
+  clistname='sfcobs_gustprovider.txt'
+  call readin_rjlists(clistname,sfcprovider_gustlistexist,cprovider_gust,500,nprov_gust)
+  if(verbose)&
+    print*,'mesonetproviderlist/gust: providerlist,nprov_gust=',sfcprovider_gustlistexist,nprov_gust
+
+  kx_save=0
+  obstype_save=cblank8//cblank//cblank
+  cstation_save=cblank8
+  cprovider_save=cblank8
+  csprovider_save=cblank8
+  usage_rj_save=9999._r_kind
+
+end subroutine init_sfcuselist
+
+subroutine destroy_sfcuselist
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    destroy_sfcuselist
+!   prgmmr:
+!
+! abstract:
+!
+! program history log:
+!   2024-02-26  pondeca - initial code 
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+  implicit none
+
+  if ( allocated (sfcuselist_stninfo) )  deallocate (sfcuselist_stninfo ) 
+  if ( allocated (sfcuselist_useflg ) )  deallocate (sfcuselist_useflg   )
+  deallocate(cprovider_wind)
+  deallocate(cprovider_gust)
+
+end subroutine destroy_sfcuselist
+
+subroutine apply_sfcuselist(kx,obstype,c_station_id_in,c_prvstg_in,c_sprvstg_in, &
+                       dlon,dlat,usage_rj)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    apply_sfcuselist
+!   prgmmr:
+!
+! abstract: use surface observation uselist to decide
+!           which surface observation should be used in the analysis
+!
+! program history log:
+!   2024-02-26  pondeca - initial code 
+!
+!   input argument list:
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+  use gridmod, only: twodvar_regional,tll2xy
+  use ndfdgrids, only: valley_adjustment
+  implicit none
+
+  integer(i_kind),intent(in   ) :: kx
+  character(10)  ,intent(in   ) :: obstype
+  character(8)   ,intent(in   ) :: c_station_id_in
+  character(8)   ,intent(in   ) :: c_prvstg_in,c_sprvstg_in
+  real(r_kind)   ,intent(in   ) :: dlon
+  real(r_kind)   ,intent(in   ) :: dlat
+  real(r_kind)   ,intent(inout) :: usage_rj
+
+! Declare local variables
+  integer(i_kind) k,m,m0,nlen1,nlen2,nlen3,mlen1,mlen2,mlen3
+  real(r_kind) usage_rj0
+  real(r_kind) xob,yob
+  logical lwind
+  logical outside
+
+! Declare local parameters
+  real(r_kind),parameter:: r6    = 6.0_r_kind
+  real(r_kind),parameter:: r5000 = 5000._r_kind
+  character(1),parameter::cblank=' ' 
+  character(8) c_station_id,c_prvstg,c_sprvstg
+
+  if(.not.sfcprovider_windlistexist.and..not.sfcprovider_gustlistexist .and. & 
+      .not.sfc_uselistexist .and. .not.vis_uselistexist) return
+
+  lwind=obstype.eq.'uv'.or.obstype.eq.'wspd10m'.or.obstype.eq.'uwnd10m'.or.obstype.eq.'vwnd10m'
+
+  if (obstype.ne.'t'.and.obstype.ne.'q'.and.obstype.ne.'ps' & 
+                    .and.obstype.ne.'gust'.and..not.lwind.and.obstype.ne.'vis') return
+
+  if (usage_rj >= r6) return  
+
+  usage_rj0=usage_rj !save incoming usage value
+
+  c_station_id=c_station_id_in
+  c_prvstg=c_prvstg_in
+  c_sprvstg=c_sprvstg_in
+!
+!==>mesonet station names may have obsproc added empty spaces following the original staton name
+!and then an "a" or "x" at the eigth place. the step below is to ensure we are working with the
+!original station name.
+!
+  if (kx==188.or.kx==195.or.kx==288.or.kx==295) then
+     if ( c_station_id(7:7)==cblank.and. & 
+          (c_station_id(8:8)=="a".or.c_station_id(8:8)=="x") ) c_station_id(8:8)=cblank
+  endif
+!       
+!==>regularize specific provider/suprovider which is known to come with
+!   strange, illegible characters
+!
+  if (c_prvstg(1:4)=='B7Hv' .or. c_prvstg(5:8)=='vH7B') then
+      c_prvstg(1:4)='B7Hv'
+      write(c_prvstg(k:k),'(a1)') (cblank, k=5,8)
+  endif
+         
+  if (c_sprvstg(1:4)=='B7Hv' .or. c_sprvstg(5:8)=='vH7B') then
+      c_sprvstg(1:4)='B7Hv'
+      write(c_sprvstg(k:k),'(a1)') (cblank, k=5,8)
+  endif
+!
+!==> for multiple reports, get previouly determined usage_rj value and get out.
+!    optiizes code for the case of mu;tiple reports occuring sequentially in the 
+!    observtaion file, as is usually the case.
+!
+  if (kx==kx_save .and. & 
+                  obstype == obstype_save .and. & 
+                  c_station_id == cstation_save .and. &  
+                  c_prvstg == cprovider_save .and. & 
+                  c_sprvstg == csprovider_save)  then
+      usage_rj=usage_rj_save
+      return
+  endif
+!
+!==>now apply accept lists. start by assuming that incoming ob is bad, and bring it
+!   back into the assimilation only if it is contained in one of the uselists
+
+  usage_rj= r5000
+
+!==> apply provider use list for vector wind
+!
+  if(sfcprovider_windlistexist .and.lwind .and.(kx==288.or.kx==295)) then
+     do m=1,nprov_wind
+        if (c_prvstg(1:8) == cprovider_wind(m)(1:8) .and. &
+           (c_sprvstg(1:8) == cprovider_wind(m)(9:16) .or. &
+            cprovider_wind(m)(9:16) == 'allsprvs') ) then
+              usage_rj=usage_rj0
+              exit
+        endif
+     enddo
+  endif
+!
+!==> apply provider use list for wind gust
+!
+  if(sfcprovider_gustlistexist .and.obstype=='gust' .and.(kx==188.or.kx==288.or.kx==195.or.kx==295)) then
+     do m=1,nprov_gust
+        if (c_prvstg(1:8) == cprovider_gust(m)(1:8) .and. &
+           (c_sprvstg(1:8) == cprovider_gust(m)(9:16) .or. &
+            cprovider_gust(m)(9:16) == 'allsprvs') ) then
+              usage_rj=usage_rj0
+              exit
+        endif
+     enddo
+  endif
+!
+!==>apply station uselist
+!
+  if(sfc_uselistexist .and. (lwind.or.obstype=='t'.or.obstype=='q'.or.obstype=='ps') .and. usage_rj/=usage_rj0) then
+     select case(obstype)
+        case('uv','wspd10m','uwnd10m','vwnd10m')   ; m0=1
+        case('t')    ; m0=2
+        case('q')    ; m0=3
+        case('gust') ; m0=4
+        case('ps')   ; m0=5
+     end select
+
+     usage_rj= r5000
+     do m=1,nt_sfcuse
+        nlen1=len_trim(sfcuselist_stninfo(m,1)) !station id
+        nlen2=len_trim(sfcuselist_stninfo(m,2)) !provider
+        nlen3=len_trim(sfcuselist_stninfo(m,3)) !subprovider
+
+        mlen1=len_trim(c_station_id)
+        mlen2=len_trim(c_prvstg)
+        mlen3=len_trim(c_sprvstg)
+           
+        if (nlen1==mlen1 .and. nlen2==mlen2 .and. nlen3==mlen3 .and. &  
+            c_station_id (1:nlen1) == sfcuselist_stninfo(m,1) (1:nlen1) .and. &
+            c_prvstg     (1:nlen2) == sfcuselist_stninfo(m,2) (1:nlen2) .and. &
+            c_sprvstg    (1:nlen3) == sfcuselist_stninfo(m,3) (1:nlen3) )  then
+
+            if(sfcuselist_useflg(m,m0)=='1') usage_rj= usage_rj0
+          exit
+     endif
+     enddo
+  endif
+!
+!==> station uselist for mesonet visibility
+
+  if (vis_uselistexist .and. obstype=='vis' .and.(kx==188.or.kx==288.or.kx==195.or.kx==295) ) then
+     usage_rj=r5000
+     do m=1,nsta_mesovis_use
+        nlen1=len_trim(csta_visuse(m))
+        if (c_station_id(1:nlen1) == csta_visuse(m)(1:nlen1)) then
+           usage_rj=usage_rj0
+           exit
+        endif
+     enddo
+  end if
+
+  if (twodvar_regional) then
+     call tll2xy(dlon,dlat,xob,yob,outside)
+     if ((obstype=='t' .or. obstype=='q') .and. .not.outside) call valley_adjustment(xob,yob,usage_rj)
+  endif
+!
+  kx_save=kx
+  obstype_save=obstype
+  cstation_save=c_station_id
+  cprovider_save=c_prvstg 
+  csprovider_save=c_sprvstg
+  usage_rj_save=usage_rj
+!
+end subroutine apply_sfcuselist
 
 subroutine init_rjlists
 !$$$  subprogram documentation block
@@ -578,6 +943,15 @@ subroutine init_rjlists
  endif
  close(meso_unit)
 
+!==> Read in multiplicative factor for mesonet wind bias correction
+ inquire(file='stnwindbiascor',exist=windbiascorlist)
+ if(windbiascorlist) then 
+    clistname='stnwindbiascor'
+    call readin_wbiaslist(clistname)
+!    if(verbose)&
+     print*,'ncountall_wbias=',ncountall_wbias
+ endif
+
 end subroutine init_rjlists
 
 subroutine get_usagerj(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
@@ -635,7 +1009,7 @@ subroutine get_usagerj(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
   real(r_kind)   ,intent(inout) :: usage_rj
 
 ! Declare local variables
-  integer(i_kind) m,nlen
+  integer(i_kind) k,m,nlen,nlen2
   integer(i_kind) ibin
   character(8)  ch8
   real(r_kind) usage_rj0
@@ -650,6 +1024,7 @@ subroutine get_usagerj(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
   real(r_kind),parameter:: r6000 = 6000._r_kind
   real(r_kind),parameter:: r6100 = 6100._r_kind
   real(r_kind),parameter:: r6200 = 6200._r_kind
+  character(1),parameter::cblank=' '
 
   if (usage_rj >= r6) return
 
@@ -865,7 +1240,9 @@ subroutine get_usagerj(kx,obstype,c_station_id,c_prvstg,c_sprvstg, &
             do m=1,nwbaccpts(ibin)
               ch8(1:8)=csta_windbin(m,ibin)(1:8)
               nlen=len_trim(ch8)
-              if (c_station_id(1:nlen)==ch8(1:nlen)) then
+              nlen2=0
+              do k=1,8 ; if (c_station_id(k:k)==cblank) exit ; nlen2=nlen2+1 ; enddo
+              if (nlen==nlen2 .and. c_station_id(1:nlen)==ch8(1:nlen)) then
                 usage_rj=usage_rj0
                 exit
               endif
@@ -934,7 +1311,7 @@ subroutine get_gustqm(kx,c_station_id,c_prvstg,c_sprvstg,gustqm)
   integer(i_kind) m
   character(8)  ch8
 
-  gustqm=9
+  if (kx==188 .or. kx==288 .or. kx==195 .or. kx==295 ) gustqm=9
   if (listexist) then
      do m=1,nprov
         if (cprovider(m)(1:7)=='allprvs' .or. &
@@ -971,6 +1348,203 @@ subroutine get_gustqm(kx,c_station_id,c_prvstg,c_sprvstg,gustqm)
   endif
 end subroutine get_gustqm
 
+subroutine readin_wbiaslist(clistname)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:  readin_wbiaslist 
+!   prgmmr: pondeca
+!
+! abstract: reads in content of file containing multiplicative factors
+!           for mesonet wind bias correction and get pointers for quicker
+!           access to the content of the file
+!
+! program history log:
+!   2022-20-04  pondeca - initial code
+!
+!   input argument list:
+!    clistname
+!
+!   output argument list:
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+
+  implicit none
+
+!Declare passed variables
+  character(*),intent(in)::clistname
+       
+!Declare local variables
+  character(150) cstring,cstring2,cstring3
+  character(8) cprv0,csprv0
+  integer(i_kind) meso_unit,k,m,n,ll,mmax,nt
+
+  data meso_unit / 20 /
+!**************************************************************************
+  open (meso_unit,file=trim(clistname),form='formatted')
+
+  do ll=1,2       
+
+     !---------------------------------------!
+     !ll=1 ==> provider/subprovider counting !
+     !ll=2 ==> load pointers                 !
+     !---------------------------------------!
+
+     if (ll==2) then
+        rewind(meso_unit)
+        cprvsubprv_wbias='88888888'
+        nmbegin_wbias=-1
+        nmlast_wbias=-1
+     end if
+
+     nt=0    !counter for number of lines in input file
+     n=0     !counter for number of providers
+     mmax=0  !counter for maximum number of subproviders for any given provider
+
+     prv_count: do
+        read(meso_unit,'(a)',end=7752) cstring ; nt=nt+1 ; if (ll==2) windbiasafactor(nt)=cstring
+        if (cstring(1:8)=='PROVIDER') then
+           cprv0(1:8)=cstring(11:18)
+           n=n+1
+           m=0
+           subprv_count: do
+             read(meso_unit,'(a)',end=7752) cstring2 ; nt=nt+1 ; if (ll==2) windbiasafactor(nt)=cstring2
+             if (cstring2(1:20)=='End of provider list') exit subprv_count
+             if (cstring2(1:11)=='SUBPROVIDER') then 
+                 csprv0(1:8)=cstring2(14:21)
+                 m=m+1
+                 if (ll==2) then
+                    cprvsubprv_wbias(n,m)=cprv0//csprv0
+                    nmbegin_wbias(n,m)=nt+1
+                    nmlast_wbias(n,m)=nmbegin_wbias(n,m)
+                 end if
+                 k=0
+                 loop_counts:do
+                    read(meso_unit,'(a)',end=7752) cstring3 ; nt=nt+1 ; if (ll==2) windbiasafactor(nt)=cstring3
+                    if (cstring3(1:23)=='End of subprovider list') exit loop_counts
+                    k=k+1
+                 end do loop_counts
+                 if (ll==2 .and. k > 0) nmlast_wbias(n,m)=nmbegin_wbias(n,m)+(k-1)
+                 if (ll==1 .and. verbose) print'(a,2x,i3,2x,a,2x,a)','n,cprv0,csprv0=',n,trim(cprv0),trim(csprv0)
+             end if
+             if (ll==2 .and. verbose) print*,'n,m,nmbegin,nmlast=',n,m,nmbegin_wbias(n,m),nmlast_wbias(n,m)
+           end do subprv_count
+           if (ll==1 .and. verbose) print*,'n,m=',n,m
+        end if
+        mmax=max(m,mmax)
+        if (ll==1 .and. verbose) then 
+           print*,'===================================================================='
+           print*,'===================================================================='
+           print*,'===================================================================='
+        end if 
+     end do prv_count
+7752      continue
+     if (ll==1) then
+        nprvcount_wbias=n
+        mmax_wbias=mmax
+        ncountall_wbias=nt
+        if (verbose) then
+           print*,'# of providers in wind bias list=',nprvcount_wbias
+           print*,'maximum # of suproviders for a given provider in wind bias list=',mmax_wbias
+           print*,'total number of lines in wind bias list=',ncountall_wbias
+        end if
+        
+        allocate(nmbegin_wbias(nprvcount_wbias,mmax_wbias))
+        allocate(nmlast_wbias(nprvcount_wbias,mmax_wbias))
+        allocate(cprvsubprv_wbias(nprvcount_wbias,mmax_wbias))
+        allocate(windbiasafactor(ncountall_wbias))
+     endif
+  end do ! ll-loop
+  close(meso_unit)
+
+end subroutine readin_wbiaslist
+
+subroutine get_wbias_afactor(kx,obstype,c_station_id,c_prvstg,c_sprvstg,afactor)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:   get_wbias_afactor
+!   prgmmr: pondeca
+!
+! abstract: retrieve the multiplicative factor for the bias correction of the 10-m wind reports
+!
+! program history log:
+!   2022-08-04  pondeca - initial code
+!
+!   input argument list:
+!    kx
+!    obstype
+!    c_station_id
+!    c_prvstg,c_sprvstg
+!
+!   output argument list:
+!    afactor
+!
+! attributes:
+!   language: f90
+!   machine:
+!
+!$$$ end documentation block
+
+  use constants, only: one
+
+  implicit none
+
+  integer(i_kind),intent(in   ) :: kx
+  character(10)  ,intent(in   ) :: obstype
+  character(8)   ,intent(in   ) :: c_station_id
+  character(8)   ,intent(in   ) :: c_prvstg,c_sprvstg
+  real(r_kind)   ,intent(out)   :: afactor
+
+! Declare local variables
+  integer(i_kind) m,n,nlen,m0,n0,i1,i2,ipos
+  character(8)  cstn,cprv,csubprv
+  logical mesonetob
+
+! Declare local parameters
+
+  mesonetob=kx==188.or.kx==195.or.kx==288.or.kx==295
+
+  afactor=one
+
+  if (windbiascorlist) then
+     n0=0 ; m0=0
+     do n=1,nprvcount_wbias
+        if (cprvsubprv_wbias(n,1)(1:8)==c_prvstg(1:8)) then
+            n0=n ; exit
+        endif
+     enddo
+
+     if (n0 > 0 ) then
+        do m=1,mmax_wbias
+           if (cprvsubprv_wbias(n0,m)(9:16)==c_sprvstg(1:8) .or. & 
+               (cprvsubprv_wbias(n0,m)(9:13)=='EMPTY' .and. c_sprvstg=='        ')  ) then
+               m0=m ; exit
+           endif
+        enddo
+     endif
+
+     if (n0>0 .and. m0>0) then
+        i1=nmbegin_wbias(n0,m0)
+        i2=nmlast_wbias(n0,m0)
+
+        do m=i1,i2
+           cstn(1:8)=windbiasafactor(m)(1:8)
+           nlen=len_trim(cstn)
+           if ( trim(c_station_id)==trim(cstn) .or. (mesonetob.and.c_station_id(1:nlen)==cstn(1:nlen)) ) then
+              ipos=index(windbiasafactor(m),"  a=",back=.true.)
+              read (windbiasafactor(m)(ipos+4:),*) afactor
+              exit
+           endif
+        enddo
+     endif
+  endif
+end subroutine get_wbias_afactor
 
 subroutine readin_rjlists(clistname,fexist,clist,ndim,ncount)
 !$$$  subprogram documentation block
@@ -1077,6 +1651,12 @@ subroutine destroy_rjlists
   if(wbinlistexist) deallocate(nwbaccpts)
   if(wbinlistexist) deallocate(csta_windbin)
   deallocate(csta_visuse)
+  if(windbiascorlist) then
+     deallocate(windbiasafactor)
+     deallocate(nmbegin_wbias)
+     deallocate(nmlast_wbias)
+     deallocate(cprvsubprv_wbias)                                    
+  endif
 end subroutine destroy_rjlists
 
 


### PR DESCRIPTION
**Description**

**_Motivation:_**
This pull request addresses issue #865.

The changes are made to enable the inclusion of an automated quality control package in 3D-RTMA/URMA. This involves reading and applying the accept lists generated by the AutoQC package; a new option (i_gsdsfc_uselist=2) was added to read these lists. In addition, a mesonet wind bias correction algorithm is performed as part of the AutoQC package; the GSI code modifications use the output of this algorithm to adjust the raw wind speed & gust observations.

**_Summary of the Main Changes to GSI source code_**

1. src/gsi/gsimod.F90
2. src/gsi/qcmod.f90
3. src/gsi/rapidrefresh_cldsurf_mod.f90
4. src/gsi/read_prepbufr.f90
5. src/gsi/read_satwnd.f90
6. src/gsi/setupgust.f90
7. src/gsi/setupuwnd10m.f90
8. src/gsi/setupvwnd10m.f90
9. src/gsi/setupw.f90
10. src/gsi/setupwspd10m.f90
11. src/gsi/sfcobsqc.f90

**Type of change**

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

GSI CTests: The modified GSI code passes all 6 regression tests in current GSI CTest suite on WCOSS2 (Cactus) and Hera.  Please see the regression test results in issue #865.

The GSI code has also been tested in 3D-RTMA and 2D-URMA parallels, and it has been confirmed that the AutoQC output lists are being used, as expected.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published