### PR TITLE
Use EIB staged CRTM coefficients and update WCOSS2 casedir path

### DIFF
--- a/modulefiles/gsi_acorn.intel.lua
+++ b/modulefiles/gsi_acorn.intel.lua
@@ -19,7 +19,7 @@ local sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
 local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
-local crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
+local crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.1"
 
@@ -51,6 +51,7 @@ load(pathJoin("sfcio", sfcio_ver))
 load(pathJoin("nemsio", nemsio_ver))
 load(pathJoin("wrf_io", wrf_io_ver))
 load(pathJoin("ncio", ncio_ver))
+--load(pathJoin("crtm", crtm_ver))
 load(pathJoin("ncdiag",ncdiag_ver))
 
 -- Lastly, load CRTM from the EMC location

--- a/modulefiles/gsi_acorn.intel.lua
+++ b/modulefiles/gsi_acorn.intel.lua
@@ -19,7 +19,7 @@ local sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
 local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
-local crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
+local crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.1"
 
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
@@ -50,7 +50,6 @@ load(pathJoin("sfcio", sfcio_ver))
 load(pathJoin("nemsio", nemsio_ver))
 load(pathJoin("wrf_io", wrf_io_ver))
 load(pathJoin("ncio", ncio_ver))
---load(pathJoin("crtm", crtm_ver))
 load(pathJoin("ncdiag",ncdiag_ver))
 
 -- Lastly, load CRTM from the EMC location
@@ -58,5 +57,6 @@ append_path("MODULEPATH", "/lfs/h1/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack
 load(pathJoin("crtm", crtm_ver))
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20250529")
+setenv("CRTM_FIX", pathJoin("/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/crtm", "v" .. crtm_ver))
 
 whatis("Description: GSI environment on WCOSS2 Acorn")

--- a/modulefiles/gsi_acorn.intel.lua
+++ b/modulefiles/gsi_acorn.intel.lua
@@ -20,7 +20,7 @@ local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
 local crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
-local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
+local crtm_fix_ver=os.getenv("crtm_fix_ver") or "2.4.0.2"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.1"
 
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
@@ -59,6 +59,6 @@ append_path("MODULEPATH", "/lfs/h1/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack
 load(pathJoin("crtm", crtm_ver))
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/crtm", "v" .. gsi_crtm_ver))
+setenv("CRTM_FIX", pathJoin("/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/crtm", "v" .. crtm_fix_ver))
 
 whatis("Description: GSI environment on WCOSS2 Acorn")

--- a/modulefiles/gsi_acorn.intel.lua
+++ b/modulefiles/gsi_acorn.intel.lua
@@ -20,6 +20,7 @@ local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
 local crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
+local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.1"
 
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
@@ -57,6 +58,6 @@ append_path("MODULEPATH", "/lfs/h1/emc/nceplibs/noscrub/hpc-stack/libs/hpc-stack
 load(pathJoin("crtm", crtm_ver))
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/crtm", "v" .. crtm_ver))
+setenv("CRTM_FIX", pathJoin("/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/crtm", "v" .. gsi_crtm_ver))
 
 whatis("Description: GSI environment on WCOSS2 Acorn")

--- a/modulefiles/gsi_common.lua
+++ b/modulefiles/gsi_common.lua
@@ -14,7 +14,7 @@ local sfcio_ver=os.getenv("sfcio_ver") or "1.4.2"
 local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
-local crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
+local crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.2"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 

--- a/modulefiles/gsi_common.lua
+++ b/modulefiles/gsi_common.lua
@@ -14,7 +14,7 @@ local sfcio_ver=os.getenv("sfcio_ver") or "1.4.2"
 local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
-local crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
+local crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.2"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 

--- a/modulefiles/gsi_container.intel.lua
+++ b/modulefiles/gsi_container.intel.lua
@@ -7,6 +7,7 @@ local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.12.2"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+local gsi_crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
 
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))

--- a/modulefiles/gsi_container.intel.lua
+++ b/modulefiles/gsi_container.intel.lua
@@ -7,7 +7,7 @@ local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.12.2"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
-local gsi_crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
+local crtm_fix_ver=os.getenv("crtm_fix_ver") or "2.4.0.2"
 
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))

--- a/modulefiles/gsi_gaeac6.intel.lua
+++ b/modulefiles/gsi_gaeac6.intel.lua
@@ -7,7 +7,7 @@ local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
 local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.30"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
-local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
+local crtm_fix_ver=os.getenv("crtm_fix_ver") or "2.4.0.2"
 
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
@@ -17,7 +17,7 @@ load(pathJoin("cmake", cmake_ver))
 load("gsi_common")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/gpfs/f6/drsa-precip3/world-shared/role.glopara/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/gpfs/f6/drsa-precip3/world-shared/role.glopara/fix/crtm", "v" .. gsi_crtm_ver))
+setenv("CRTM_FIX", pathJoin("/gpfs/f6/drsa-precip3/world-shared/role.glopara/fix/crtm", "v" .. crtm_fix_ver))
 
 setenv("CC","cc")
 setenv("FC","ftn")

--- a/modulefiles/gsi_gaeac6.intel.lua
+++ b/modulefiles/gsi_gaeac6.intel.lua
@@ -7,6 +7,7 @@ local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
 local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.30"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
 
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
@@ -16,7 +17,7 @@ load(pathJoin("cmake", cmake_ver))
 load("gsi_common")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/gpfs/f6/drsa-precip3/world-shared/role.glopara/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/gpfs/f6/drsa-precip3/world-shared/role.glopara/fix/crtm", "v" .. crtm_ver))
+setenv("CRTM_FIX", pathJoin("/gpfs/f6/drsa-precip3/world-shared/role.glopara/fix/crtm", "v" .. gsi_crtm_ver))
 
 setenv("CC","cc")
 setenv("FC","ftn")

--- a/modulefiles/gsi_gaeac6.intel.lua
+++ b/modulefiles/gsi_gaeac6.intel.lua
@@ -16,6 +16,7 @@ load(pathJoin("cmake", cmake_ver))
 load("gsi_common")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/gpfs/f6/drsa-precip3/world-shared/role.glopara/fix/gsi/20250529")
+setenv("CRTM_FIX", pathJoin("/gpfs/f6/drsa-precip3/world-shared/role.glopara/fix/crtm", "v" .. crtm_ver))
 
 setenv("CC","cc")
 setenv("FC","ftn")

--- a/modulefiles/gsi_hera.intel.lua
+++ b/modulefiles/gsi_hera.intel.lua
@@ -24,5 +24,6 @@ pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/scratch3/NCEPDEV/global/role.glopara/fix/gsi/20250529")
+setenv("CRTM_FIX", pathJoin("/scratch3/NCEPDEV/global/role.glopara/fix/crtm", "v" .. crtm_ver))
 
 whatis("Description: GSI environment on Hera with Intel Compilers")

--- a/modulefiles/gsi_hera.intel.lua
+++ b/modulefiles/gsi_hera.intel.lua
@@ -8,6 +8,7 @@ local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "202
 local mkl_ver=os.getenv("mkl_ver") or "2024.2.1"
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))
@@ -24,6 +25,6 @@ pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/scratch3/NCEPDEV/global/role.glopara/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/scratch3/NCEPDEV/global/role.glopara/fix/crtm", "v" .. crtm_ver))
+setenv("CRTM_FIX", pathJoin("/scratch3/NCEPDEV/global/role.glopara/fix/crtm", "v" .. gsi_crtm_ver))
 
 whatis("Description: GSI environment on Hera with Intel Compilers")

--- a/modulefiles/gsi_hera.intel.lua
+++ b/modulefiles/gsi_hera.intel.lua
@@ -8,7 +8,7 @@ local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "202
 local mkl_ver=os.getenv("mkl_ver") or "2024.2.1"
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
-local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
+local crtm_fix_ver=os.getenv("crtm_fix_ver") or "2.4.0.2"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))
@@ -25,6 +25,6 @@ pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/scratch3/NCEPDEV/global/role.glopara/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/scratch3/NCEPDEV/global/role.glopara/fix/crtm", "v" .. gsi_crtm_ver))
+setenv("CRTM_FIX", pathJoin("/scratch3/NCEPDEV/global/role.glopara/fix/crtm", "v" .. crtm_fix_ver))
 
 whatis("Description: GSI environment on Hera with Intel Compilers")

--- a/modulefiles/gsi_hercules.intel.lua
+++ b/modulefiles/gsi_hercules.intel.lua
@@ -30,5 +30,6 @@ setenv("CXX","mpiicpc")
 setenv("FC","mpiifort")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
+setenv("CRTM_FIX", pathJoin("/work2/noaa/global/role-global/fix/crtm", "v" .. crtm_ver))
 
 whatis("Description: GSI environment on Hercules with Intel Compilers")

--- a/modulefiles/gsi_hercules.intel.lua
+++ b/modulefiles/gsi_hercules.intel.lua
@@ -8,6 +8,7 @@ local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "202
 local intel_oneapi_mkl_ver=os.getenv("intel_oneapi_mkl_ver") or "2024.2.1"
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))
@@ -30,6 +31,6 @@ setenv("CXX","mpiicpc")
 setenv("FC","mpiifort")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/work2/noaa/global/role-global/fix/crtm", "v" .. crtm_ver))
+setenv("CRTM_FIX", pathJoin("/work2/noaa/global/role-global/fix/crtm", "v" .. gsi_crtm_ver))
 
 whatis("Description: GSI environment on Hercules with Intel Compilers")

--- a/modulefiles/gsi_hercules.intel.lua
+++ b/modulefiles/gsi_hercules.intel.lua
@@ -8,7 +8,7 @@ local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "202
 local intel_oneapi_mkl_ver=os.getenv("intel_oneapi_mkl_ver") or "2024.2.1"
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
-local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
+local crtm_fix_ver=os.getenv("crtm_fix_ver") or "2.4.0.2"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))
@@ -31,6 +31,6 @@ setenv("CXX","mpiicpc")
 setenv("FC","mpiifort")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/work2/noaa/global/role-global/fix/crtm", "v" .. gsi_crtm_ver))
+setenv("CRTM_FIX", pathJoin("/work2/noaa/global/role-global/fix/crtm", "v" .. crtm_fix_ver))
 
 whatis("Description: GSI environment on Hercules with Intel Compilers")

--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -24,5 +24,6 @@ pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20250529")
+setenv("CRTM_FIX", pathJoin("/contrib/global-workflow-shared-data/fix/crtm", "v" .. crtm_ver))
 
 whatis("Description: GSI environment on NOAA Cloud with Intel Compilers")

--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -10,7 +10,7 @@ local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "202
 local mkl_ver=os.getenv("mkl_ver") or "2024.2.1"
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
-local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
+local crtm_fix_ver=os.getenv("crtm_fix_ver") or "2.4.0.2"
 
 load(pathJoin("gnu", gcc_ver))
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
@@ -25,6 +25,6 @@ pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/contrib/global-workflow-shared-data/fix/crtm", "v" .. gsi_crtm_ver))
+setenv("CRTM_FIX", pathJoin("/contrib/global-workflow-shared-data/fix/crtm", "v" .. crtm_fix_ver))
 
 whatis("Description: GSI environment on NOAA Cloud with Intel Compilers")

--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -10,6 +10,7 @@ local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "202
 local mkl_ver=os.getenv("mkl_ver") or "2024.2.1"
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
 
 load(pathJoin("gnu", gcc_ver))
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
@@ -24,6 +25,6 @@ pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/contrib/global-workflow-shared-data/fix/crtm", "v" .. crtm_ver))
+setenv("CRTM_FIX", pathJoin("/contrib/global-workflow-shared-data/fix/crtm", "v" .. gsi_crtm_ver))
 
 whatis("Description: GSI environment on NOAA Cloud with Intel Compilers")

--- a/modulefiles/gsi_orion.intel.lua
+++ b/modulefiles/gsi_orion.intel.lua
@@ -8,7 +8,7 @@ local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "202
 local intel_oneapi_mkl_ver=os.getenv("intel_oneapi_mkl_ver") or "2024.2.1"
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
-local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
+local crtm_fix_ver=os.getenv("crtm_fix_ver") or "2.4.0.2"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))
@@ -29,6 +29,6 @@ setenv("CXX","mpiicpc")
 setenv("FC","mpiifort")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/work2/noaa/global/role-global/fix/crtm", "v" .. gsi_crtm_ver))
+setenv("CRTM_FIX", pathJoin("/work2/noaa/global/role-global/fix/crtm", "v" .. crtm_fix_ver))
 
 whatis("Description: GSI environment on Orion with Intel Compilers")

--- a/modulefiles/gsi_orion.intel.lua
+++ b/modulefiles/gsi_orion.intel.lua
@@ -28,5 +28,6 @@ setenv("CXX","mpiicpc")
 setenv("FC","mpiifort")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
+setenv("CRTM_FIX", pathJoin("/work2/noaa/global/role-global/fix/crtm", "v" .. crtm_ver))
 
 whatis("Description: GSI environment on Orion with Intel Compilers")

--- a/modulefiles/gsi_orion.intel.lua
+++ b/modulefiles/gsi_orion.intel.lua
@@ -8,6 +8,7 @@ local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "202
 local intel_oneapi_mkl_ver=os.getenv("intel_oneapi_mkl_ver") or "2024.2.1"
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))
@@ -28,6 +29,6 @@ setenv("CXX","mpiicpc")
 setenv("FC","mpiifort")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/work2/noaa/global/role-global/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/work2/noaa/global/role-global/fix/crtm", "v" .. crtm_ver))
+setenv("CRTM_FIX", pathJoin("/work2/noaa/global/role-global/fix/crtm", "v" .. gsi_crtm_ver))
 
 whatis("Description: GSI environment on Orion with Intel Compilers")

--- a/modulefiles/gsi_ursa.intel.lua
+++ b/modulefiles/gsi_ursa.intel.lua
@@ -8,6 +8,7 @@ local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
 local oneapi_mkl_ver=os.getenv("oneapi_mkl_ver") or "2024.2.1"
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
@@ -18,6 +19,6 @@ load(pathJoin("cmake", cmake_ver))
 load("gsi_common")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/scratch3/NCEPDEV/global/role.glopara/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/scratch3/NCEPDEV/global/role.glopara/fix/crtm", "v" .. crtm_ver))
+setenv("CRTM_FIX", pathJoin("/scratch3/NCEPDEV/global/role.glopara/fix/crtm", "v" .. gsi_crtm_ver))
 
 whatis("Description: GSI environment on Ursa with Intel Compilers")

--- a/modulefiles/gsi_ursa.intel.lua
+++ b/modulefiles/gsi_ursa.intel.lua
@@ -18,5 +18,6 @@ load(pathJoin("cmake", cmake_ver))
 load("gsi_common")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/scratch3/NCEPDEV/global/role.glopara/fix/gsi/20250529")
+setenv("CRTM_FIX", pathJoin("/scratch3/NCEPDEV/global/role.glopara/fix/crtm", "v" .. crtm_ver))
 
 whatis("Description: GSI environment on Ursa with Intel Compilers")

--- a/modulefiles/gsi_ursa.intel.lua
+++ b/modulefiles/gsi_ursa.intel.lua
@@ -8,7 +8,7 @@ local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
 local oneapi_mkl_ver=os.getenv("oneapi_mkl_ver") or "2024.2.1"
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.7"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
-local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
+local crtm_fix_ver=os.getenv("crtm_fix_ver") or "2.4.0.2"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
@@ -19,6 +19,6 @@ load(pathJoin("cmake", cmake_ver))
 load("gsi_common")
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/scratch3/NCEPDEV/global/role.glopara/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/scratch3/NCEPDEV/global/role.glopara/fix/crtm", "v" .. gsi_crtm_ver))
+setenv("CRTM_FIX", pathJoin("/scratch3/NCEPDEV/global/role.glopara/fix/crtm", "v" .. crtm_fix_ver))
 
 whatis("Description: GSI environment on Ursa with Intel Compilers")

--- a/modulefiles/gsi_wcoss2.intel.lua
+++ b/modulefiles/gsi_wcoss2.intel.lua
@@ -21,7 +21,7 @@ local sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
 local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
-local crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
+local crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.2"
 
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
@@ -50,5 +50,6 @@ load(pathJoin("crtm", crtm_ver))
 load(pathJoin("ncdiag-A",ncdiag_ver))
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20250529")
+setenv("CRTM_FIX", pathJoin("/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/crtm", "v" .. crtm_ver))
 
 whatis("Description: GSI environment on WCOSS2")

--- a/modulefiles/gsi_wcoss2.intel.lua
+++ b/modulefiles/gsi_wcoss2.intel.lua
@@ -22,7 +22,7 @@ local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
 local crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
-local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
+local crtm_fix_ver=os.getenv("crtm_fix_ver") or "2.4.0.2"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.2"
 
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
@@ -51,6 +51,6 @@ load(pathJoin("crtm", crtm_ver))
 load(pathJoin("ncdiag-A",ncdiag_ver))
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/crtm", "v" .. gsi_crtm_ver))
+setenv("CRTM_FIX", pathJoin("/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/crtm", "v" .. crtm_fix_ver))
 
 whatis("Description: GSI environment on WCOSS2")

--- a/modulefiles/gsi_wcoss2.intel.lua
+++ b/modulefiles/gsi_wcoss2.intel.lua
@@ -22,6 +22,7 @@ local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
 local crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
+local gsi_crtm_ver=os.getenv("gsi_crtm_ver") or "2.4.0.2"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.2"
 
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
@@ -50,6 +51,6 @@ load(pathJoin("crtm", crtm_ver))
 load(pathJoin("ncdiag-A",ncdiag_ver))
 
 pushenv("GSI_BINARY_SOURCE_DIR", "/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/crtm", "v" .. crtm_ver))
+setenv("CRTM_FIX", pathJoin("/lfs/h2/emc/global/noscrub/emc.global/FIX/fix/crtm", "v" .. gsi_crtm_ver))
 
 whatis("Description: GSI environment on WCOSS2")

--- a/modulefiles/gsi_wcoss2.intel.lua
+++ b/modulefiles/gsi_wcoss2.intel.lua
@@ -21,7 +21,7 @@ local sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
 local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
 local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
-local crtm_ver=os.getenv("crtm_ver") or "2.4.0.2"
+local crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
 local crtm_fix_ver=os.getenv("crtm_fix_ver") or "2.4.0.2"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.2"
 

--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -81,7 +81,7 @@ case $machine in
       fi
       export ptmp="${ptmp:-/lfs/h2/emc/ptmp/$LOGNAME/$ptmpName}"
 
-      export casesdir="/lfs/h2/emc/da/noscrub/russ.treadon/CASES/regtest"
+      export casesdir="/lfs/h2/emc/global/noscrub/russ.treadon/CASES/regtest"
 
       export check_resource="no"
       export accnt="${accnt:-GFS-DEV}"


### PR DESCRIPTION
**Description**

This PR includes two sets of changes:
- update gsi modulefiles to set variable `CRTM_FIX` to point at EIB staged CRTM coefficients.
- change the `casedire` path on WCOSS2

Resolves #934
Resolves #935

**Type of change**
- [x] Maintenance

**How Has This Been Tested?**

Run GSI ctests on Acorn, Gaea C6, Hera, Hercules, Orion, Ursa, and WCOSS2 (Cactus).   All tests _Passed_ on all machines.  [Detailed results](https://github.com/NOAA-EMC/GSI/issues/935#issuecomment-3358026156) are found in GSI issue #935.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes