### PR TITLE
Port global RTs to noaalcoud; update noaacloud paths

### DIFF
--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -24,7 +24,7 @@ load("gsi_common")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20250529")
-setenv("CRTM_FIX", pathJoin("/contrib/global-workflow-shared-data/fix/crtm", "v" .. crtm_fix_ver))
+pushenv("GSI_BINARY_SOURCE_DIR", "/lustre/fix/gsi/20250529")
+setenv("CRTM_FIX", pathJoin("/lustre/fix/crtm", "v" .. crtm_fix_ver))
 
 whatis("Description: GSI environment on NOAA Cloud with Intel Compilers")

--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -79,8 +79,8 @@ case $regtest in
            topts[1]="0:10:00" ; popts[1]="12/8/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="12/10/" ; ropts[2]="/2"
 	elif [[ "$machine" = "noaacloud" ]]; then
-           topts[1]="0:10:00" ; popts[1]="24/4/" ; ropts[1]="/1"
-           topts[2]="0:10:00" ; popts[2]="24/5/" ; ropts[2]="/2"
+           topts[1]="0:20:00" ; popts[1]="24/4/" ; ropts[1]="/1"
+           topts[2]="0:20:00" ; popts[2]="24/5/" ; ropts[2]="/2"
         fi
 
         if [ "$debug" = ".true." ] ; then
@@ -262,8 +262,8 @@ case $regtest in
            topts[1]="0:10:00" ; popts[1]="16/2/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="16/4/" ; ropts[2]="/2"
 	elif [[ "$machine" = "noaacloud" ]]; then
-	   topts[1]="0:10:00" ; popts[1]="18/2/" ; ropts[1]="/1"
-	   topts[2]="0:10:00" ; popts[2]="20/3/" ; ropts[2]="/2"
+	   topts[1]="0:20:00" ; popts[1]="18/2/" ; ropts[1]="/1"
+	   topts[2]="0:20:00" ; popts[2]="20/3/" ; ropts[2]="/2"
         fi
 
         if [ "$debug" = ".true." ] ; then
@@ -331,5 +331,6 @@ elif [[ "$machine" = "wcoss2" || "$machine" = "acorn" ]]; then
    export FI_OFI_RXM_SAR_LIMIT=3145728
    export APRUN="mpiexec -n \$ntasks -ppn \$ppn --cpu-bind core --depth \$threads"
 elif [[ "$machine" = "noaacloud" ]]; then
+   export I_MPI_ADJUST_ALLREDUCE=5
    export APRUN="srun --mpi=pmi2 -n \$ntasks --cpus-per-task=\$threads"
 fi

--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -40,9 +40,9 @@ case $machine in
            numcore=128
     ;;
     noaacloud)
-	   sub_cmd="sub_noaacloud"
-	   memnode=192
-	   numcore=48
+           sub_cmd="sub_noaacloud"
+           memnode=192
+           numcore=48
     ;;
     *) # EXIT out for unresolved machine
         echo "unknown $machine"
@@ -78,7 +78,7 @@ case $regtest in
         elif [[ "$machine" = "wcoss2" || "$machine" = "acorn" ]]; then
            topts[1]="0:10:00" ; popts[1]="12/8/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="12/10/" ; ropts[2]="/2"
-	elif [[ "$machine" = "noaacloud" ]]; then
+        elif [[ "$machine" = "noaacloud" ]]; then
            topts[1]="0:10:00" ; popts[1]="48/2/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="24/5/" ; ropts[2]="/2"
         fi
@@ -261,9 +261,9 @@ case $regtest in
         elif [[ "$machine" = "wcoss2" || "$machine" = "acorn" ]]; then
            topts[1]="0:10:00" ; popts[1]="16/2/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="16/4/" ; ropts[2]="/2"
-	elif [[ "$machine" = "noaacloud" ]]; then
-	   topts[1]="0:10:00" ; popts[1]="36/1/" ; ropts[1]="/1"
-	   topts[2]="0:10:00" ; popts[2]="30/2/" ; ropts[2]="/1"
+        elif [[ "$machine" = "noaacloud" ]]; then
+           topts[1]="0:10:00" ; popts[1]="36/1/" ; ropts[1]="/1"
+           topts[2]="0:10:00" ; popts[2]="30/2/" ; ropts[2]="/1"
         fi
 
         if [ "$debug" = ".true." ] ; then

--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -39,6 +39,11 @@ case $machine in
            memnode=512
            numcore=128
     ;;
+    noaacloud)
+	   sub_cmd="sub_noaacloud"
+	   memnode=96
+	   numcore=24
+    ;;
     *) # EXIT out for unresolved machine
         echo "unknown $machine"
         exit 1
@@ -73,6 +78,9 @@ case $regtest in
         elif [[ "$machine" = "wcoss2" || "$machine" = "acorn" ]]; then
            topts[1]="0:10:00" ; popts[1]="12/8/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="12/10/" ; ropts[2]="/2"
+	elif [[ "$machine" = "noaacloud" ]]; then
+           topts[1]="0:10:00" ; popts[1]="24/4/" ; ropts[1]="/1"
+           topts[2]="0:10:00" ; popts[2]="24/5/" ; ropts[2]="/2"
         fi
 
         if [ "$debug" = ".true." ] ; then
@@ -253,6 +261,9 @@ case $regtest in
         elif [[ "$machine" = "wcoss2" || "$machine" = "acorn" ]]; then
            topts[1]="0:10:00" ; popts[1]="16/2/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="16/4/" ; ropts[2]="/2"
+	elif [[ "$machine" = "noaacloud" ]]; then
+	   topts[1]="0:10:00" ; popts[1]="18/2/" ; ropts[1]="/1"
+	   topts[2]="0:10:00" ; popts[2]="20/3/" ; ropts[2]="/2"
         fi
 
         if [ "$debug" = ".true." ] ; then
@@ -319,4 +330,6 @@ elif [[ "$machine" = "wcoss2" || "$machine" = "acorn" ]]; then
    export FORT_BUFFERED=true
    export FI_OFI_RXM_SAR_LIMIT=3145728
    export APRUN="mpiexec -n \$ntasks -ppn \$ppn --cpu-bind core --depth \$threads"
+elif [[ "$machine" = "noaacloud" ]]; then
+   export APRUN="srun --mpi=pmi2 -n \$ntasks --cpus-per-task=\$threads"
 fi

--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -79,8 +79,8 @@ case $regtest in
            topts[1]="0:10:00" ; popts[1]="12/8/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="12/10/" ; ropts[2]="/2"
 	elif [[ "$machine" = "noaacloud" ]]; then
-           topts[1]="0:10:00" ; popts[1]="36/1/" ; ropts[1]="/1"
-           topts[2]="0:10:00" ; popts[2]="24/2/" ; ropts[2]="/2"
+           topts[1]="0:10:00" ; popts[1]="48/2/" ; ropts[1]="/1"
+           topts[2]="0:10:00" ; popts[2]="24/5/" ; ropts[2]="/2"
         fi
 
         if [ "$debug" = ".true." ] ; then
@@ -263,7 +263,7 @@ case $regtest in
            topts[2]="0:10:00" ; popts[2]="16/4/" ; ropts[2]="/2"
 	elif [[ "$machine" = "noaacloud" ]]; then
 	   topts[1]="0:10:00" ; popts[1]="36/1/" ; ropts[1]="/1"
-	   topts[2]="0:10:00" ; popts[2]="48/1/" ; ropts[2]="/1"
+	   topts[2]="0:10:00" ; popts[2]="30/2/" ; ropts[2]="/1"
         fi
 
         if [ "$debug" = ".true." ] ; then

--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -41,8 +41,8 @@ case $machine in
     ;;
     noaacloud)
 	   sub_cmd="sub_noaacloud"
-	   memnode=96
-	   numcore=24
+	   memnode=192
+	   numcore=48
     ;;
     *) # EXIT out for unresolved machine
         echo "unknown $machine"
@@ -79,8 +79,8 @@ case $regtest in
            topts[1]="0:10:00" ; popts[1]="12/8/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="12/10/" ; ropts[2]="/2"
 	elif [[ "$machine" = "noaacloud" ]]; then
-           topts[1]="0:20:00" ; popts[1]="24/4/" ; ropts[1]="/1"
-           topts[2]="0:20:00" ; popts[2]="24/5/" ; ropts[2]="/2"
+           topts[1]="0:20:00" ; popts[1]="48/2/" ; ropts[1]="/1"
+           topts[2]="0:20:00" ; popts[2]="40/3/" ; ropts[2]="/1"
         fi
 
         if [ "$debug" = ".true." ] ; then
@@ -262,8 +262,8 @@ case $regtest in
            topts[1]="0:10:00" ; popts[1]="16/2/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="16/4/" ; ropts[2]="/2"
 	elif [[ "$machine" = "noaacloud" ]]; then
-	   topts[1]="0:20:00" ; popts[1]="18/2/" ; ropts[1]="/1"
-	   topts[2]="0:20:00" ; popts[2]="20/3/" ; ropts[2]="/2"
+	   topts[1]="0:20:00" ; popts[1]="36/1/" ; ropts[1]="/1"
+	   topts[2]="0:20:00" ; popts[2]="30/2/" ; ropts[2]="/1"
         fi
 
         if [ "$debug" = ".true." ] ; then

--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -332,5 +332,5 @@ elif [[ "$machine" = "wcoss2" || "$machine" = "acorn" ]]; then
    export APRUN="mpiexec -n \$ntasks -ppn \$ppn --cpu-bind core --depth \$threads"
 elif [[ "$machine" = "noaacloud" ]]; then
    export I_MPI_ADJUST_ALLREDUCE=5
-   export APRUN="srun --mpi=pmi2 -n \$ntasks --cpus-per-task=\$threads"
+   export APRUN="srun --exclusive --distribution=cyclic:block --mpi=pmi2 -n \$ntasks --cpus-per-task=\$threads"
 fi

--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -79,8 +79,8 @@ case $regtest in
            topts[1]="0:10:00" ; popts[1]="12/8/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="12/10/" ; ropts[2]="/2"
 	elif [[ "$machine" = "noaacloud" ]]; then
-           topts[1]="0:20:00" ; popts[1]="48/2/" ; ropts[1]="/1"
-           topts[2]="0:20:00" ; popts[2]="40/3/" ; ropts[2]="/1"
+           topts[1]="0:10:00" ; popts[1]="36/1/" ; ropts[1]="/1"
+           topts[2]="0:10:00" ; popts[2]="24/2/" ; ropts[2]="/2"
         fi
 
         if [ "$debug" = ".true." ] ; then
@@ -262,8 +262,8 @@ case $regtest in
            topts[1]="0:10:00" ; popts[1]="16/2/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="16/4/" ; ropts[2]="/2"
 	elif [[ "$machine" = "noaacloud" ]]; then
-	   topts[1]="0:20:00" ; popts[1]="36/1/" ; ropts[1]="/1"
-	   topts[2]="0:20:00" ; popts[2]="30/2/" ; ropts[2]="/1"
+	   topts[1]="0:10:00" ; popts[1]="36/1/" ; ropts[1]="/1"
+	   topts[2]="0:10:00" ; popts[2]="48/1/" ; ropts[2]="/1"
         fi
 
         if [ "$debug" = ".true." ] ; then

--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -180,7 +180,7 @@ case $machine in
     export noscrub="${noscrub:-/contrib/$USER/noscrub}"
     export group="${group:-$USER}"
     export queue="${queue:-batch}"
-    export ptmp="${ptmp:-/contrib/$USER/ptmp}"
+    export ptmp="${ptmp:-/lustre/$USER/ptmp}"
     export casesdir="${casesdir:-/bucket/GSI_RTs}"
     export partition="${partition:-process}"
     export check_resource="yes"

--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -178,13 +178,13 @@ case $machine in
   noaacloud)
 
     export noscrub="${noscrub:-/contrib/$USER/noscrub}"
-    export group="${group:-$USER}"
+    #export group="${group:-$USER}"
     export queue="${queue:-batch}"
     export ptmp="${ptmp:-/lustre/$USER/ptmp}"
     export casesdir="${casesdir:-/bucket/GSI_RTs}"
-    export partition="${partition:-process}"
-    export check_resource="yes"
-    export accnt="${accnt:-ca-epic}"
+    export partition="${partition:-compute}"
+    export check_resource="no"
+    #export accnt="${accnt:-ca-epic}"
     export clean=".false."
   ;;
 

--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -208,12 +208,12 @@ export JCAP="62"
 
 # Case Study analysis dates
 if [[ "${machine}" == "noaacloud" ]]; then
-  # due to unavailable un-restricted versions of obs data 
+  # due to unavailable unrestricted versions of obs data 
   # for 2024022300 noaacloud uses its own global date
   export global_adate="2021122100"
 else
   export global_adate="2024022300"
-fi  
+fi
 export rtma_adate="2020022420"
 export rrfs_enkf_adate="2023061012"
 export rrfs_3denvar_rdasens_adate="2023061012"

--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -181,7 +181,7 @@ case $machine in
     export group="${group:-$USER}"
     export queue="${queue:-batch}"
     export ptmp="${ptmp:-/lustre/$USER/ptmp}"
-    export casesdir="${casesdir:-/bucket/GSI_RTs}"
+    export casesdir="${casesdir:-/lustre/GSI_RTs}"
     export partition="${partition:-compute}"
     export check_resource="no"
     export accnt="${accnt:-}"

--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -207,7 +207,13 @@ export savdir="$ptmp"
 export JCAP="62"
 
 # Case Study analysis dates
-export global_adate="2021122100" #"2024022300"
+if [[ "${machine}" == "noaacloud" ]]; then
+  # due to unavailable un-restricted versions of obs data 
+  # for 2024022300 noaacloud uses its own global date
+  export global_adate="2021122100"
+else
+  export global_adate="2024022300"
+fi  
 export rtma_adate="2020022420"
 export rrfs_enkf_adate="2023061012"
 export rrfs_3denvar_rdasens_adate="2023061012"

--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -178,13 +178,13 @@ case $machine in
   noaacloud)
 
     export noscrub="${noscrub:-/contrib/$USER/noscrub}"
-    #export group="${group:-$USER}"
+    export group="${group:-$USER}"
     export queue="${queue:-batch}"
     export ptmp="${ptmp:-/lustre/$USER/ptmp}"
     export casesdir="${casesdir:-/bucket/GSI_RTs}"
     export partition="${partition:-compute}"
     export check_resource="no"
-    #export accnt="${accnt:-ca-epic}"
+    export accnt="${accnt:-}"
     export clean=".false."
   ;;
 

--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -52,6 +52,12 @@ elif [[ -d /lfs/h2 ]]; then # wcoss2 or acorn
   else
     export machine="wcoss2"
   fi
+elif [[ ! -z "${PW_CSP:+x}" ]]; then # noaacloud
+   case "${PW_CSP}" in
+      "aws" | "google" | "azure")
+        export machine="noaacloud"
+        ;;
+   esac
 fi
 echo "Running Regression Tests on '$machine'";
 
@@ -169,6 +175,18 @@ case $machine in
     #  After completion of regression tests, will remove the regression test subdirecories
     export clean=".false."
   ;;
+  noaacloud)
+
+    export noscrub="${noscrub:-/contrib/$USER/noscrub}"
+    export group="${group:-$USER}"
+    export queue="${queue:-batch}"
+    export ptmp="${ptmp:-/contrib/$USER/ptmp}"
+    export casesdir="${casesdir:-/bucket/GSI_RTs}"
+    export partition="${partition:-process}"
+    export check_resource="yes"
+    export accnt="${accnt:-ca-epic}"
+    export clean=".false."
+  ;;
 
   *)
     echo "Regression tests are not setup on '$machine', ABORT!"
@@ -189,7 +207,7 @@ export savdir="$ptmp"
 export JCAP="62"
 
 # Case Study analysis dates
-export global_adate="2024022300"
+export global_adate="2021122100" #"2024022300"
 export rtma_adate="2020022420"
 export rrfs_enkf_adate="2023061012"
 export rrfs_3denvar_rdasens_adate="2023061012"

--- a/ush/sub_noaacloud
+++ b/ush/sub_noaacloud
@@ -92,7 +92,6 @@ DATA=${DATA:-$ptmp/tmp}
 
 mkdir -p $DATA
 
-#partition=${partition:-process}
 queue=${queue:-batch}
 timew=${timew:-01:20:00}
 task_node=${task_node:-$procs}
@@ -113,6 +112,7 @@ cat << EOF >> $cfile
 #SBATCH --nodes=$nodes
 #SBATCH --ntasks-per-node=$procs
 #SBATCH --exclusive
+#SBATCH --partition=$partition
 
 set -x
 export ntasks=$(( $nodes * $procs ))

--- a/ush/sub_noaacloud
+++ b/ush/sub_noaacloud
@@ -112,7 +112,6 @@ cat << EOF >> $cfile
 #SBATCH --time=$timew
 #SBATCH --nodes=$nodes
 #SBATCH --ntasks-per-node=$procs
-#SBATCH --cpus-per-task=$threads
 #SBATCH --exclusive
 
 set -x

--- a/ush/sub_noaacloud
+++ b/ush/sub_noaacloud
@@ -1,0 +1,154 @@
+#!/bin/bash
+set -x
+usage="\
+Usage:  $0 [options] executable [args]
+      where the options are:
+      -a account        account (default: none)
+      -b binding        run smt binding or not (default:NO)
+      -d dirin          initial directory (default: cwd)
+      -e envars         copy comma-separated environment variables
+      -g group          group name
+      -i                append standard input to command file
+      -j jobname        specify jobname (default: executable basename)
+      -m machine        machine on which to run (default: current)
+      -n                write command file to stdout rather than submitting it
+      -o output         specify output file (default: jobname.out)
+      -p procs[/nodes[/ppreq]
+                        number of MPI tasks and optional nodes or Bblocking and
+                        ppreq option (N or S) (defaults: serial, Bunlimited, S)
+      -q queue[/qpreq]  queue name and optional requirement, e.g. dev/P
+                        (defaults: 1 if serial or dev if parallel and none)
+                        (queue 3 or 4 is dev or prod with twice tasks over ip)
+                        (options: P=parallel, B=bigmem, b=batch)
+      -r rmem[/rcpu]    resources memory and cpus/task (default: '1024 mb', 1)
+      -t timew          wall time limit in [[hh:]mm:]ss format (default: 900)
+      -u userid         userid to run under (default: self)
+      -v                verbose mode
+      -w when           when to run, in yyyymmddhh[mm], +hh[mm], thh[mm], or
+                        Thh[mm] (full, incremental, today or tomorrow) format
+                        (default: now)
+Function:  This command submits a job to the batch queue."
+subcmd="$*"
+stdin=NO
+nosub=NO
+account=""
+binding="NO"
+dirin=""
+envars=""
+group=""
+jobname=""
+machine=""
+output=""
+procs=0
+nodes=""
+ppreq=""
+queue=""
+qpreq=""
+rmem="1024"
+rcpu="1"
+timew="900"
+userid=""
+verbose=NO
+when=""
+while getopts a:b:d:e:g:ij:m:no:p:q:r:t:u:vw: opt;do
+  case $opt in
+    a) account="$OPTARG";;
+    b) binding="$OPTARG";;
+    d) dirin="$OPTARG";;
+    e) envars="$OPTARG";;
+    g) group="$OPTARG";;
+    i) stdin=YES;;
+    j) jobname=$OPTARG;;
+    m) machine="$OPTARG";;
+    n) nosub=YES;;
+    o) output=$OPTARG;;
+    p) procs=$(echo $OPTARG/|cut -d/ -f1);nodes=$(echo $OPTARG/|cut -d/ -f2);ppreq=$(echo $OPTARG/|cut -d/ -f3);;
+    q) queue=$(echo $OPTARG/|cut -d/ -f1);qpreq=$(echo $OPTARG/|cut -d/ -f2);;
+    r) rmem=$(echo $OPTARG/|cut -d/ -f1);rcpu=$(echo $OPTARG/|cut -d/ -f2);;
+    t) timew=$OPTARG;;
+    u) userid=$OPTARG;;
+    v) verbose=YES;;
+    w) when=$OPTARG;;
+    \?) echo $0: invalid option >&2;echo "$usage" >&2;exit 1;;
+  esac
+done
+shift $(($OPTIND-1))
+if [[ $# -eq 0 ]];then
+  echo $0: missing executable name >&2;echo "$usage" >&2;exit 1
+fi
+exec=$1
+if [[ ! -s $exec ]]&&which $exec >/dev/null 2>&1;then
+  exec=$(which $exec)
+fi
+shift
+args="$*"
+bn=$(basename $exec)
+export jobname=${jobname:-$bn}
+output=${output:-$jobname.out}
+myuser=$LOGNAME
+myhost=$(hostname)
+
+DATA=${DATA:-$ptmp/tmp}
+
+mkdir -p $DATA
+
+#partition=${partition:-process}
+queue=${queue:-batch}
+timew=${timew:-01:20:00}
+task_node=${task_node:-$procs}
+size=$((nodes*task_node))
+envars=$envars
+threads=${rcpu:-1}
+
+export TZ=GMT
+cfile=$DATA/sub$$
+#> $cfile
+cat << EOF >> $cfile
+#!/bin/bash
+
+#SBATCH --output=$output
+#SBATCH --job-name=$jobname
+#SBATCH --qos=$queue
+#SBATCH --time=$timew
+#SBATCH --nodes=$nodes
+#SBATCH --ntasks-per-node=$procs
+#SBATCH --exclusive
+
+set -x
+export ntasks=$(( $nodes * $procs ))
+export ppn=$procs
+export threads=$threads
+export OMP_NUM_THREADS=$threads
+
+. "$(awk '{ print $1, $2, $3, $4, $5, $6, $7, $8, $9 }' $regdir/regression_var.out)"
+
+module purge
+module use $modulefiles
+module load gsi_noaacloud.intel
+module list
+EOF
+
+cat $exec >> $cfile
+
+if [[ $nosub = YES ]];then
+  cat $cfile
+  exit
+elif [[ $verbose = YES ]];then
+  set -x
+  cat $cfile
+fi
+sbatch=${sbatch:-sbatch}
+
+ofile=$DATA/subout$$
+>$ofile
+chmod 777 $ofile
+$sbatch $cfile >$ofile
+rc=$?
+cat $ofile
+if [[ -w $SUBLOG ]];then
+  jobn=$(grep -i submitted $ofile|head -n1|cut -d\" -f2)
+  date -u +"%Y%m%d%H%M%S : $subcmd : $jobn" >>$SUBLOG
+fi
+#rm $cfile $ofile
+#[[ $MKDATA = YES ]] && rmdir $DATA
+exit $rc

--- a/ush/sub_noaacloud
+++ b/ush/sub_noaacloud
@@ -14,8 +14,8 @@ Usage:  $0 [options] executable [args]
       -n                write command file to stdout rather than submitting it
       -o output         specify output file (default: jobname.out)
       -p procs[/nodes[/ppreq]
-                        number of MPI tasks and optional nodes or Bblocking and
-                        ppreq option (N or S) (defaults: serial, Bunlimited, S)
+                        number of MPI tasks and optional nodes or blocking and
+                        ppreq option (N or S) (defaults: serial, unlimited, S)
       -q queue[/qpreq]  queue name and optional requirement, e.g. dev/P
                         (defaults: 1 if serial or dev if parallel and none)
                         (queue 3 or 4 is dev or prod with twice tasks over ip)

--- a/ush/sub_noaacloud
+++ b/ush/sub_noaacloud
@@ -112,6 +112,7 @@ cat << EOF >> $cfile
 #SBATCH --time=$timew
 #SBATCH --nodes=$nodes
 #SBATCH --ntasks-per-node=$procs
+#SBATCH --cpus-per-task=$threads
 #SBATCH --exclusive
 
 set -x
@@ -149,6 +150,6 @@ if [[ -w $SUBLOG ]];then
   jobn=$(grep -i submitted $ofile|head -n1|cut -d\" -f2)
   date -u +"%Y%m%d%H%M%S : $subcmd : $jobn" >>$SUBLOG
 fi
-#rm $cfile $ofile
-#[[ $MKDATA = YES ]] && rmdir $DATA
+rm $cfile $ofile
+[[ $MKDATA = YES ]] && rmdir $DATA
 exit $rc


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

This PR enables running global regression tests on the cloud. In establishing a baseline for the regression tests, I discovered that either 1) staging data on AWS FSx for Lustre or 2) staging data on an S3 bucket and linking the AWS FSx for Lustre mount to the bucket allowed for reproducible results. Thus, the noaacloud paths for `CRTM_FIX` and `GSI_BINARY_SOURCE_DIR`  are updated to be within lustre mount. Additionally, restricted data cannot be staged on the cloud so that un-restricted versions of obs BUFR files needed to be used. Since the currently set date for the global ctests are after when GDA spaces stopped being populated with unrestricted versions, I staged data for 2021122018-2021122100. This is why there is an if-block in the `regression_var.sh` script to set a different `global_adate` for noaacloud only. 

Resolves #944 
Resolves #951 

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

Cloned and built duplicate copies of GSI at head of develop under `GSI/develop` and `GSI/update`, then ran `ctest -R global` from `GSI/update/build`. Tested multiple configurations until I settled on those specified in this PR. 
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published