### PR TITLE
Update MSU modulefiles to use intel ifort instead of intel LLVM

### DIFF
--- a/modulefiles/gsi_hercules.intel.lua
+++ b/modulefiles/gsi_hercules.intel.lua
@@ -2,6 +2,7 @@ help([[
 ]])
 
 prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/gcc/13.3.0")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"
@@ -22,8 +23,9 @@ load("intel-oneapi-mpi/2021.7.1")
 
 load("tar/1.34")
 
-pushenv("CFLAGS", "-xHOST")
-pushenv("FFLAGS", "-xHOST")
+setenv("CC","mpiicc")
+setenv("CXX","mpiicpc")
+setenv("FC","mpiifort")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
 

--- a/modulefiles/gsi_orion.intel.lua
+++ b/modulefiles/gsi_orion.intel.lua
@@ -2,6 +2,7 @@ help([[
 ]])
 
 prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/gcc/13.3.0")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"
@@ -20,8 +21,11 @@ load("gsi_common")
 unload("intel-oneapi-mpi/2021.13.1")
 load("intel-oneapi-mpi/2021.7.1")
 
-pushenv("CFLAGS", "-xHOST")
-pushenv("FFLAGS", "-xHOST")
+load("tar/1.34")
+
+setenv("CC","mpiicc")
+setenv("CXX","mpiicpc")
+setenv("FC","mpiifort")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
 

--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -87,11 +87,11 @@ case $machine in
       export accnt="${accnt:-GFS-DEV}"
   ;;
   Orion | Hercules)
-      export local_or_default="${local_or_default:-/work/noaa/da/$LOGNAME}"
+      export local_or_default="${local_or_default:-/work2/noaa/da/$LOGNAME}"
       if [ -d $local_or_default ]; then
          export noscrub="$local_or_default/noscrub"
-      elif [ -d /work/noaa/global/$LOGNAME ]; then
-         export noscrub="/work/noaa/global/$LOGNAME/noscrub"
+      elif [ -d /work2/noaa/global/$LOGNAME ]; then
+         export noscrub="/work2/noaa/da/$LOGNAME/noscrub"
       fi
 
       export queue="${queue:-batch}"
@@ -104,11 +104,11 @@ case $machine in
 
       export group="${group:-global}"
       if [[ "$cmaketest" = "false" ]]; then
-         export basedir="/work/noaa/da/$LOGNAME/gsi"
+         export basedir="/work2/noaa/da/$LOGNAME/gsi"
       fi
-      export ptmp="${ptmp:-/work/noaa/stmp/$LOGNAME/${machine}/$ptmpName}"
+      export ptmp="${ptmp:-/work2/noaa/stmp/$LOGNAME/${machine}/$ptmpName}"
 
-      export casesdir="/work/noaa/da/rtreadon/CASES/regtest"
+      export casesdir="/work2/noaa/da/rtreadon/CASES/regtest"
 
       export check_resource="no"
       export accnt="${accnt:-da-cpu}"


### PR DESCRIPTION
**Description**

This PR updates `gsi_orion.intel.lua` and `gsi_hercules.intel.lua` to use 
```
Intel 2021.1.0.2024070
```
instead of
```
IntelLLVM 2024.2.1
```
to compiler fortran source code files.

An additional change is to move MSU ctests `/work` to `/work2`.  The `/work2` fileset has generally better i/o performance.

Resolves #910 

**Type of change**

- [ ] Maintenance

**How Has This Been Tested?**

Run ctest on Orion and Hercules with changes.  All tests pass on both machines.

Not all GSI ctests cases pass when built with `develop` which uses the IntelLLVM 2024.2.1 fortran compiler.  All ctests pass when using the  Intel 2021.1.0.2024070 fortran compiler.

  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes
