### PR TITLE
allow floating point underflow so debug enkf test passes (issue #776)

### DIFF
--- a/src/enkf/cmake/enkfapp_compiler_flags_Intel_Fortran.cmake
+++ b/src/enkf/cmake/enkfapp_compiler_flags_Intel_Fortran.cmake
@@ -14,7 +14,7 @@ set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -fp-model strict")
 # DEBUG FLAGS
 ####################################################################
 
-set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -fp-model source -debug -ftrapuv -warn all,nointerfaces -check all,noarg_temp_created -fp-stack-check -fstack-protector")
+set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -fpe1 -debug -ftrapuv -warn all,nointerfaces -check all,noarg_temp_created -fp-stack-check -fstack-protector")
 
 ####################################################################
 # LINK FLAGS


### PR DESCRIPTION

EnKF debug ctest currently fails with a floating point exception inside LAPACK eigensolver.  To fix this, ```-fpe1``` replaces ```-fp-model source``` in debug compiler flags.  Addresses issue #776 

Resolves #776
