### PR TITLE
Update Hera filesets used by ctests

### DIFF
--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -115,24 +115,24 @@ case $machine in
   ;;
   Hera)
 
-    export local_or_default="${local_or_default:-/scratch1/NCEPDEV/da/$LOGNAME}"
+    export local_or_default="${local_or_default:-/scratch3/NCEPDEV/da/$LOGNAME}"
     if [ -d $local_or_default ]; then
       export noscrub="$local_or_default/noscrub"
-    elif [ -d /scratch1/NCEPDEV/global/$LOGNAME ]; then
-      export noscrub="/scratch1/NCEPDEV/global/$LOGNAME/noscrub"
-     elif [ -d /scratch2/BMC/gsienkf/$LOGNAME ]; then
-      export noscrub="/scratch2/BMC/gsienkf/$LOGNAME"
+    elif [ -d /scratch3/NCEPDEV/global/$LOGNAME ]; then
+      export noscrub="/scratch3/NCEPDEV/global/$LOGNAME/noscrub"
+     elif [ -d /scratch4/BMC/gsienkf/$LOGNAME ]; then
+      export noscrub="/scratch4/BMC/gsienkf/$LOGNAME"
     fi
 
     export group="${group:-global}"
     export queue="${queue:-batch}"
     if [[ "$cmaketest" = "false" ]]; then
-      export basedir="/scratch1/NCEPDEV/da/$LOGNAME/git/gsi"
+      export basedir="/scratch3/NCEPDEV/da/$LOGNAME/git/gsi"
     fi
 
-    export ptmp="${ptmp:-/scratch1/NCEPDEV/stmp2/$LOGNAME/$ptmpName}"
+    export ptmp="${ptmp:-/scratch3/NCEPDEV/stmp/$LOGNAME/${machine}/$ptmpName}"
 
-    export casesdir="/scratch1/NCEPDEV/da/Russ.Treadon/CASES/regtest"
+    export casesdir="/scratch3/NCEPDEV/da/Russ.Treadon/CASES/regtest"
 
     export check_resource="no"
     export accnt="${accnt:-da-cpu}"


### PR DESCRIPTION
**Description**

This PR replaces references to `/scratch1` and `/scratch2` with `/scratch3` and `/scratch4` for Hera ctests.  The  `/scratch1` and `/scratch2` filesets are scheduled to be decommissioned on 8/5/2025.

Resolves #912

**Type of change**
- [x] Maintenance

**How Has This Been Tested?**

Install `bugfix/hera` at 51dd9ee6 on Hera.  Run ctests.  [All tests pass](https://github.com/NOAA-EMC/GSI/issues/912#issuecomment-3140594763).  Confirm that ctests run in `/scratch3`.  Check job log files and do not find any references to `/scratch1` or `/scratch2`.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes
