### PR TITLE
Bugfix/gsi hang

### DIFF
--- a/src/gsi/deter_sfc_mod.f90
+++ b/src/gsi/deter_sfc_mod.f90
@@ -1149,7 +1149,6 @@ subroutine deter_sfc_fov(fov_flag,ifov,instr,ichan,sat_aziang,dlat_earth_deg,&
 !    "chopped" into smaller pieces.
 
      if (sum(sfc_sum%count) == zero) then
-        close(9)
         subgrid_lengths_x = subgrid_lengths_x + 1
         subgrid_lengths_y = subgrid_lengths_y + 1
 !       print*,'NO GRID POINTS INSIDE FOV, CHOP MODEL BOX INTO FINER PIECES',subgrid_lengths_x,subgrid_lengths_y

--- a/src/gsi/radinfo.f90
+++ b/src/gsi/radinfo.f90
@@ -1834,6 +1834,7 @@ contains
       if (satsens /= satsens_id) then
          write(6,'(''INIT_PREDX:  ***ERROR*** inconsistent satellite ids '',&
               '' fdiag_rad= '',a,'' satsens,satsens_id='')')trim(fdiag_rad),satsens,satsens_id
+         deallocate(ich)
          cycle loopf
       endif
 
@@ -1846,7 +1847,10 @@ contains
             sensor_end = j
          endif
       end do
-      if ( sensor_start == 0 ) cycle loopf
+      if ( sensor_start == 0 ) then
+        deallocate(ich)
+        cycle loopf
+      endif
 
 !     Extract satinfo relative index and get new_chan
       new_chan=0
@@ -1856,6 +1860,7 @@ contains
 !     do not use this diag* file
       if ( satsens(1:6) == 'seviri' .and. header_chan(1)%nuchan < 4) then
         call close_radiag(fdiag_rad,lndiag)
+        deallocate(ich)
         cycle loopf
       endif
 
@@ -1877,6 +1882,7 @@ contains
       write(6,*) 'INIT_PREDX: inst_sat  new_chan = ', trim(fdiag_rad), new_chan
       if (.not. update .and. new_chan==0) then 
          call close_radiag(fdiag_rad,lndiag)
+         deallocate(ich)
          cycle loopf
       end if
 
@@ -2080,6 +2086,7 @@ contains
       if (new_chan/=0) then
          if (all(iobs<nthreshold)) then
             deallocate(A,b,iobs,pred)
+            deallocate(ich)
             cycle loopf
          endif
 
@@ -2126,6 +2133,8 @@ contains
          deallocate(A,b)
          deallocate(iobs,pred)
       end if
+
+      deallocate(ich)
 
 !  End of loop over satellite/sensor types
    end do loopf


### PR DESCRIPTION
**Description**

When `gsi.x` is built from NOAA-EMC/GSI after GSI PR #875, `gsi.x` hangs when running the analysis in g-w CI C48mx500_3DVarAOWCDA.  See g-w PR [#3498](#https://github.com/NOAA-EMC/global-workflow/pull/3498) for details.

Investigation found that removing an extraneous `close(9)` statement from `deter_sfc_fov` (file `src/gsi/deter_sfc_mod.f90`) allowed `gsi.x` to run to completion in the C48mx500_3DVarAOWCDA analysis.   

During this investigation it was found that subroutine `init_predx` (file `radinfo.f90`) reallocates an already allocated array, `ich`.

The changes in this PR
- remove `close(9)` from `deter_sfc_mod.f90`
- ensure `ich` is deallocated before being allocated in `radinfo.f90`

Resolves #898

**Type of change**

- [ ] Bug fix


**How Has This Been Tested?**

Two tests have been conducted
1. Run the failed C48mx500_3DVarAOWCDA gdas analysis using `gsi.x` built from the PR.  `gsi.x` runs to completion.
2. run standard suite of GSI ctests.   WCOSS2 (Dogwood) results posted below
```
Test project /lfs/h2/emc/da/noscrub/russ.treadon/git/gsi/bugfix/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test #3: rrfs_3denvar_rdasens .............   Passed  795.14 sec
2/6 Test #6: global_enkf ......................   Passed  918.86 sec
3/6 Test #2: rtma .............................   Passed  1096.69 sec
4/6 Test #5: hafs_3denvar_hybens ..............   Passed  1224.75 sec
5/6 Test #4: hafs_4denvar_glbens ..............   Passed  1462.76 sec
6/6 Test #1: global_4denvar ...................   Passed  1984.28 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) = 1984.30 sec
```
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass with my changes