### PR TITLE
Fixed a bug in setupq.f90 when saving Tdry for pseudo-observation of q to binary obs-diag file (applied to RTMA only)

### DIFF
--- a/src/gsi/setupq.f90
+++ b/src/gsi/setupq.f90
@@ -1323,8 +1323,8 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         rdiagbufp(21,iip) = 1e+10_r_single     ! spread (filled in by EnKF)
 
         if (l_rtma3d .or. twodvar_regional) then  ! in binary obsdiag for 2D/3DRTMA
-          rdiagbufp(22,ii) = data(itemp,i)    ! dry temperature associated to qob
-          rdiagbufp(23,ii) = data(iqt,  i)    ! tv flag (0: virtual temp; 1: sensible temp)
+          rdiagbufp(22,iip) = data(itemp,i)    ! dry temperature associated to qob
+          rdiagbufp(23,iip) = data(iqt,  i)    ! tv flag (0: virtual temp; 1: sensible temp)
         end if
 
         ioff=ioff0


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

### Description

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->
_**Background**_
It was found that in the binary observation diagnostic file of 3DRTMA , the value of dry-bulb temperature (hereafter as Tdry) associated with a pseudo observation of moisture (q) is a non-sense random number. This Tdry does not get involved in any GSI analysis inside GSI, so it has no influence on the analysis. But it could be a concern for RTMA QC developer when using the information in obs-diag file. 

_**Method**_ 
A bug was found in setupq.f90, when assign the Tdry into the obs-diag array,
in subroutine contents_binary_diagp_, for dry temperature info of pseudo obs of q,

`1323         rdiagbufp(21,**_iip_**) = 1e+10_r_single     ! spread (filled in by EnKF)`
`1324                                                                                           `
`1325         if (l_rtma3d .or. twodvar_regional) then  ! in binary obsdiag for 2D/3DRTMA`
`1326    rdiagbufp(22,**_ii_**) = data(itemp,i)    ! dry temperature associated to qob`
`1327    rdiagbufp(23,**_ii_**) = data(iqt,  i)    ! tv flag (0: virtual temp; 1: sensible temp)`

  the 2nd subscript of array rdiagbufp is "**_ii_**". This is incorrect, comparing to the lines of code above in the same subroutine for pseudo obs. It should be '**_iip_**'. Just simple changes in two lines can fix this bug.

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->
Fixes #889

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

1. This Tdry is only saved in obs-diag file for pseudo obs of q. It is never used in GSI analysis, so this bug does not affect the analysis of GSI. And this Tdry information is only saved for RTMA run. So this modification also has no impact on the GSI analysis. Even so, we still run GSI CTest on WCOSS2 (Dogwood) and Hera. All the 6 tasks passed on both machines. The following are the brief results of GSI Ctest on Hera and WCOSS2 (Dogwood):
        <details><summary>GSI  CTest results on **_Hera_**</summary>
        <p>
(work-env2) [Gang.Zhao@hfe10:build] (bug/rtma3d_TdryInObsDiag)$ ctest -N
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
  Test # 1: global_4denvar
  Test # 2: rtma
  Test # 3: rrfs_3denvar_rdasens
  Test # 4: hafs_4denvar_glbens
  Test # 5: hafs_3denvar_hybens
  Test # 6: global_enkf
Total Tests: 6
(work-env2) [Gang.Zhao@hfe10:build] (bug/rtma3d_TdryInObsDiag)$ ctest -j 6
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test # 3: rrfs_3denvar_rdasens .............***Failed  613.97 sec
2/6 Test # 2: rtma .............................   Passed  970.15 sec
3/6 Test # 5: hafs_3denvar_hybens ..............   Passed  1103.10 sec
4/6 Test # 6: global_enkf ......................   Passed  1170.58 sec
5/6 Test # 4: hafs_4denvar_glbens ..............   Passed  1228.66 sec
6/6 Test # 1: global_4denvar ...................   Passed  1971.01 sec
83% tests passed, 1 tests failed out of 6
Total Test time (real) = 1971.04 sec
The following tests FAILED:
          3 - rrfs_3denvar_rdasens (Failed)
Errors while running CTest
Output from these tests are in: /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
(work-env2) [Gang.Zhao@hfe10:build] (bug/rtma3d_TdryInObsDiag)$ ctest -R rrfs_3denvar_rdasens
Test project /scratch1/NCEPDEV/da/Gang.Zhao/ProdGSI_dev/gsi_dev/build
    Start 3: rrfs_3denvar_rdasens
1/1 Test # 3: rrfs_3denvar_rdasens .............   Passed  492.11 sec
100% tests passed, 0 tests failed out of 1
Total Test time (real) = 492.18 sec
        </p>
        </details> 
        <details><summary>GSI  CTest results on **_WCOSS2(Dogwood)_**</summary>
        <p>
[gang.zhao@dlogin01:build] (bug/rtma3d_TdryInObsDiag)$ ctest -N
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
  Test # 1: global_4denvar
  Test # 2: rtma
  Test # 3: rrfs_3denvar_rdasens
  Test # 4: hafs_4denvar_glbens
  Test # 5: hafs_3denvar_hybens
  Test # 6: global_enkf
Total Tests: 6
[gang.zhao@dlogin01:build] (bug/rtma3d_TdryInObsDiag)$ ctest -j 6
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test # 3: rrfs_3denvar_rdasens .............   Passed  736.76 sec
2/6 Test # 2: rtma .............................   Passed  1099.46 sec
3/6 Test # 5: hafs_3denvar_hybens ..............   Passed  1226.29 sec
4/6 Test # 4: hafs_4denvar_glbens ..............   Passed  1472.28 sec
5/6 Test # 6: global_enkf ......................   Passed  1479.89 sec
6/6 Test # 1: global_4denvar ...................   Passed  1928.14 sec
100% tests passed, 0 tests failed out of 6
Total Test time (real) = 1928.22 sec
        </p>
        </details> 

2. With the modified code running GSI for 3DRTMA, the Tdry of pseudo obs of q in binary obs-diag file is good and as expected.    This validate this code modification.

 **Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published