### PR TITLE
Update craype and cray_mpich versions on WCOSS2

### DIFF
--- a/modulefiles/gsi_wcoss2.intel.lua
+++ b/modulefiles/gsi_wcoss2.intel.lua
@@ -3,10 +3,9 @@ help([[
 
 local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
 local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
-local craype_ver=os.getenv("craype_ver") or "2.7.10"
-local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
+local craype_ver=os.getenv("craype_ver") or "2.7.13"
+local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.9"
 local cmake_ver= os.getenv("cmake_ver") or "3.20.2"
-local python_ver=os.getenv("python_ver") or "3.8.6"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.0.10"
 
 local hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
@@ -30,7 +29,6 @@ load(pathJoin("intel", intel_ver))
 load(pathJoin("craype", craype_ver))
 load(pathJoin("cray-mpich", cray_mpich_ver))
 load(pathJoin("cmake", cmake_ver))
-load(pathJoin("python", python_ver))
 
 load(pathJoin("prod_util", prod_util_ver))
 


### PR DESCRIPTION
**Description**
This PR updates the craype and cray_mpich versions for WCOSS2 so that they are the same across the GSI, GSI-monitor, GSI-utils, and global workflow branches.  This also removes the Python module which is not used in this repository.

Prerequisite for https://github.com/NOAA-EMC/global-workflow/issues/4044

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**
- [x] Global workflow suite of CI tests on WCOSS2.
- [x] Regression tests on WCOSS2
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes