### PR TITLE
Adding options in GSI building script (ush/build.sh) for 3DRTMA

### DIFF
--- a/ush/build.sh
+++ b/ush/build.sh
@@ -26,6 +26,10 @@ INSTALL_PREFIX=${INSTALL_PREFIX:-"${DIR_ROOT}/install"}
 GSI_MODE=${GSI_MODE:-"Regional"}  # By default build Regional GSI (for regression testing)
 ENKF_MODE=${ENKF_MODE:-"GFS"}     # By default build Global EnKF  (for regression testing)
 REGRESSION_TESTS=${REGRESSION_TESTS:-"YES"} # Build regression test suite
+if [[ -v BUILD_GSI4RTMA3D && ${BUILD_GSI4RTMA3D} =~ [yYtT] ]] ; then
+    BUILD_GSDCLOUD=${BUILD_GSDCLOUD:-"ON"}      # Build GSD Cloud Analysis library
+    USE_GSDCLOUD=${USE_GSDCLOUD:-"ON"}          # Build with GSD Cloud Analysis library
+fi
 
 #==============================================================================#
 
@@ -51,6 +55,11 @@ CMAKE_OPTS+=" -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX"
 # Configure for GSI and EnKF
 CMAKE_OPTS+=" -DGSI_MODE=$GSI_MODE -DENKF_MODE=${ENKF_MODE}"
 
+# Configure for building GSI with GSD Cloud Analysis
+if [[ -v BUILD_GSI4RTMA3D && ${BUILD_GSI4RTMA3D} =~ [yYtT] ]] ; then
+    CMAKE_OPTS+=" -DBUILD_GSDCLOUD=${BUILD_GSDCLOUD} -DUSE_GSDCLOUD=${USE_GSDCLOUD}"
+fi
+
 # Build regression test suite (on supported MACHINE_ID where CONTROLPATH exists)
 [[ ${REGRESSION_TESTS} =~ [yYtT] ]] && CMAKE_OPTS+=" -DBUILD_REG_TESTING=ON -DCONTROLPATH=${CONTROLPATH:-}"
 
@@ -62,9 +71,6 @@ mkdir -p $BUILD_DIR && cd $BUILD_DIR
 #     specifit options for 3DRTMA
 if [[ -v BUILD_GSI4RTMA3D && ${BUILD_GSI4RTMA3D} =~ [yYtT] ]] ; then
     echo " ****** Building GSI with GSD Cloud Analysis for 3D-RTMA ****** "
-    BUILD_GSDCLOUD=${BUILD_GSDCLOUD:-"ON"}      # Build GSD Cloud Analysis library
-    USE_GSDCLOUD=${USE_GSDCLOUD:-"ON"}          # Build with GSD Cloud Analysis library
-    CMAKE_OPTS+=" -DBUILD_GSDCLOUD=${BUILD_GSDCLOUD} -DUSE_GSDCLOUD=${USE_GSDCLOUD}"
     cmake $CMAKE_OPTS $DIR_ROOT 2>&1 | tee log.cmake
     make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-1} 2>&1 | tee log.make
     make install 2>&1 | tee log.install

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -eux
+set -eu
+set +x
 
 #=================================================================================================#
 usage() {
@@ -9,20 +10,44 @@ usage() {
 #   https://github.com/NOAA-EMC/RDASApp/blob/e9ea4c1c02ece82931bf66d2f36b6009a921f6d9/build.sh
   set +x
   echo
-  echo "Usage options: "
-  echo "  -c additional CMake options				DEFAULT: <none>; (GSDCLOUD: using GSD Cloud Analysis)"
-  echo "  -v build with verbose output				DEFAULT: do not use this flag"
-  echo "  -l save the building log files under build directory	DEFAULT: do not use this flag"
+  echo "$0: GSI building script"
+  echo "Usage: "
+  echo "  -c additional CMake options. Multiple options are separated with comma, e.g., -c c1,c2"
+  echo "     DEFAULT: <none>"
+  echo "     Example: $0               # building GSI with default config (for most DA systems, e.g. GDAS, RRFS-DA, etc.)"
+  echo "              $0 -c GSDCLOUD   # building GSI with GSD Cloud Analysis support (only for RAP/HRRR, 3DRTMA, not default)"
+  echo "  -v build with verbose output and enable script-debugging by set -x"
+  echo "     DEFAULT: <none> (this option requires no argument)"
+  echo "  -l save the building log files under build directory"
+  echo "     DEFAULT: <none> (this option requires no argument)"
   echo "  -h display this usage/help information and quit"
-  echo "Usage examples: "
-  echo "  $0                    # building GSI with default config (for most DA systems, e.g. GDAS, RRFS-DA, etc.)"
-  echo "  $0 -c GSDCLOUD        # building GSI with GSD Cloud Analysis support (only for RAP/HRRR, 3DRTMA, not default)"
-  echo "  $0 -v                 # building GSI with verbose output (not default)"
-  echo "  $0 -l                 # saving the cmake/make/install log into log files under build directory (not default)"
   echo 
   exit 1
 }
 #=================================================================================================#
+
+# First, checking if any specific option(s) is passed through the option arguments
+unset OPTS4CMAKE
+unset SAVELOG
+while getopts "c:hlv" opt; do
+  case ${opt} in
+    c)
+      OPTS4CMAKE="${OPTARG}"
+      ;;
+    v)
+      set -x
+      BUILD_VERBOSE=1
+      ;;
+    l)
+      SAVELOG="Yes"
+      ;;
+    h|\?|\:)
+      usage
+      ;;
+  esac
+done
+
+shift $((OPTIND - 1)) # Shift positional parameters to remove parsed options
 
 # Get the root of the cloned GSI directory
 readonly DIR_ROOT=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )/.." && pwd -P)
@@ -41,44 +66,6 @@ REGRESSION_TESTS=${REGRESSION_TESTS:-"YES"} # Build regression test suite
 
 # Detect machine (sets MACHINE_ID)
 source $DIR_ROOT/ush/detect_machine.sh
-
-# checking if any specific option(s) is specified through the option arguments
-unset OPTS4CMAKE
-unset SAVELOG
-unset BUILD_GSDCLDANL
-while getopts "c:hlv" opt; do
-  case ${opt} in
-    c)
-      OPTS4CMAKE=${OPTARG}
-      ;;
-    v)
-      BUILD_VERBOSE=1
-      ;;
-    l)
-      SAVELOG="Yes"
-      ;;
-    h|\?|\:)
-      usage
-      ;;
-  esac
-done
-
-shift $((OPTIND - 1)) # Shift positional parameters to remove parsed options
-
-shopt -s nocasematch		# enable case-insensitive matching for patterns
-if [[ -v OPTS4CMAKE ]] ; then
-  case "${OPTS4CMAKE}" in
-    gsdcloud|gsdcldanl|gsdcld|gsdcloudanalysis|cloudanalysis|cldanl)
-      BUILD_GSDCLDANL="Yes"
-      echo " ****** Building GSI with GSD Cloud Analysis Support ****** "
-      ;;
-    *)
-      unset BUILD_GSDCLDANL
-      ;;
-  esac
-fi
-shopt -u nocasematch		# disable case-insensitive matching for patterns
-unset OPTS4CMAKE
 
 # Load modules
 set +x
@@ -99,12 +86,25 @@ CMAKE_OPTS+=" -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX"
 # Configure for GSI and EnKF
 CMAKE_OPTS+=" -DGSI_MODE=$GSI_MODE -DENKF_MODE=${ENKF_MODE}"
 
-# Configure for building GSI with GSD Cloud Analysis
-if [[ -v BUILD_GSDCLDANL && ${BUILD_GSDCLDANL} =~ [yYtT] ]] ; then
-    BUILD_GSDCLOUD="ON"				# Build GSD Cloud Analysis library
-    USE_GSDCLOUD="ON"				# Build with GSD Cloud Analysis library
-    CMAKE_OPTS+=" -DBUILD_GSDCLOUD=${BUILD_GSDCLOUD} -DUSE_GSDCLOUD=${USE_GSDCLOUD}"
+# Configure for building GSI with User-specified options which are passed through "-c" option
+shopt -s nocasematch		# enable case-insensitive matching for patterns
+if [[ -v OPTS4CMAKE && -n "${OPTS4CMAKE}" ]] ; then
+  IFS=',' read -ra ITEMS <<< "${OPTS4CMAKE}"
+  for item in "${ITEMS[@]}"; do
+    case "${item}" in
+      gsdcloud|gsdcldanl|gsdcld|gsdcloudanalysis|cloudanalysis|cldanl)
+        echo " ****** Building GSI with GSD Cloud Analysis Support ****** "
+        BUILD_GSDCLOUD="ON"				# Build GSD Cloud Analysis library
+        USE_GSDCLOUD="ON"				# Build with GSD Cloud Analysis library
+        CMAKE_OPTS+=" -DBUILD_GSDCLOUD=${BUILD_GSDCLOUD} -DUSE_GSDCLOUD=${USE_GSDCLOUD}"
+        ;;
+      *)
+        ;;
+    esac
+  done
 fi
+shopt -u nocasematch		# disable case-insensitive matching for patterns
+unset OPTS4CMAKE
 
 # Build regression test suite (on supported MACHINE_ID where CONTROLPATH exists)
 [[ ${REGRESSION_TESTS} =~ [yYtT] ]] && CMAKE_OPTS+=" -DBUILD_REG_TESTING=ON -DCONTROLPATH=${CONTROLPATH:-}"
@@ -114,7 +114,6 @@ fi
 mkdir -p $BUILD_DIR && cd $BUILD_DIR
 
 # Configure, build, install
-#     specifit options for 3DRTMA
 if [[ -v SAVELOG && ${SAVELOG} =~ [yYtT] ]] ; then
     cmake $CMAKE_OPTS $DIR_ROOT 2>&1 | tee log.cmake
     make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-} 2>&1 | tee log.make

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -2,6 +2,18 @@
 
 set -eux
 
+# checking if the first positional argument is specified to build a special system
+if [[ $# -ge 1 ]] ; then
+    DASYS_NAME="$1"
+    if [[ ${DASYS_NAME,,} == "3drtma" ||  ${DASYS_NAME,,} == "rtma3d" ]] ; then
+        BUILD_GSI4RTMA3D="Yes"
+        echo " ****** Building GSI for 3D-RTMA ****** "
+    else
+        unset BUILD_GSI4RTMA3D
+    fi
+fi
+unset DASYS_NAME
+
 # Get the root of the cloned GSI directory
 readonly DIR_ROOT=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )/.." && pwd -P)
 
@@ -47,8 +59,19 @@ CMAKE_OPTS+=" -DGSI_MODE=$GSI_MODE -DENKF_MODE=${ENKF_MODE}"
 mkdir -p $BUILD_DIR && cd $BUILD_DIR
 
 # Configure, build, install
-cmake $CMAKE_OPTS $DIR_ROOT
-make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-}
-make install
+#     specifit options for 3DRTMA
+if [[ -v BUILD_GSI4RTMA3D && ${BUILD_GSI4RTMA3D} =~ [yYtT] ]] ; then
+    echo " ****** Building GSI with GSD Cloud Analysis for 3D-RTMA ****** "
+    BUILD_GSDCLOUD=${BUILD_GSDCLOUD:-"ON"}      # Build GSD Cloud Analysis library
+    USE_GSDCLOUD=${USE_GSDCLOUD:-"ON"}          # Build with GSD Cloud Analysis library
+    CMAKE_OPTS+=" -DBUILD_GSDCLOUD=${BUILD_GSDCLOUD} -DUSE_GSDCLOUD=${USE_GSDCLOUD}"
+    cmake $CMAKE_OPTS $DIR_ROOT 2>&1 | tee log.cmake
+    make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-1} 2>&1 | tee log.make
+    make install 2>&1 | tee log.install
+else
+    cmake $CMAKE_OPTS $DIR_ROOT
+    make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-}
+    make install
+fi
 
 exit

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -2,22 +2,32 @@
 
 set -eux
 
-# checking if the first positional argument is specified to build a special system
-if [[ $# -ge 1 ]] ; then
-    DASYS_NAME="$1"
-    if [[ ${DASYS_NAME,,} == "3drtma" ||  ${DASYS_NAME,,} == "rtma3d" ]] ; then
-        BUILD_GSI4RTMA3D="Yes"
-        echo " ****** Building GSI for 3D-RTMA ****** "
-    else
-        unset BUILD_GSI4RTMA3D
-    fi
-fi
-unset DASYS_NAME
+#=================================================================================================#
+usage() {
+#   This usage function is based on the usage function in the build.sh in NOAA-EMC RDASApp 
+#   for JEDI-based DA pacakge. see
+#   https://github.com/NOAA-EMC/RDASApp/blob/e9ea4c1c02ece82931bf66d2f36b6009a921f6d9/build.sh
+  set +x
+  echo
+  echo "Usage options: "
+  echo "  -c additional CMake options				DEFAULT: <none>; (GSDCLOUD: using GSD Cloud Analysis)"
+  echo "  -v build with verbose output				DEFAULT: do not use this flag"
+  echo "  -l save the building log files under build directory	DEFAULT: do not use this flag"
+  echo "  -h display this usage/help information and quit"
+  echo "Usage examples: "
+  echo "  $0                    # building GSI with default config (for most DA systems, e.g. GDAS, RRFS-DA, etc.)"
+  echo "  $0 -c GSDCLOUD        # building GSI with GSD Cloud Analysis support (only for RAP/HRRR, 3DRTMA, not default)"
+  echo "  $0 -v                 # building GSI with verbose output (not default)"
+  echo "  $0 -l                 # saving the cmake/make/install log into log files under build directory (not default)"
+  echo 
+  exit 1
+}
+#=================================================================================================#
 
 # Get the root of the cloned GSI directory
 readonly DIR_ROOT=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )/.." && pwd -P)
 
-# User Options
+# User Options -- Defaults
 BUILD_TYPE=${BUILD_TYPE:-"Release"}
 CMAKE_OPTS=${CMAKE_OPTS:-}
 COMPILER=${COMPILER:-"intel"}
@@ -31,6 +41,44 @@ REGRESSION_TESTS=${REGRESSION_TESTS:-"YES"} # Build regression test suite
 
 # Detect machine (sets MACHINE_ID)
 source $DIR_ROOT/ush/detect_machine.sh
+
+# checking if any specific option(s) is specified through the option arguments
+unset OPTS4CMAKE
+unset SAVELOG
+unset BUILD_GSDCLDANL
+while getopts "c:hlv" opt; do
+  case ${opt} in
+    c)
+      OPTS4CMAKE=${OPTARG}
+      ;;
+    v)
+      BUILD_VERBOSE=1
+      ;;
+    l)
+      SAVELOG="Yes"
+      ;;
+    h|\?|\:)
+      usage
+      ;;
+  esac
+done
+
+shift $((OPTIND - 1)) # Shift positional parameters to remove parsed options
+
+shopt -s nocasematch		# enable case-insensitive matching for patterns
+if [[ -v OPTS4CMAKE ]] ; then
+  case "${OPTS4CMAKE}" in
+    gsdcloud|gsdcldanl|gsdcld|gsdcloudanalysis|cloudanalysis|cldanl)
+      BUILD_GSDCLDANL="Yes"
+      echo " ****** Building GSI with GSD Cloud Analysis Support ****** "
+      ;;
+    *)
+      unset BUILD_GSDCLDANL
+      ;;
+  esac
+fi
+shopt -u nocasematch		# disable case-insensitive matching for patterns
+unset OPTS4CMAKE
 
 # Load modules
 set +x
@@ -52,9 +100,9 @@ CMAKE_OPTS+=" -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX"
 CMAKE_OPTS+=" -DGSI_MODE=$GSI_MODE -DENKF_MODE=${ENKF_MODE}"
 
 # Configure for building GSI with GSD Cloud Analysis
-if [[ -v BUILD_GSI4RTMA3D && ${BUILD_GSI4RTMA3D} =~ [yYtT] ]] ; then
-    BUILD_GSDCLOUD=${BUILD_GSDCLOUD:-"ON"}      # Build GSD Cloud Analysis library
-    USE_GSDCLOUD=${USE_GSDCLOUD:-"ON"}          # Build with GSD Cloud Analysis library
+if [[ -v BUILD_GSDCLDANL && ${BUILD_GSDCLDANL} =~ [yYtT] ]] ; then
+    BUILD_GSDCLOUD="ON"				# Build GSD Cloud Analysis library
+    USE_GSDCLOUD="ON"				# Build with GSD Cloud Analysis library
     CMAKE_OPTS+=" -DBUILD_GSDCLOUD=${BUILD_GSDCLOUD} -DUSE_GSDCLOUD=${USE_GSDCLOUD}"
 fi
 
@@ -67,10 +115,9 @@ mkdir -p $BUILD_DIR && cd $BUILD_DIR
 
 # Configure, build, install
 #     specifit options for 3DRTMA
-if [[ -v BUILD_GSI4RTMA3D && ${BUILD_GSI4RTMA3D} =~ [yYtT] ]] ; then
-    echo " ****** Building GSI with GSD Cloud Analysis for 3D-RTMA ****** "
+if [[ -v SAVELOG && ${SAVELOG} =~ [yYtT] ]] ; then
     cmake $CMAKE_OPTS $DIR_ROOT 2>&1 | tee log.cmake
-    make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-1} 2>&1 | tee log.make
+    make -j ${BUILD_JOBS:-8} VERBOSE=${BUILD_VERBOSE:-} 2>&1 | tee log.make
     make install 2>&1 | tee log.install
 else
     cmake $CMAKE_OPTS $DIR_ROOT

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -17,9 +17,9 @@ usage() {
   echo "     Example: $0               # building GSI with default config (for most DA systems, e.g. GDAS, RRFS-DA, etc.)"
   echo "              $0 -c GSDCLOUD   # building GSI with GSD Cloud Analysis support (only for RAP/HRRR, 3DRTMA, not default)"
   echo "  -v build with verbose output and enable script-debugging by set -x"
-  echo "     DEFAULT: <none> (this option requires no argument)"
+  echo "     DEFAULT: <none>, flag option (no argument)"
   echo "  -l save the building log files under build directory"
-  echo "     DEFAULT: <none> (this option requires no argument)"
+  echo "     DEFAULT: <none>, flag option (no argument)"
   echo "  -h display this usage/help information and quit"
   echo 
   exit 1
@@ -42,7 +42,7 @@ while getopts "c:hlv" opt; do
     l)
       SAVELOG="Yes"
       ;;
-    h|\?|\:)
+    h|\?|:)
       usage
       ;;
   esac

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -26,10 +26,6 @@ INSTALL_PREFIX=${INSTALL_PREFIX:-"${DIR_ROOT}/install"}
 GSI_MODE=${GSI_MODE:-"Regional"}  # By default build Regional GSI (for regression testing)
 ENKF_MODE=${ENKF_MODE:-"GFS"}     # By default build Global EnKF  (for regression testing)
 REGRESSION_TESTS=${REGRESSION_TESTS:-"YES"} # Build regression test suite
-if [[ -v BUILD_GSI4RTMA3D && ${BUILD_GSI4RTMA3D} =~ [yYtT] ]] ; then
-    BUILD_GSDCLOUD=${BUILD_GSDCLOUD:-"ON"}      # Build GSD Cloud Analysis library
-    USE_GSDCLOUD=${USE_GSDCLOUD:-"ON"}          # Build with GSD Cloud Analysis library
-fi
 
 #==============================================================================#
 
@@ -57,6 +53,8 @@ CMAKE_OPTS+=" -DGSI_MODE=$GSI_MODE -DENKF_MODE=${ENKF_MODE}"
 
 # Configure for building GSI with GSD Cloud Analysis
 if [[ -v BUILD_GSI4RTMA3D && ${BUILD_GSI4RTMA3D} =~ [yYtT] ]] ; then
+    BUILD_GSDCLOUD=${BUILD_GSDCLOUD:-"ON"}      # Build GSD Cloud Analysis library
+    USE_GSDCLOUD=${USE_GSDCLOUD:-"ON"}          # Build with GSD Cloud Analysis library
     CMAKE_OPTS+=" -DBUILD_GSDCLOUD=${BUILD_GSDCLOUD} -DUSE_GSDCLOUD=${USE_GSDCLOUD}"
 fi
 

--- a/ush/build.sh
+++ b/ush/build.sh
@@ -33,6 +33,7 @@ while getopts "c:hlv" opt; do
   case ${opt} in
     c)
       OPTS4CMAKE="${OPTARG}"
+      echo "User-specified additionl building options ==> ${OPTS4CMAKE}"
       ;;
     v)
       set -x


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->
**_Motivation_**
GSI, when running in 3DRTMA, needs the support of GSD Cloud Analysis. Because the default configuration in the building script (ush/buiild.sh) does not include the CMake options for GSD Cloud Analysis, therefore when building GSI for 3DRTMA, user has to modify the building script manually to set up the GSD cloud options. We would like to make building GSI more friendly and flexible for various user's configurations. It is better and more flexible by passing the user-specified building options into building script when running the building script, and meanwhile want to avoid modifying the configuration manually in the script for different situation.

**_Method_**
As mentioned in the motivation above, the user-specified building options would be passed into script when running the script. In the first version, the building options are passed as the "positional arguments". Then following the suggestions from code reviewers to make the building script more flexible and friendly, the way of "option arguments" is adopted in building script to pass the user-specified options into script. In the current version, "-c" option is used to get the argument to set up the CMake options, and the arguments could be multiple arguments, which are separated by comma, for example,
` ./build.sh -c c1,c2`
c1 and c2 are two user-specified arguments to set up the special CMake options, which are not set up in default building configurations. 

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->
Resolves #946

**Type of change**

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

I built the GSI code with modified building script (ush/build.sh) and run the GSI ctest:
1. CTest with the GSI code built with the default configuration,  that is to run "build.sh" without any arguments just same as before. The code passed the CTest on WCOSS2 Dev machine (Cactus). Here is the ctest running log:
        <details><summary>CTest results on **_WCOSS2_** with GSI code built with default configurations</summary>
        <p>
[gang.zhao@clogin07:build.default] (feature/build_gsi4rtma3d)$ ctest -N
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
  Test # 1: global_4denvar
  Test # 2: rtma
  Test # 3: rrfs_3denvar_rdasens
  Test # 4: hafs_4denvar_glbens
  Test # 5: hafs_3denvar_hybens
  Test # 6: global_enkf
Total Tests: 6
[gang.zhao@clogin04:build] (feature/build_gsi4rtma3d)$ nohup ctest -j 6 > ./ctest_6tasks_run.log 2>&1 &
nohup: ignoring input
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test # 3: rrfs_3denvar_rdasens .............   Passed  798.62 sec
2/6 Test # 2: rtma .............................   Passed  1161.17 sec
3/6 Test # 5: hafs_3denvar_hybens ..............   Passed  1291.43 sec
4/6 Test # 4: hafs_4denvar_glbens ..............   Passed  1470.13 sec
5/6 Test # 6: global_enkf ......................   Passed  1484.70 sec
6/6 Test # 1: global_4denvar ...................   Passed  2048.06 sec
100% tests passed, 0 tests failed out of 6
Total Test time (real) = 2048.10 sec
        </p>
        </details> 
2.  CTest with the GSI code built for 3DRTMA with specific options,  that is to run "_build.sh  **3DRTMA**_". The code also passed the CTest on WCOSS2 Dev machine (Cactus). Here is the ctest running log:
        <details><summary>CTest results on **_WCOSS2_** with GSI code built for _**3DRTMA""_ </summary>
        <p>
[gang.zhao@clogin04:build] (feature/build_gsi4rtma3d)$ git branch
  develop
  feature/build_gsi4rtma3d
  feature/crossvalidation_3drtma
  feature/sfcfull_dumpout
[gang.zhao@clogin04:build] (feature/build_gsi4rtma3d)$ pwd
/lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
[gang.zhao@clogin04:build.default] (feature/build_gsi4rtma3d)$ ctest -N
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
  Test # 1: global_4denvar
  Test # 2: rtma
  Test # 3: rrfs_3denvar_rdasens
  Test # 4: hafs_4denvar_glbens
  Test # 5: hafs_3denvar_hybens
  Test # 6: global_enkf
Total Tests: 6
[gang.zhao@clogin04:build] (feature/build_gsi4rtma3d)$ nohup ctest -j 6 > ./ctest_6tasks_run.log 2>&1 &
[1] 4126990
nohup: ignoring input
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test # 3: rrfs_3denvar_rdasens .............   Passed  734.02 sec
2/6 Test # 2: rtma .............................   Passed  1102.29 sec
3/6 Test # 5: hafs_3denvar_hybens ..............   Passed  1303.90 sec
4/6 Test # 4: hafs_4denvar_glbens ..............   Passed  1407.09 sec
5/6 Test # 6: global_enkf ......................   Passed  1435.44 sec
6/6 Test # 1: global_4denvar ...................   Passed  2047.09 sec
100% tests passed, 0 tests failed out of 6
Total Test time (real) = 2047.24 sec
        </p>
        </details>