### PR TITLE
Deallocate arrays before cycling the prod_bias loop

### DIFF
--- a/modulefiles/gsi_orion.intel.lua
+++ b/modulefiles/gsi_orion.intel.lua
@@ -17,6 +17,9 @@ load(pathJoin("cmake", cmake_ver))
 
 load("gsi_common")
 
+unload("intel-oneapi-mpi/2021.13.1")
+load("intel-oneapi-mpi/2021.7.1")
+
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 

--- a/modulefiles/gsi_wcoss2.intel.lua
+++ b/modulefiles/gsi_wcoss2.intel.lua
@@ -41,15 +41,7 @@ load(pathJoin("netcdf-D", netcdf_ver))
 load(pathJoin("bufr", bufr_ver))
 load(pathJoin("bacio", bacio_ver))
 load(pathJoin("w3emc", w3emc_ver))
---load(pathJoin("ip", ip_ver))
--- Temporarily define IP's paths here.
--- TODO when testing is complete, request an official installation in https://github.com/NOAA-EMC/WCOSS2-requests/issues/11
-pushenv("ip_ROOT", pathJoin("/apps/ops/para/libs/intel/19.1.3.304/ip", ip_ver))
-pushenv("IP_INC4", pathJoin("/apps/ops/para/libs/intel/19.1.3.304/ip", ip_ver, "include_4"))
-pushenv("IP_INCd", pathJoin("/apps/ops/para/libs/intel/19.1.3.304/ip", ip_ver, "include_d"))
-pushenv("IP_LIB4", pathJoin("/apps/ops/para/libs/intel/19.1.3.304/ip", ip_ver, "lib64/libip_4.a"))
-pushenv("IP_LIBd", pathJoin("/apps/ops/para/libs/intel/19.1.3.304/ip", ip_ver, "lib64/libip_d.a"))
-pushenv("ip_VERSION", ip_ver)
+load(pathJoin("ip", ip_ver))
 
 load(pathJoin("sigio", sigio_ver))
 load(pathJoin("sfcio", sfcio_ver))

--- a/src/gsi/prad_bias.f90
+++ b/src/gsi/prad_bias.f90
@@ -311,6 +311,7 @@ contains
         AA(i,i) = AA(i,i)+one/varprd(jj)
      end do
      if (all(abs(AA)<atiny) .or. all(abs(be)<atiny)) then
+        ! Deallocate before cycling to prevent re-allocation
         deallocate(AA,be)
         cycle
      endif

--- a/src/gsi/prad_bias.f90
+++ b/src/gsi/prad_bias.f90
@@ -310,8 +310,10 @@ contains
         jj=(mm-1)*npred+ii
         AA(i,i) = AA(i,i)+one/varprd(jj)
      end do
-     if (all(abs(AA)<atiny)) cycle
-     if (all(abs(be)<atiny)) cycle
+     if (all(abs(AA)<atiny) .or. all(abs(be)<atiny)) then
+        deallocate(AA,be)
+        cycle
+     endif
      call linmm(AA,be,kpred,1,kpred,kpred)
 
 


### PR DESCRIPTION
**Description**
This deallocates the `AA` and `be` arrays in the `prad_bias` loop to prevent reallocating the same arrays more than once.

Also, replace the variable definitions in `gsi_wcoss2.intel.lua` with the module load for `ip/5.2.0`.

Resolves #904 
Resolves #896 
**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Ran a test in the global workflow for a `C96_atm3dvar` test case.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes