### PR TITLE
Explicitly use the Intel class compilers on Orion/Hercules

### DIFF
--- a/modulefiles/gsi_hercules.intel.lua
+++ b/modulefiles/gsi_hercules.intel.lua
@@ -25,6 +25,10 @@ load("tar/1.34")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
+setenv("CC","mpiicc")
+setenv("CXX","mpiicpc")
+setenv("FC","mpiifort")
+
 pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
 
 whatis("Description: GSI environment on Hercules with Intel Compilers")

--- a/modulefiles/gsi_orion.intel.lua
+++ b/modulefiles/gsi_orion.intel.lua
@@ -23,6 +23,10 @@ load("intel-oneapi-mpi/2021.7.1")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
+setenv("CC","mpiicc")
+setenv("CXX","mpiicpc")
+setenv("FC","mpiifort")
+
 pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
 
 whatis("Description: GSI environment on Orion with Intel Compilers")


### PR DESCRIPTION
**Description**

This makes the GSI explicitly use the Intel Clasic Fortran compilers on Orion and Hercules.

Fixes #910 
**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested in the global workflow on Orion and ctests on Orion and Hercules by @RussTreadon-NOAA.
I performed a test build on Orion and Hercules verifying the lines
```
-- The C compiler identification is IntelLLVM 2024.2.1
-- The Fortran compiler identification is Intel 2021.1.0.20240703
```
were present.
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes