### PR TITLE
Add PlanetiQ YAM8 SAID=768 RO data in GSI v16

### DIFF
--- a/src/gsi/read_obs.F90
+++ b/src/gsi/read_obs.F90
@@ -408,7 +408,8 @@ subroutine read_obs_check (lexist,filename,jsatid,dtype,minuse,nread)
                (said == 42) .or. (said == 43) .or. (said == 722) .or. & 
                (said == 723).or. (said == 265).or. (said == 266) .or. &
                (said == 267).or. (said == 268).or. (said == 269) .or. &
-               (said == 803).or. (said == 804).or. (said == 66)) then
+               (said == 803).or. (said == 804).or. (said == 66)  .or. &
+               (said == 768)) then
                lexist=.true. 
              exit gpsloop 
            end if 

--- a/src/gsi/setupbend.f90
+++ b/src/gsi/setupbend.f90
@@ -111,6 +111,7 @@ subroutine setupbend(obsLL,odiagLL, &
 !   2024-12-04  Li       - remove the QC check for rejecting MetOp data <8 km
 !   2024-12-04  Li       - add GRACE-FO (803&804) data 
 !   2024-12-04  Li       - add new obs error model by Chris Riedel
+!   2025-09-08  Li       - add PlanetiQ YAM-8 (768) data
 !
 !   input argument list:
 !     lunin    - unit from which to read observations
@@ -653,7 +654,7 @@ subroutine setupbend(obsLL,odiagLL, &
        rdiagbuf(18,i)  = trefges ! temperature at obs location (Kelvin) if monotone grid
        rdiagbuf(21,i)  = qrefges ! specific humidity at obs location (kg/kg) if monotone grid
        commdat=.false.
-       if (data(isatid,i)>=265 .and. data(isatid,i)<=269) commdat=.true.
+       if ( (data(isatid,i)>=265 .and. data(isatid,i)<=269) .or. (data(isatid,i)==768) ) commdat=.true.
        if (.not. qcfail(i)) then ! not SR
 
          ratio_errors(i) = data(ier,i)
@@ -855,7 +856,7 @@ subroutine setupbend(obsLL,odiagLL, &
 
   end do loopoverobs1 ! end of loop over observations
 
-  write(6,'("setupbend: Number of obs considered and accepted " 2I10)') nobs, count(mask=muse .neqv. .false.)
+! write(6,'("setupbend: Number of obs considered and accepted " 2I10)') nobs, count(mask=muse .neqv. .false.)
 
   if (nobs_out>=1) then
      write(6,*)'WARNING GPSRO:',nobs_out,'obs outside integration grid. Increase nsig_ext to',&


### PR DESCRIPTION
**Description**

This PR addresses issue https://github.com/NOAA-EMC/GSI/issues/928 by adding satellite ID 768 commercial PlanetiQ YAM8 RO data to GSI v16. setupbend.f90 has been updated to apply the commercial RO QC filters for this data, and the print statement for the number of RO obs considered and accepted has been turned off. Note that the fix submodule in this fork is the develop branch, and it works fine for the GSI sample data test runs.

Resolves https://github.com/NOAA-EMC/GSI/issues/928.

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

A GSI test was conducted on WCOSS2 using sample PlanetiQ YAM8 files with SAID = 768 provided by UCAR. Additional testing was performed with files containing PlanetiQ data from both SAID 267 (GNOMES satellites) and 768. Both tests successfully assimilated the YAM8 data, and the statistics in fort.212 look good for PlanetiQ.

A GSI regression test against the develop-v16 branch (262ce16) was run on WCOSS2. All tests passed.
`Test project /lfs/h2/emc/da/noscrub/xuanli.li/git/v16_piqyam8_768/GSI/build`
`    Start 1: global_4denvar`
`    Start 2: rtma`
`    Start 3: rrfs_3denvar_rdasens`
`    Start 4: hafs_4denvar_glbens`
`    Start 5: hafs_3denvar_hybens`
`    Start 6: global_enkf`
`1/6 Test #3: rrfs_3denvar_rdasens .............   Passed  736.16 sec`
`2/6 Test #2: rtma .............................   Passed  1157.18 sec`
`3/6 Test #5: hafs_3denvar_hybens ..............   Passed  1285.03 sec`
`4/6 Test #4: hafs_4denvar_glbens ..............   Passed  1534.61 sec`
`5/6 Test #6: global_enkf ......................   Passed  1536.60 sec`
`6/6 Test #1: global_4denvar ...................   Passed  1985.11 sec`
`                                                                 `
`100% tests passed, 0 tests failed out of 6`
`                                                                 `
`Total Test time (real) = 1985.12 sec`

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published