### PR TITLE
read_prepbufr update format speciifer for vtcd and glcd to f8.0 in debug print - complete issue #921

### DIFF
--- a/src/gsi/read_prepbufr.F90
+++ b/src/gsi/read_prepbufr.F90
@@ -901,7 +901,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
      glcd=-999
   endif
 
-  if(print_verbose) write(6,'(1x,A,A,A,2(A,1x,I8))') 'read_prepbufr:',        &
+  if(print_verbose) write(6,'(1x,A,A,A,2(A,1x,F8.0))') 'read_prepbufr:',        &
      trim(adjustl(obstype)),':', '  vtcd= ',vtcd,'  glcd= ',glcd
   call init_rjlists
   call init_aircraft_rjlists


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

A debug print format for variables vtcd and glcd was adjusted to complete issue #921 which reverted them to real values.

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published