### PR TITLE
add SAID=768 piq yam8  RO data 

### DIFF
--- a/src/gsi/read_obs.F90
+++ b/src/gsi/read_obs.F90
@@ -408,7 +408,8 @@ subroutine read_obs_check (lexist,filename,jsatid,dtype,minuse,nread)
                (said == 42) .or. (said == 43) .or. (said == 722) .or. & 
                (said == 723).or. (said == 265).or. (said == 266) .or. &
                (said == 267).or. (said == 268).or. (said == 269) .or. &
-               (said == 803).or. (said == 804).or. (said == 66)) then
+               (said == 803).or. (said == 804).or. (said == 66)  .or. &
+               (said == 768)) then
                lexist=.true. 
              exit gpsloop 
            end if 

--- a/src/gsi/setupbend.f90
+++ b/src/gsi/setupbend.f90
@@ -111,6 +111,7 @@ subroutine setupbend(obsLL,odiagLL, &
 !   2024-12-04  Li       - remove the QC check for rejecting MetOp data <8 km
 !   2024-12-04  Li       - add GRACE-FO (803&804) data 
 !   2024-12-04  Li       - add new obs error model by Chris Riedel
+!   2025-09-08  Li       - add PlanetiQ YAM-8 (768) data
 !
 !   input argument list:
 !     lunin    - unit from which to read observations
@@ -674,7 +675,7 @@ subroutine setupbend(obsLL,odiagLL, &
        rdiagbuf(18,i)  = trefges ! temperature at obs location (Kelvin) if monotone grid
        rdiagbuf(21,i)  = qrefges ! specific humidity at obs location (kg/kg) if monotone grid
        commdat=.false.
-       if (data(isatid,i)>=265 .and. data(isatid,i)<=269) commdat=.true.
+       if (data(isatid,i)>=265 .and. data(isatid,i)<=269 .or. data(isatid,i)==768) commdat=.true.
        if (.not. qcfail(i)) then ! not SR
 
          ratio_errors(i) = data(ier,i)

--- a/src/gsi/setupbend.f90
+++ b/src/gsi/setupbend.f90
@@ -675,7 +675,7 @@ subroutine setupbend(obsLL,odiagLL, &
        rdiagbuf(18,i)  = trefges ! temperature at obs location (Kelvin) if monotone grid
        rdiagbuf(21,i)  = qrefges ! specific humidity at obs location (kg/kg) if monotone grid
        commdat=.false.
-       if (data(isatid,i)>=265 .and. data(isatid,i)<=269 .or. data(isatid,i)==768) commdat=.true.
+       if ( (data(isatid,i)>=265 .and. data(isatid,i)<=269) .or. (data(isatid,i)==768) ) commdat=.true.
        if (.not. qcfail(i)) then ! not SR
 
          ratio_errors(i) = data(ier,i)


### PR DESCRIPTION
**Description**

This PR addresses issue #928 by adding satellite ID 768 for the commercial PlanetiQ YAM8 data onboard the Loft satellite. The setupbend code has been updated to apply the correct QC filters, and the satellite ID has been added to global_convinfo.txt (GSI-fix PR [#47).](https://github.com/NOAA-EMC/GSI-fix/pull/47/files)

Resolves [#928](https://github.com/NOAA-EMC/GSI/issues/928).

Dependent upon GSI-fix PR [#47](https://github.com/NOAA-EMC/GSI-fix/pull/47)

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

A GSI test was conducted on Hera using sample PlanetiQ YAM8 files with SAID = 768 provided by UCAR. Additional testing was performed with files containing PlanetiQ data from both SAID 267 (GNOMES satellites) and 768. Both tests successfully assimilated the YAM8 data, and the statistics in fort.212 look good for PlanetiQ.

A GSI regression test against the develop branch (`4ac3132`) was run on Hera. All tests passed.

`Test project /scratch3/NCEPDEV/da/Xuanli.Li/git/piqyam8_768/GSI/build`
`   Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf  `
`1/6 Test #3: rrfs_3denvar_rdasens .............   Passed  548.97 sec`
`2/6 Test #2: rtma .............................   Passed  1149.93 sec`
`3/6 Test #6: global_enkf ......................   Passed  1173.39 sec`
`4/6 Test #5: hafs_3denvar_hybens ..............   Passed  1273.22 sec`
`5/6 Test #4: hafs_4denvar_glbens ..............   Passed  1273.44 sec`
`6/6 Test #1: global_4denvar ...................   Passed  1546.37 sec`
`                                                                                               `
`100% tests passed, 0 tests failed out of 6`
`                                                                 `
`Total Test time (real) = 1546.38 sec `
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published