### PR TITLE
update GSI_BINARY_SOURCE_DIR to be consistent with g-w

### DIFF
--- a/modulefiles/gsi_acorn.intel.lua
+++ b/modulefiles/gsi_acorn.intel.lua
@@ -57,6 +57,6 @@ load(pathJoin("ncdiag",ncdiag_ver))
 append_path("MODULEPATH", "/lfs/h1/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack/modulefiles/compiler/intel/19.1.3.304")
 load(pathJoin("crtm", crtm_ver))
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20241022")
+pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20250529")
 
 whatis("Description: GSI environment on WCOSS2 Acorn")

--- a/modulefiles/gsi_gaeac6.intel.lua
+++ b/modulefiles/gsi_gaeac6.intel.lua
@@ -15,7 +15,7 @@ load(pathJoin("cmake", cmake_ver))
 
 load("gsi_common")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/gpfs/f6/bil-fire8/world-shared/GSI_data/fix/gsi/20241022")
+pushenv("GSI_BINARY_SOURCE_DIR", "/gpfs/f6/drsa-precip3/world-shared/role.glopara/fix/gsi/20250529")
 
 setenv("CC","cc")
 setenv("FC","ftn")

--- a/modulefiles/gsi_hera.intel.lua
+++ b/modulefiles/gsi_hera.intel.lua
@@ -23,6 +23,6 @@ load("impi/2022.1.2")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/scratch1/NCEPDEV/global/glopara/fix/gsi/20241022")
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch3/NCEPDEV/global/role.glopara/fix/gsi/20250529")
 
 whatis("Description: GSI environment on Hera with Intel Compilers")

--- a/modulefiles/gsi_hercules.intel.lua
+++ b/modulefiles/gsi_hercules.intel.lua
@@ -25,6 +25,6 @@ load("tar/1.34")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20241022")
+pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
 
 whatis("Description: GSI environment on Hercules with Intel Compilers")

--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -25,6 +25,6 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20241022")
+pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20250529")
 
 whatis("Description: GSI environment on NOAA Cloud with Intel Compilers")

--- a/modulefiles/gsi_orion.intel.lua
+++ b/modulefiles/gsi_orion.intel.lua
@@ -23,6 +23,6 @@ load("intel-oneapi-mpi/2021.7.1")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20241022")
+pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
 
 whatis("Description: GSI environment on Orion with Intel Compilers")

--- a/modulefiles/gsi_ursa.intel.lua
+++ b/modulefiles/gsi_ursa.intel.lua
@@ -17,6 +17,6 @@ load(pathJoin("cmake", cmake_ver))
 
 load("gsi_common")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/scratch3/NCEPDEV/global/role.glopara/fix/gsi/20250430")
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch3/NCEPDEV/global/role.glopara/fix/gsi/20250529")
 
 whatis("Description: GSI environment on Ursa with Intel Compilers")

--- a/modulefiles/gsi_wcoss2.intel.lua
+++ b/modulefiles/gsi_wcoss2.intel.lua
@@ -51,6 +51,6 @@ load(pathJoin("ncio-A", ncio_ver))
 load(pathJoin("crtm", crtm_ver))
 load(pathJoin("ncdiag-A",ncdiag_ver))
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20241022")
+pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20250529")
 
 whatis("Description: GSI environment on WCOSS2")

--- a/ush/sub_hera
+++ b/ush/sub_hera
@@ -88,10 +88,10 @@ output=${output:-$jobname.out}
 myuser=$LOGNAME
 myhost=$(hostname)
 
-if [ -d /scratch1/NCEPDEV/stmp4/$LOGNAME ]; then
-  DATA=/scratch1/NCEPDEV/stmp4/$LOGNAME/tmp
-elif [ -d /scratch2/BMC/gsienkf/$LOGNAME ]; then
-  DATA=/scratch2/BMC/gsienkf/$LOGNAME/tmp/tmp
+if [ -d /scratch4/NCEPDEV/stmp/$LOGNAME ]; then
+  DATA=/scratch4/NCEPDEV/stmp/$LOGNAME/tmp
+elif [ -d /scratch4/BMC/gsienkf/$LOGNAME ]; then
+  DATA=/scratch4/BMC/gsienkf/$LOGNAME/tmp/tmp
 fi
 DATA=${DATA:-$ptmp/tmp}
 

--- a/ush/sub_ursa
+++ b/ush/sub_ursa
@@ -88,10 +88,10 @@ output=${output:-$jobname.out}
 myuser=$LOGNAME
 myhost=$(hostname)
 
-if [ -d /scratch1/NCEPDEV/stmp4/$LOGNAME ]; then
-  DATA=/scratch1/NCEPDEV/stmp4/$LOGNAME/tmp
-elif [ -d /scratch2/BMC/gsienkf/$LOGNAME ]; then
-  DATA=/scratch2/BMC/gsienkf/$LOGNAME/tmp/tmp
+if [ -d /scratch4/NCEPDEV/stmp/$LOGNAME ]; then
+  DATA=/scratch4/NCEPDEV/stmp/$LOGNAME/tmp
+elif [ -d /scratch4/BMC/gsienkf/$LOGNAME ]; then
+  DATA=/scratch4/BMC/gsienkf/$LOGNAME/tmp/tmp
 fi
 DATA=${DATA:-$ptmp/tmp}
 


### PR DESCRIPTION
**Description**
This PR updates the `GSI_BINARY_SOURCE_DIR` in machine specific GSI modulefiles to be consistent with g-w.  

References to `/scratch1` and `/scratch2` were found while running ctests on Hera.  These fileset will be taken offline in early August 2025.  As such, references to these filesets are replaced with `/scratch3` and `/scratch4` in this PR.

Resolves #907
 
**Type of change**

Please delete options that are not relevant.

- [ ] Maintenance


**How Has This Been Tested?**

The standard suite of ctests have been run on various machines
  
**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass with my changes