### PR TITLE
Fix for runtime failure when disabling thinning for ATMS and bufrtovs data (Issue #917)

### DIFF
--- a/src/gsi/read_atms.f90
+++ b/src/gsi/read_atms.f90
@@ -74,7 +74,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
 !$$$
   use kinds, only: r_kind,r_double,i_kind
   use satthin, only: super_val,itxmax,makegrids,destroygrids,checkob, &
-      finalcheck,map2tgrid,score_crit,map2tgrid2,binit
+      finalcheck,map2tgrid,score_crit,map2tgrid2,binit,itx_all
   use satthin, only: radthin_time_info,tdiff2crit
   use obsmod,  only: time_window_max, ta2tb
   use radinfo, only: iuse_rad,newchn,cbias,nusis,jpch_rad,air_rad,ang_rad, &
@@ -195,7 +195,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   real(r_kind)    :: ptime,timeinflat,crit0,score
   integer(i_kind) :: ithin_time,n_tbin
   integer(i_kind),pointer :: it_mesh => null()
-  integer(kind=4) :: good,bin,bin2,Obindx,maxPerBin,numBinsWithObs
+  integer(kind=4) :: good,bin,bin2,Obindx,maxPerBin,numBinsWithObs,numobs
   integer(kind=4),allocatable,dimension(:)   :: binCount,binsWithObs,hash
   integer(kind=4),allocatable,dimension(:,:) :: binObs
 
@@ -532,7 +532,8 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   allocate(binCount(itxmax))
   binCount(:)=0
 
-! First scan to determine which obs fall into which bins
+! First scan to count how many obs fall in each bin.  Will use this info to allocate the binObs array
+! Consider removing all the "cycles" as that code is repeated several times
   ObsLoop: do iob=1,num_obs
 
      t4dv       => t4dv_save(iob)
@@ -582,23 +583,30 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
        ifovmod=ifov
      endif
  
-!    Map obs to thinning grid
-     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,it_mesh)
+!    Map obs to thinning grid or return immediately if ithin<=0
+     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,ithin,sis,it_mesh)
      binCount(itx2) = binCount(itx2)+1
   end do ObsLoop
 
+  !numobs=sum(binCount)
   maxPerBin=maxval(binCount)
   numBinsWithObs = count(mask=binCount>0)
-  ! Find the indices of positive elements
+
+  ! Find thinning bins with at least one observation
+  ! Packing those bins into a dense vector allows us to greatly reduce
+  ! memory useage for binObs
   allocate(binsWithObs(numBinsWithObs))
   binsWithObs = pack( (/ (i, i=1,size(binCount)) /), binCount > 0)
 
+  ! Map between physical bin index and Packed index
   allocate(hash(itxmax))
   hash=0
   do bin = 1,numBinsWithObs
     hash(binsWithObs(bin)) = bin
   enddo
 
+  !write(6,'("read_atms: numobs passing first scan" I10)') numobs
+  !write(6,'("read_atms: itx_all " I10)') itx_all
   write(6,'("read_atms: max number of obs in any bin " I10)') maxPerBin
   write(6,'("read_atms: number of bins with any obs " I10)') numBinsWithObs
 
@@ -606,6 +614,11 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   binObs(:,:)=0
   binCount(:)=0
 
+  ! Reset itx_all counter held in the satthin module
+  itx_all=0
+
+  ! Second scan to place obs within the bins that actually have obs (binObs).
+  ! This is a space saving measure since otherwise we would need to allocate a MUCH larger array
   ObsLoop2: do iob=1,num_obs
 
      t4dv       => t4dv_save(iob)
@@ -655,14 +668,20 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
        ifovmod=ifov
      endif
 
-!    Map obs to thinning grid
-     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,it_mesh)
+!    Map obs to thinning grid or return immediately if ithin<=0
+     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,ithin,sis,it_mesh)
      binCount(itx2) = binCount(itx2)+1
      binObs(binCount(itx2),hash(itx2)) = iob
   end do ObsLoop2
   deallocate(hash)
+  !numobs=sum(binCount)
+  !write(6,'("read_atms: numobs passing second scan" I10)') numobs
 
-! Second scan to determine which observation in a given bin is best to use
+  ! Reset itx_all counter held in the satthin module.  Not an issue as of 2025, but would
+  ! start to be a problem when an observation file contains more than 1/3 of itxmax observations
+  itx_all=0
+
+! Third scan to determine which observation in a given bin is best to use
   good=0
   !$omp parallel do default(none), schedule(dynamic,12), &
   !$omp& firstprivate(ich1,ich2,ich3,ich16,ich17), &
@@ -932,6 +951,7 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   end do BinLoop
   !$omp end parallel do
 
+  write(6,'("read_atms: itx_all " I10)') itx_all
   write(6,'("read_atms: Number of obs considered and accepted " 2I10)') num_obs, good
   deallocate(binCount)
   deallocate(binObs)

--- a/src/gsi/read_atms.f90
+++ b/src/gsi/read_atms.f90
@@ -951,7 +951,6 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   end do BinLoop
   !$omp end parallel do
 
-  write(6,'("read_atms: itx_all " I10)') itx_all
   write(6,'("read_atms: Number of obs considered and accepted " 2I10)') num_obs, good
   deallocate(binCount)
   deallocate(binObs)

--- a/src/gsi/read_atms.f90
+++ b/src/gsi/read_atms.f90
@@ -195,13 +195,12 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
   real(r_kind)    :: ptime,timeinflat,crit0,score
   integer(i_kind) :: ithin_time,n_tbin
   integer(i_kind),pointer :: it_mesh => null()
-  integer(kind=4) :: good,bin,bin2,Obindx,maxPerBin,numBinsWithObs,numobs
-  integer(kind=4),allocatable,dimension(:)   :: binCount,binsWithObs,hash
-  integer(kind=4),allocatable,dimension(:,:) :: binObs
+  integer(i_kind) :: good,bin,bin2,Obindx,maxPerBin,numBinsWithObs
+  integer(i_kind),allocatable,dimension(:)   :: binCount,binsWithObs,hash
+  integer(i_kind),allocatable,dimension(:,:) :: binObs
 
 !**************************************************************************
 ! Initialize variables
-  !write(6,'("read_atms: Enter ithin is " I8)') ithin
 
   maxinfo=31
   lnbufr = 15
@@ -588,7 +587,6 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
      binCount(itx2) = binCount(itx2)+1
   end do ObsLoop
 
-  !numobs=sum(binCount)
   maxPerBin=maxval(binCount)
   numBinsWithObs = count(mask=binCount>0)
 
@@ -605,8 +603,6 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
     hash(binsWithObs(bin)) = bin
   enddo
 
-  !write(6,'("read_atms: numobs passing first scan" I10)') numobs
-  !write(6,'("read_atms: itx_all " I10)') itx_all
   write(6,'("read_atms: max number of obs in any bin " I10)') maxPerBin
   write(6,'("read_atms: number of bins with any obs " I10)') numBinsWithObs
 
@@ -674,8 +670,6 @@ subroutine read_atms(mype,val_tovs,ithin,isfcalc,&
      binObs(binCount(itx2),hash(itx2)) = iob
   end do ObsLoop2
   deallocate(hash)
-  !numobs=sum(binCount)
-  !write(6,'("read_atms: numobs passing second scan" I10)') numobs
 
   ! Reset itx_all counter held in the satthin module.  Not an issue as of 2025, but would
   ! start to be a problem when an observation file contains more than 1/3 of itxmax observations

--- a/src/gsi/read_bufrtovs.f90
+++ b/src/gsi/read_bufrtovs.f90
@@ -130,7 +130,7 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
 !
 !$$$
   use kinds, only: r_kind,r_double,i_kind
-  use satthin, only: super_val,itxmax,makegrids,destroygrids,score_crit,map2tgrid2,binit
+  use satthin, only: super_val,itxmax,makegrids,destroygrids,score_crit,map2tgrid2,binit,itx_all
   use satthin, only: radthin_time_info,tdiff2crit
   use obsmod, only: time_window_max, ta2tb
   use radinfo, only: iuse_rad,newchn,cbias,predx,nusis,jpch_rad,air_rad,ang_rad, &
@@ -843,8 +843,9 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   allocate(binCount(itxmax))
   binCount(:)=0
 
-! First scan to determine which obs fall into which bins
-  ObsLoop: do iob = 1, num_obs
+! First scan to count how many obs fall in each bin.  Will use this info to allocate the binObs array
+! Consider removing all the "cycles" as that code is repeated several times
+  ObsLoop: do iob=1,num_obs
 
      t4dv       => t4dv_save(iob)
      dlon_earth => dlon_earth_save(iob)
@@ -868,7 +869,7 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
      endif
 
 !    Map obs to thinning grid
-     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,it_mesh)
+     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,ithin,sis,it_mesh)
      binCount(itx2) = binCount(itx2)+1
   end do ObsLoop
 
@@ -895,7 +896,11 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
   binObs(:,:)=0
   binCount(:)=0
 
-! Second scan to fill binObs
+  ! Reset itx_all counter held in the satthin module
+  itx_all=0
+
+  ! Second scan to place obs within the bins that actually have obs (binObs).
+  ! This is a space saving measure since otherwise we would need to allocate a MUCH larger array
   ObsLoop2: do iob=1,num_obs
 
      t4dv       => t4dv_save(iob)
@@ -919,11 +924,15 @@ subroutine read_bufrtovs(mype,val_tovs,ithin,isfcalc,&
         if(outside) cycle ObsLoop2
      endif
 !    Map obs to thinning grid
-     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,it_mesh)
+     call binit(dlat_earth*deg2rad,dlon_earth*deg2rad,itx2,ithin,sis,it_mesh)
      binCount(itx2) = binCount(itx2)+1
      binObs(binCount(itx2),hash(itx2)) = iob
   end do ObsLoop2
   deallocate(hash)
+
+  ! Reset itx_all counter held in the satthin module.  Not an issue as of 2025, but would
+  ! start to be a problem when an observation file contains more than 1/3 of itxmax observations
+  itx_all=0
 
 ! Third scan to determine which observation in a given bin is best to use
   good=0

--- a/src/gsi/satthin.F90
+++ b/src/gsi/satthin.F90
@@ -36,12 +36,12 @@ module satthin
 !   2012-01-31  hchuang - add read_nemsnst in sub getnst
 !   2012-03-05  akella  - remove create_nst,getnst and destroy_nst; nst fields now handled by gsi_nstcoupler
 !   2015-05-01  li      - modify to use single precision for the variables read from sfc files
-!   2016-08-18  li      - tic591: when use_readin_anl_sfcmask is true,
-!                                 add read sili_anl from analysis grid/resolution sfc file (sfcf06_anl)
+!   2016-08-18  li      - tic591: when use_readin_anl_sfcmask is true, 
+!                                 add read sili_anl from analysis grid/resolution sfc file (sfcf06_anl) 
 !                                 modify to use isli_anl
-!                                 determine sno2 with interpolate, accordingly
+!                                 determine sno2 with interpolate, accordingly 
 !                                 use the modified 2d interpolation (sfc_interpolate to intrp22)
-!   2018-05-21  j.jin   - add an option for time-thinning. Check time preference (including thin4d) here.
+!   2018-05-21  j.jin   - add an option for time-thinning. Check time preference (including thin4d) here. 
 !
 !   2019-07-09  todling - revisit Li''s shuffling of nst init, read and final routines
 !   2019-08-08  j.jin   - add a comment block for an example of dtype-wise time-thinning
@@ -65,11 +65,11 @@ module satthin
 !   []_makegvals                        - set up for superob weighting
 !   []_getsfc                           - create full horizontal fields of surface arrays
 !                     []_makegrids      - set up thinning grids
-!                     []_tdiff2crit     - get time preference and time cell id in time-thinning
+!                     []_tdiff2crit     - get time preference and time cell id in time-thinning 
 !                     []_map2tgrid      - map observation to location on thinning grid
 !                     []_checkob        - intermediate ob checking to see if it should not be used
 !                     []_finalcheck     - the final criterion check for sat obs and increments counters
-!                     combine_radobs    -
+!                     combine_radobs    - 
 !                     []_destroygrids   - deallocate thinning grid arrays
 !   []_destroy_sfc                      - deallocate full horizontal fields of surface arrays
 !
@@ -104,12 +104,12 @@ module satthin
 ! > ! ptime:      Time interval (hour) for thinning radiance and ozone data.
 ! > !             It defines the number of time thinning bins (time_window/ptime).
 ! > !             0, only one time thinning bin, by default.
-! > ! ithin_time: Time preference is given
-! > !             1, (default) at the center time when thin4d=false, or
+! > ! ithin_time: Time preference is given 
+! > !             1, (default) at the center time when thin4d=false, or 
 ! > !                observation time is ignored when thin4d=true. ptime must be 0.0;
 ! > !             2, at the center of time intervals (suppressing thin4d);
 ! > !             3, at the end of time intervals (suppressing thin4d);
-! > !             4, at the beginning, middle, and end of the 1st, 2nd,and 3rd two-hour
+! > !             4, at the beginning, middle, and end of the 1st, 2nd,and 3rd two-hour 
 ! > !                time interval, respectively. ptime must be 2.0 (suppressing thin4d);
 ! > !             5, select observations at random time, and ptime must be 0.0
 ! > !                (Only applicable to seviri data, May 2018).
@@ -120,8 +120,8 @@ module satthin
 ! >  seviri      m10         seviri_m10            2.0     4
 ! >  seviri      m11         seviri_m11            2.0     4
 ! > ::
-!
-! details through an info file.
+!   
+! details through an info file.  
 !
 ! attributes:
 !   language: f90
@@ -135,7 +135,6 @@ module satthin
   use constants, only: deg2rad,rearth_equator,zero,two,pi,half,one,&
        rad2deg,r1000
   use chemmod, only: laeroana_fv3smoke
-  use sp_mod, only: splat
 
   implicit none
 
@@ -146,7 +145,7 @@ module satthin
   public :: makegrids
   public :: getsfc
   public :: get_hsst
-  public :: map2tgrid,map2tgrid2,binit
+  public :: map2tgrid,map2tgrid2,binit,itx_all
   public :: destroygrids
   public :: destroy_sfc
   public :: indexx
@@ -164,7 +163,7 @@ module satthin
   integer(i_kind) itxmax0
   integer(i_kind), save:: itx_all
   integer(i_kind),dimension(0:51):: istart_val
-
+  
   integer(i_kind),allocatable,dimension(:):: mlon
   logical,allocatable,dimension(:)::icount
 
@@ -186,7 +185,7 @@ module satthin
   real(r_single), allocatable, dimension(:,:)   :: zs_full_gfs
 ! declare the dummy variables of routine read_gfssfc_anl
   integer(i_kind),allocatable, dimension(:,:)   :: isli_anl
-! declare local array sno_anl
+! declare local array sno_anl 
   real(r_single),allocatable, dimension(:,:,:)   :: sno_anl
 ! declare the dummy variables of routine berror_read_hsst
   real(r_single), allocatable, dimension(:,:) :: hsst
@@ -198,7 +197,7 @@ contains
   subroutine makegvals
 !$$$  subprogram documentation block
 !                .      .    .                                       .
-! subprogram:    makegvals
+! subprogram:    makegvals                            
 !     prgmmr:    derber      org: np23                date: 2002-10-17
 !
 ! abstract:  This routine allocates and initializes arrays
@@ -209,7 +208,7 @@ contains
 !   2004-06-22  treadon - update documentation
 !   2004-12-09  treadon - allocate thinning grids consistent with analysis domain
 !   2006-07-28  derber  - use r1000 from constants
-!   2007-05-01  wu      - correct error which incorrectly defines longitude range
+!   2007-05-01  wu      - correct error which incorrectly defines longitude range 
 !                         on regional grid when domain includes north pole.
 !   2008-05-23  safford - rm unused vars
 !   2008-09-08  lueken  - merged ed's changes into q1fy09 code
@@ -253,7 +252,7 @@ contains
     do i=1,ndat
        maxthin=max(maxthin,abs(dthin(i)))
     end do
-!   Check if there are any time-thinning
+!   Check if there are any time-thinning 
     allocate(n_tbin_m1(0:maxthin))
     n_tbin_m1 = 0
     do i=1,ndat
@@ -318,7 +317,7 @@ contains
              glatx = rlat_min + (j-1)*delat
              glatx = glatx*deg2rad
              glatm = glatx + dgv*deg2rad
-
+             
              factor = abs(cos(abs(glatm)))
              if (dmesh(ii)>zero) then
                 mlonj = nint(mlonx*factor)
@@ -334,19 +333,19 @@ contains
              enddo
 
           enddo
-          istart_val(ii+1) = istart_val(ii+1)+ &
+          istart_val(ii+1) = istart_val(ii+1)+ & 
                              (istart_val(ii+1)-istart_val(ii))*n_tbin_m1(ii)
        end if
     end do
     superp=istart_val(maxthin+1)
-
+    
 !   Allocate and initialize arrays for superobs weighthing
     allocate(super_val(0:superp),super_val1(0:superp))
     do i=0,superp
        super_val(i)=zero
     end do
-    deallocate(n_tbin_m1)
-
+    deallocate(n_tbin_m1) 
+    
     return
   end subroutine makegvals
 
@@ -354,7 +353,7 @@ contains
   subroutine makegrids(rmesh,ithin,n_tbin,itxmax_in)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
-! subprogram:    makegrids
+! subprogram:    makegrids                            
 !     prgmmr:    treadon     org: np23                date: 2002-10-17
 !
 ! abstract:  This routine sets up dimensions for and allocates
@@ -369,7 +368,7 @@ contains
 !   2015-03-23  zaizhong ma - changed itxmax=1e9 for Himawari-8 ahi read in
 !
 !   input argument list:
-!     rmesh - mesh size (km) of thinning grid.  If (rmesh <= one),
+!     rmesh - mesh size (km) of thinning grid.  If (rmesh <= one), 
 !             then no thinning of the data will occur.  Instead,
 !             all data will be used without thinning.
 !     n_tbin - (optional) number of time intervals.
@@ -467,7 +466,7 @@ contains
     end do
 
     if (present(n_tbin)) then
-        itxmax0 = itxmax
+        itxmax0 = itxmax 
         itxmax  = itxmax0 * n_tbin
     endif
 
@@ -506,7 +505,7 @@ contains
 !     prgmmr:    parrish     org: np23                date: 2006-02-02
 !
 ! abstract:  This routine converts subdomain surface fields in
-!            guess_grids to full horizontal fields for use in
+!            guess_grids to full horizontal fields for use in 
 !            reading of observations.
 !
 ! program history log:
@@ -678,7 +677,7 @@ contains
              veg_type_full,soil_type_full,zs_full_gfs,isli_full,use_sfc_any)
 
           if ( use_readin_anl_sfcmask ) then
-             call read_gfssfc_anl(mype_io,isli_anl)
+             call read_gfssfc_anl(mype_io,isli_anl) 
           endif
        endif
 !
@@ -696,7 +695,7 @@ contains
 
        if (bcoption>0) then
           if (mype==0) write(6,*)'GETSFC:   add bias correction to guess field ', trim(filename)
-
+ 
 !         Correct Tskin over the full grid
           if(nlon == nlon_sfc .and. nlat == nlat_sfc)then
              call bkg_bias_model(work2,'sst',bias_hour,ierror)
@@ -705,7 +704,7 @@ contains
                 call mpi_allgatherv(zsm,ijn(mm1),mpi_rtype,&
                    work1,ijn,displs_g,mpi_rtype,&
                    mpi_comm_world,ierror)
-
+ 
                 do k=1,iglobal
                    i=ltosi(k) ; j=ltosj(k)
                    bias(i,j)=nint(work1(k))
@@ -725,7 +724,7 @@ contains
           end if
        end if
 
-    else                   ! for regional
+    else                   ! for regional 
 #else /* HAVE_ESMF */
 !
 !      read NSST variables while .not. sfcnst_comb (in sigio or nemsio)
@@ -903,7 +902,7 @@ contains
              deallocate(work)
           endif
        endif
-    endif
+    endif                 
 
 !   find subdomain for isli2
     if (nlon == nlon_sfc .and. nlat == nlat_sfc) then
@@ -1000,13 +999,13 @@ contains
 !     crit1      - quality indicator for observation (smaller = better)
 !     ithin      - number of obs to retain per thinning grid box
 !     sis        - sensor/instrument/satellite
-!     it_mesh    - time meth id
+!     it_mesh    - time meth id 
 !
 !   output argument list:
 !     itx   - combined (i,j) index of observation on thinning grid
 !     itt   - superobs thinning counter
 !     iuse  - .true. if observation should be used
-!
+!     
 !
 ! attributes:
 !   language: f90
@@ -1044,7 +1043,7 @@ contains
        return
     end if
 
-!   Compute (i,j) indices of coarse mesh grid (grid number 1) which
+!   Compute (i,j) indices of coarse mesh grid (grid number 1) which 
 !   contains the current observation.
     dlat1=dlat_earth
     dlon1=dlon_earth
@@ -1077,8 +1076,8 @@ contains
 !   if ( dx > zero ) ratio=dy/dx
 !   dista=sin(two*atan(ratio))
 !   distb=sin(pi*dx)                !dista+distb is max at grid box center
-!   dist1=one - quarter*(dista + distb)  !dist1 is min at grid box center and
-                                    !ranges from 1 (at corners)to
+!   dist1=one - quarter*(dista + distb)  !dist1 is min at grid box center and 
+                                    !ranges from 1 (at corners)to 
                                     !.5 (at center of box)
     iuse=.true.
 
@@ -1142,6 +1141,7 @@ contains
        iuse=.true.
        itt=1
        dist1=one
+       !$omp critical
        if(itx_all < itxmax) then
           itx_all=itx_all+1
        else
@@ -1149,6 +1149,7 @@ contains
           write(6,*)'MAP2TGRID2:  ndata > maxobs when reading data for ',sis,itxmax
        end if
        itx=itx_all
+       !$omp end critical
        return
     end if
 
@@ -1194,7 +1195,7 @@ contains
     return
   end subroutine map2tgrid2
 
-  subroutine binit(dlat_earth,dlon_earth,itx,it_mesh)
+  subroutine binit(dlat_earth,dlon_earth,itx,ithin,sis,it_mesh)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
 ! subprogram:    binit
@@ -1214,9 +1215,10 @@ contains
 !     itx   - combined (i,j) index of observation on thinning grid
 !$$$
     implicit none
-
+    integer(i_kind),intent(in   ) :: ithin
     integer(i_kind),intent(  out) :: itx
     real(r_kind)   ,intent(in   ) :: dlat_earth,dlon_earth
+    character(20)  ,intent(in   ) :: sis
     integer(i_kind),intent(in   ), optional :: it_mesh
 
     integer(i_kind) ix,iy
@@ -1224,19 +1226,15 @@ contains
 
 
 !   If using all data (no thinning), simply return to calling routine
-!    if(use_all .or. ithin <= 0)then
-!       !iuse=.true.
-!       !itt=1
-!       !dist1=one
-!       if(itx_all < itxmax) then
-!          itx_all=itx_all+1
-!       else
-!          !iuse = .false.
-!          !write(6,*)'MAP2TGRID2:  ndata > maxobs when reading data for ',sis,itxmax
-!       end if
-!       itx=itx_all
-!       return
-!    end if
+    if(use_all .or. ithin <= 0)then
+       if(itx_all < itxmax) then
+          itx_all=itx_all+1
+       else
+          write(6,*)'binit:  ndata > maxobs when reading data for ',sis,itxmax
+       end if
+       itx=itx_all
+       return
+    end if
 
 !   Compute (i,j) indices of coarse mesh grid (grid number 1) which
 !   contains the current observation.
@@ -1279,7 +1277,7 @@ contains
 !
 !   output argument list:
 !     iuse  - .true. if observation should be used
-!
+!     
 !
 ! attributes:
 !   language: f90
@@ -1306,7 +1304,7 @@ contains
 ! subprogram:    finalcheck
 !     prgmmr:    derber     org: np23                date: 2002-10-17
 !
-! abstract:  This routine performs the final criterion check for sat
+! abstract:  This routine performs the final criterion check for sat 
 !              obs and increments counters
 !
 ! program history log:
@@ -1319,7 +1317,7 @@ contains
 !
 !   output argument list:
 !     iuse   - .true. if observation should be used
-!
+!     
 !
 ! attributes:
 !   language: f90
@@ -1527,22 +1525,22 @@ contains
     parameter (m=7,nstack=500)
     integer(i_kind) i,indxt,ir,itemp,j,jstack,k,l,istack(nstack)
     real(r_kind) a
-
+    
     do j=1,n
        indx(j)=j
     end do
     jstack=0
     l=1
     ir=n
-
-    loop0: do
-
+    
+    loop0: do 
+    
        if(ir-l<m)then
           loop: do j=l+1,ir
              indxt=indx(j)
              a=arr(indxt)
              do i=j-1,l,-1
-                if(arr(indx(i))<=a)then
+                if(arr(indx(i))<=a)then   
                    indx(i+1)=indxt
                    cycle loop
                 end if
@@ -1555,7 +1553,7 @@ contains
           ir=istack(jstack)
           l=istack(jstack-1)
           jstack=jstack-2
-
+          
        else
           k=(l+ir)/2
           itemp=indx(k)
@@ -1583,8 +1581,8 @@ contains
           loop1: do
             i=i+1
             if(arr(indx(i))<a)cycle loop1
-
-            loop2: do
+          
+            loop2: do 
                j=j-1
                if(arr(indx(j))<=a)exit loop2
             end do loop2
@@ -1593,7 +1591,7 @@ contains
             indx(i)=indx(j)
             indx(j)=itemp
           end do loop1
-
+       
           indx(l+1)=indx(j)
           indx(j)=indxt
           jstack=jstack+2
@@ -1617,12 +1615,12 @@ contains
 
   subroutine tdiff2crit(tdiff,ptime,ithin_time,timeinflat,crit0,crit1,it_mesh)
 
-!$$$
+!$$$ 
 ! Abstract:  Get time preference and time cell id in time-thinning.
 ! Program history log:
 !   2018-05-18   j.jin      - initial code.
-!
-!$$$
+! 
+!$$$ 
 !Inputs
 !     tdiff         - observational time minus gsttime.
 !     ptime         - thinning time interval
@@ -1631,10 +1629,10 @@ contains
 !     crit0         - an added value to crit
 !Outputs
 !     crit1         - thinning crit
-!     it_mesh       - time cell id
+!     it_mesh       - time cell id 
 
     use constants, only: tiny_r_kind
-    use gsi_4dvar, only: thin4d
+    use gsi_4dvar, only: thin4d 
     implicit none
     integer(i_kind),intent(in   ) :: ithin_time
     real(r_kind)   ,intent(in   ) :: tdiff,ptime,timeinflat
@@ -1665,7 +1663,7 @@ contains
           crit1=abs(critb-(it_mesh+0.5_r_kind)*ptimeb)
        case (3)
           crit1=abs(critb-(it_mesh+1_r_kind)*ptimeb)
-       case (4)
+       case (4) 
           crit1=abs(critb-it_mesh*time_window_max)
        case (5)
           crit1=abs(tdiff)      ! .eqv. ithin_time==1 .and. .not.thin4d
@@ -1682,20 +1680,20 @@ contains
 
   subroutine radthin_time_info(obstype, platid, sis, ptime, ithin_time)
 
-!$$$
+!$$$ 
 ! Abstract:  Read time-thinning options for radiance and ozone data.
 ! Program history log:
 !   2018-05-10   j.jin      - initial code.
-!
-!$$$
+! 
+!$$$ 
 
 ! Inputs
 !   obstype     - observation type to process
 !   platid      - satellite indicator
 !   sis         - satellite_instrument/sensor indicator
 ! Outputs
-!   ptime       - time interval
-!   ithin_time  - indicator of time preference
+!   ptime       - time interval 
+!   ithin_time  - indicator of time preference  
 !
   use kinds, only: r_kind,i_kind
   use file_utility, only: get_lun
@@ -1705,7 +1703,7 @@ contains
   real(r_kind),intent(out)   :: ptime
   integer(i_kind),intent(out):: ithin_time
 
-  character(len=*),parameter:: rcname='anavinfo'
+  character(len=*),parameter:: rcname='anavinfo' 
   character(len=*),parameter:: tbname='rad_time_thinning_options::'
   integer(i_kind) luin,ii,ntot, nvars
   character(len=256),allocatable,dimension(:):: utable
@@ -1748,12 +1746,12 @@ contains
   deallocate(utable)
 
 ! Check the settings
-  if( ithin_time == 1 .or. ithin_time == 5 ) then
+  if( ithin_time == 1 .or. ithin_time == 5 ) then 
      if( ptime /= 0.0_r_kind ) then
         call die("satthin.F90 (subroutine radthin_time_info)", &
             "ithin_time=1 or 5 requires ptime=0.0"  )
      endif
-  else if( ithin_time == 4) then
+  else if( ithin_time == 4) then 
      if( ptime /= 2.0_r_kind .or. time_window_max /= 3.0_r_kind ) then
         call die("satthin.F90 (subroutine radthin_time_info)", &
             "ithin_time=4 requires ptime=2.0 and time_window_max=3.0" )

--- a/src/gsi/satthin.F90
+++ b/src/gsi/satthin.F90
@@ -1142,6 +1142,8 @@ contains
        iuse=.true.
        itt=1
        dist1=one
+       ! This subroutine is called from within an OpenMP region so we need to ensure
+       ! the threads don't race on the itx_all counter 
        !$omp critical
        if(itx_all < itxmax) then
           itx_all=itx_all+1

--- a/src/gsi/satthin.F90
+++ b/src/gsi/satthin.F90
@@ -36,12 +36,12 @@ module satthin
 !   2012-01-31  hchuang - add read_nemsnst in sub getnst
 !   2012-03-05  akella  - remove create_nst,getnst and destroy_nst; nst fields now handled by gsi_nstcoupler
 !   2015-05-01  li      - modify to use single precision for the variables read from sfc files
-!   2016-08-18  li      - tic591: when use_readin_anl_sfcmask is true, 
-!                                 add read sili_anl from analysis grid/resolution sfc file (sfcf06_anl) 
+!   2016-08-18  li      - tic591: when use_readin_anl_sfcmask is true,
+!                                 add read sili_anl from analysis grid/resolution sfc file (sfcf06_anl)
 !                                 modify to use isli_anl
-!                                 determine sno2 with interpolate, accordingly 
+!                                 determine sno2 with interpolate, accordingly
 !                                 use the modified 2d interpolation (sfc_interpolate to intrp22)
-!   2018-05-21  j.jin   - add an option for time-thinning. Check time preference (including thin4d) here. 
+!   2018-05-21  j.jin   - add an option for time-thinning. Check time preference (including thin4d) here.
 !
 !   2019-07-09  todling - revisit Li''s shuffling of nst init, read and final routines
 !   2019-08-08  j.jin   - add a comment block for an example of dtype-wise time-thinning
@@ -65,11 +65,11 @@ module satthin
 !   []_makegvals                        - set up for superob weighting
 !   []_getsfc                           - create full horizontal fields of surface arrays
 !                     []_makegrids      - set up thinning grids
-!                     []_tdiff2crit     - get time preference and time cell id in time-thinning 
+!                     []_tdiff2crit     - get time preference and time cell id in time-thinning
 !                     []_map2tgrid      - map observation to location on thinning grid
 !                     []_checkob        - intermediate ob checking to see if it should not be used
 !                     []_finalcheck     - the final criterion check for sat obs and increments counters
-!                     combine_radobs    - 
+!                     combine_radobs    -
 !                     []_destroygrids   - deallocate thinning grid arrays
 !   []_destroy_sfc                      - deallocate full horizontal fields of surface arrays
 !
@@ -104,12 +104,12 @@ module satthin
 ! > ! ptime:      Time interval (hour) for thinning radiance and ozone data.
 ! > !             It defines the number of time thinning bins (time_window/ptime).
 ! > !             0, only one time thinning bin, by default.
-! > ! ithin_time: Time preference is given 
-! > !             1, (default) at the center time when thin4d=false, or 
+! > ! ithin_time: Time preference is given
+! > !             1, (default) at the center time when thin4d=false, or
 ! > !                observation time is ignored when thin4d=true. ptime must be 0.0;
 ! > !             2, at the center of time intervals (suppressing thin4d);
 ! > !             3, at the end of time intervals (suppressing thin4d);
-! > !             4, at the beginning, middle, and end of the 1st, 2nd,and 3rd two-hour 
+! > !             4, at the beginning, middle, and end of the 1st, 2nd,and 3rd two-hour
 ! > !                time interval, respectively. ptime must be 2.0 (suppressing thin4d);
 ! > !             5, select observations at random time, and ptime must be 0.0
 ! > !                (Only applicable to seviri data, May 2018).
@@ -120,8 +120,8 @@ module satthin
 ! >  seviri      m10         seviri_m10            2.0     4
 ! >  seviri      m11         seviri_m11            2.0     4
 ! > ::
-!   
-! details through an info file.  
+!
+! details through an info file.
 !
 ! attributes:
 !   language: f90
@@ -135,6 +135,7 @@ module satthin
   use constants, only: deg2rad,rearth_equator,zero,two,pi,half,one,&
        rad2deg,r1000
   use chemmod, only: laeroana_fv3smoke
+  use sp_mod, only: splat
 
   implicit none
 
@@ -163,7 +164,7 @@ module satthin
   integer(i_kind) itxmax0
   integer(i_kind), save:: itx_all
   integer(i_kind),dimension(0:51):: istart_val
-  
+
   integer(i_kind),allocatable,dimension(:):: mlon
   logical,allocatable,dimension(:)::icount
 
@@ -185,7 +186,7 @@ module satthin
   real(r_single), allocatable, dimension(:,:)   :: zs_full_gfs
 ! declare the dummy variables of routine read_gfssfc_anl
   integer(i_kind),allocatable, dimension(:,:)   :: isli_anl
-! declare local array sno_anl 
+! declare local array sno_anl
   real(r_single),allocatable, dimension(:,:,:)   :: sno_anl
 ! declare the dummy variables of routine berror_read_hsst
   real(r_single), allocatable, dimension(:,:) :: hsst
@@ -197,7 +198,7 @@ contains
   subroutine makegvals
 !$$$  subprogram documentation block
 !                .      .    .                                       .
-! subprogram:    makegvals                            
+! subprogram:    makegvals
 !     prgmmr:    derber      org: np23                date: 2002-10-17
 !
 ! abstract:  This routine allocates and initializes arrays
@@ -208,7 +209,7 @@ contains
 !   2004-06-22  treadon - update documentation
 !   2004-12-09  treadon - allocate thinning grids consistent with analysis domain
 !   2006-07-28  derber  - use r1000 from constants
-!   2007-05-01  wu      - correct error which incorrectly defines longitude range 
+!   2007-05-01  wu      - correct error which incorrectly defines longitude range
 !                         on regional grid when domain includes north pole.
 !   2008-05-23  safford - rm unused vars
 !   2008-09-08  lueken  - merged ed's changes into q1fy09 code
@@ -252,7 +253,7 @@ contains
     do i=1,ndat
        maxthin=max(maxthin,abs(dthin(i)))
     end do
-!   Check if there are any time-thinning 
+!   Check if there are any time-thinning
     allocate(n_tbin_m1(0:maxthin))
     n_tbin_m1 = 0
     do i=1,ndat
@@ -317,7 +318,7 @@ contains
              glatx = rlat_min + (j-1)*delat
              glatx = glatx*deg2rad
              glatm = glatx + dgv*deg2rad
-             
+
              factor = abs(cos(abs(glatm)))
              if (dmesh(ii)>zero) then
                 mlonj = nint(mlonx*factor)
@@ -333,19 +334,19 @@ contains
              enddo
 
           enddo
-          istart_val(ii+1) = istart_val(ii+1)+ & 
+          istart_val(ii+1) = istart_val(ii+1)+ &
                              (istart_val(ii+1)-istart_val(ii))*n_tbin_m1(ii)
        end if
     end do
     superp=istart_val(maxthin+1)
-    
+
 !   Allocate and initialize arrays for superobs weighthing
     allocate(super_val(0:superp),super_val1(0:superp))
     do i=0,superp
        super_val(i)=zero
     end do
-    deallocate(n_tbin_m1) 
-    
+    deallocate(n_tbin_m1)
+
     return
   end subroutine makegvals
 
@@ -353,7 +354,7 @@ contains
   subroutine makegrids(rmesh,ithin,n_tbin,itxmax_in)
 !$$$  subprogram documentation block
 !                .      .    .                                       .
-! subprogram:    makegrids                            
+! subprogram:    makegrids
 !     prgmmr:    treadon     org: np23                date: 2002-10-17
 !
 ! abstract:  This routine sets up dimensions for and allocates
@@ -368,7 +369,7 @@ contains
 !   2015-03-23  zaizhong ma - changed itxmax=1e9 for Himawari-8 ahi read in
 !
 !   input argument list:
-!     rmesh - mesh size (km) of thinning grid.  If (rmesh <= one), 
+!     rmesh - mesh size (km) of thinning grid.  If (rmesh <= one),
 !             then no thinning of the data will occur.  Instead,
 !             all data will be used without thinning.
 !     n_tbin - (optional) number of time intervals.
@@ -466,7 +467,7 @@ contains
     end do
 
     if (present(n_tbin)) then
-        itxmax0 = itxmax 
+        itxmax0 = itxmax
         itxmax  = itxmax0 * n_tbin
     endif
 
@@ -505,7 +506,7 @@ contains
 !     prgmmr:    parrish     org: np23                date: 2006-02-02
 !
 ! abstract:  This routine converts subdomain surface fields in
-!            guess_grids to full horizontal fields for use in 
+!            guess_grids to full horizontal fields for use in
 !            reading of observations.
 !
 ! program history log:
@@ -677,7 +678,7 @@ contains
              veg_type_full,soil_type_full,zs_full_gfs,isli_full,use_sfc_any)
 
           if ( use_readin_anl_sfcmask ) then
-             call read_gfssfc_anl(mype_io,isli_anl) 
+             call read_gfssfc_anl(mype_io,isli_anl)
           endif
        endif
 !
@@ -695,7 +696,7 @@ contains
 
        if (bcoption>0) then
           if (mype==0) write(6,*)'GETSFC:   add bias correction to guess field ', trim(filename)
- 
+
 !         Correct Tskin over the full grid
           if(nlon == nlon_sfc .and. nlat == nlat_sfc)then
              call bkg_bias_model(work2,'sst',bias_hour,ierror)
@@ -704,7 +705,7 @@ contains
                 call mpi_allgatherv(zsm,ijn(mm1),mpi_rtype,&
                    work1,ijn,displs_g,mpi_rtype,&
                    mpi_comm_world,ierror)
- 
+
                 do k=1,iglobal
                    i=ltosi(k) ; j=ltosj(k)
                    bias(i,j)=nint(work1(k))
@@ -724,7 +725,7 @@ contains
           end if
        end if
 
-    else                   ! for regional 
+    else                   ! for regional
 #else /* HAVE_ESMF */
 !
 !      read NSST variables while .not. sfcnst_comb (in sigio or nemsio)
@@ -902,7 +903,7 @@ contains
              deallocate(work)
           endif
        endif
-    endif                 
+    endif
 
 !   find subdomain for isli2
     if (nlon == nlon_sfc .and. nlat == nlat_sfc) then
@@ -999,13 +1000,13 @@ contains
 !     crit1      - quality indicator for observation (smaller = better)
 !     ithin      - number of obs to retain per thinning grid box
 !     sis        - sensor/instrument/satellite
-!     it_mesh    - time meth id 
+!     it_mesh    - time meth id
 !
 !   output argument list:
 !     itx   - combined (i,j) index of observation on thinning grid
 !     itt   - superobs thinning counter
 !     iuse  - .true. if observation should be used
-!     
+!
 !
 ! attributes:
 !   language: f90
@@ -1043,7 +1044,7 @@ contains
        return
     end if
 
-!   Compute (i,j) indices of coarse mesh grid (grid number 1) which 
+!   Compute (i,j) indices of coarse mesh grid (grid number 1) which
 !   contains the current observation.
     dlat1=dlat_earth
     dlon1=dlon_earth
@@ -1076,8 +1077,8 @@ contains
 !   if ( dx > zero ) ratio=dy/dx
 !   dista=sin(two*atan(ratio))
 !   distb=sin(pi*dx)                !dista+distb is max at grid box center
-!   dist1=one - quarter*(dista + distb)  !dist1 is min at grid box center and 
-                                    !ranges from 1 (at corners)to 
+!   dist1=one - quarter*(dista + distb)  !dist1 is min at grid box center and
+                                    !ranges from 1 (at corners)to
                                     !.5 (at center of box)
     iuse=.true.
 
@@ -1277,7 +1278,7 @@ contains
 !
 !   output argument list:
 !     iuse  - .true. if observation should be used
-!     
+!
 !
 ! attributes:
 !   language: f90
@@ -1304,7 +1305,7 @@ contains
 ! subprogram:    finalcheck
 !     prgmmr:    derber     org: np23                date: 2002-10-17
 !
-! abstract:  This routine performs the final criterion check for sat 
+! abstract:  This routine performs the final criterion check for sat
 !              obs and increments counters
 !
 ! program history log:
@@ -1317,7 +1318,7 @@ contains
 !
 !   output argument list:
 !     iuse   - .true. if observation should be used
-!     
+!
 !
 ! attributes:
 !   language: f90
@@ -1525,22 +1526,22 @@ contains
     parameter (m=7,nstack=500)
     integer(i_kind) i,indxt,ir,itemp,j,jstack,k,l,istack(nstack)
     real(r_kind) a
-    
+
     do j=1,n
        indx(j)=j
     end do
     jstack=0
     l=1
     ir=n
-    
-    loop0: do 
-    
+
+    loop0: do
+
        if(ir-l<m)then
           loop: do j=l+1,ir
              indxt=indx(j)
              a=arr(indxt)
              do i=j-1,l,-1
-                if(arr(indx(i))<=a)then   
+                if(arr(indx(i))<=a)then
                    indx(i+1)=indxt
                    cycle loop
                 end if
@@ -1553,7 +1554,7 @@ contains
           ir=istack(jstack)
           l=istack(jstack-1)
           jstack=jstack-2
-          
+
        else
           k=(l+ir)/2
           itemp=indx(k)
@@ -1581,8 +1582,8 @@ contains
           loop1: do
             i=i+1
             if(arr(indx(i))<a)cycle loop1
-          
-            loop2: do 
+
+            loop2: do
                j=j-1
                if(arr(indx(j))<=a)exit loop2
             end do loop2
@@ -1591,7 +1592,7 @@ contains
             indx(i)=indx(j)
             indx(j)=itemp
           end do loop1
-       
+
           indx(l+1)=indx(j)
           indx(j)=indxt
           jstack=jstack+2
@@ -1615,12 +1616,12 @@ contains
 
   subroutine tdiff2crit(tdiff,ptime,ithin_time,timeinflat,crit0,crit1,it_mesh)
 
-!$$$ 
+!$$$
 ! Abstract:  Get time preference and time cell id in time-thinning.
 ! Program history log:
 !   2018-05-18   j.jin      - initial code.
-! 
-!$$$ 
+!
+!$$$
 !Inputs
 !     tdiff         - observational time minus gsttime.
 !     ptime         - thinning time interval
@@ -1629,10 +1630,10 @@ contains
 !     crit0         - an added value to crit
 !Outputs
 !     crit1         - thinning crit
-!     it_mesh       - time cell id 
+!     it_mesh       - time cell id
 
     use constants, only: tiny_r_kind
-    use gsi_4dvar, only: thin4d 
+    use gsi_4dvar, only: thin4d
     implicit none
     integer(i_kind),intent(in   ) :: ithin_time
     real(r_kind)   ,intent(in   ) :: tdiff,ptime,timeinflat
@@ -1663,7 +1664,7 @@ contains
           crit1=abs(critb-(it_mesh+0.5_r_kind)*ptimeb)
        case (3)
           crit1=abs(critb-(it_mesh+1_r_kind)*ptimeb)
-       case (4) 
+       case (4)
           crit1=abs(critb-it_mesh*time_window_max)
        case (5)
           crit1=abs(tdiff)      ! .eqv. ithin_time==1 .and. .not.thin4d
@@ -1680,20 +1681,20 @@ contains
 
   subroutine radthin_time_info(obstype, platid, sis, ptime, ithin_time)
 
-!$$$ 
+!$$$
 ! Abstract:  Read time-thinning options for radiance and ozone data.
 ! Program history log:
 !   2018-05-10   j.jin      - initial code.
-! 
-!$$$ 
+!
+!$$$
 
 ! Inputs
 !   obstype     - observation type to process
 !   platid      - satellite indicator
 !   sis         - satellite_instrument/sensor indicator
 ! Outputs
-!   ptime       - time interval 
-!   ithin_time  - indicator of time preference  
+!   ptime       - time interval
+!   ithin_time  - indicator of time preference
 !
   use kinds, only: r_kind,i_kind
   use file_utility, only: get_lun
@@ -1703,7 +1704,7 @@ contains
   real(r_kind),intent(out)   :: ptime
   integer(i_kind),intent(out):: ithin_time
 
-  character(len=*),parameter:: rcname='anavinfo' 
+  character(len=*),parameter:: rcname='anavinfo'
   character(len=*),parameter:: tbname='rad_time_thinning_options::'
   integer(i_kind) luin,ii,ntot, nvars
   character(len=256),allocatable,dimension(:):: utable
@@ -1746,12 +1747,12 @@ contains
   deallocate(utable)
 
 ! Check the settings
-  if( ithin_time == 1 .or. ithin_time == 5 ) then 
+  if( ithin_time == 1 .or. ithin_time == 5 ) then
      if( ptime /= 0.0_r_kind ) then
         call die("satthin.F90 (subroutine radthin_time_info)", &
             "ithin_time=1 or 5 requires ptime=0.0"  )
      endif
-  else if( ithin_time == 4) then 
+  else if( ithin_time == 4) then
      if( ptime /= 2.0_r_kind .or. time_window_max /= 3.0_r_kind ) then
         call die("satthin.F90 (subroutine radthin_time_info)", &
             "ithin_time=4 requires ptime=2.0 and time_window_max=3.0" )


### PR DESCRIPTION
**Description**
This PR resolves issue 917 which revolves around a runtime failure when observation thinning is disabled for ATMS and BUFRTOVS data types.

Resolves #917 

**Type of change**

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
I ran a GSI case on acorn with and without thinning of all ATMS and BUFRTOVS data types (see list below).  No runtime failures were encountered.

atms_npp
atms_n20
atms_n21
amsua_metop-c
amsua_n18
amsua_n15
amsua_n19
amsua_metop-b
mhs_n19
mhs_n19
mhs_metop-b
mhs_metop-b
mhs_metop-c
mhs_metop-c
amsua_metop-b
amsua_n19
amsua_n18
amsua_metop-c

I also ran the GSI regression suite to compare with a stock develop branch (16c19a2bc).  All tests passed.

Test project /lfs/h1/hpc/support/daniel.kokron/Projects/GSI/GFSv17/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test #3: rrfs_3denvar_rdasens .............   Passed  727.85 sec
2/6 Test #2: rtma .............................   Passed  969.81 sec
3/6 Test #4: hafs_4denvar_glbens ..............   Passed  1215.07 sec
4/6 Test #5: hafs_3denvar_hybens ..............   Passed  1215.45 sec
5/6 Test #6: global_enkf ......................   Passed  1340.34 sec
6/6 Test #1: global_4denvar ...................   Passed  1853.49 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) = 1853.50 sec
  
**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published