### PR TITLE
GSI for 3DRTMA: Enhancement of Valley-Check for Surface Obs of T & Q and Applying GSD Terrain Match to MESONET Obs of T (kx=188) 

### DIFF
--- a/src/gsi/gsd_terrain_match_surfTobs.f90
+++ b/src/gsi/gsd_terrain_match_surfTobs.f90
@@ -32,7 +32,7 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
   use gsi_metguess_mod, only: gsi_metguess_bundle
   use gsi_bundlemod, only: gsi_bundlegetpointer  
   use mpeu_util, only: die
-  use rapidrefresh_cldsurf_mod, only: i_gsd_terrain_match_mso
+  use rapidrefresh_cldsurf_mod, only: i_gsd_terrain_match_mesonet
 
   implicit none
 
@@ -88,7 +88,7 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
      iqtflg=nint(cdata_all(9,iobsout)) == 0
 
 !here starts surface data correction   DEDE 28 April 2009
-     if(kx==181.or.kx==187.or.(i_gsd_terrain_match_mso==1.and.kx==188)) then
+     if(kx==181.or.kx==187.or.(i_gsd_terrain_match_mesonet==1.and.kx==188)) then
         toe     = cdata_all(1,iobsout)
         dlon    = cdata_all(2,iobsout)
         dlat    = cdata_all(3,iobsout)

--- a/src/gsi/gsd_terrain_match_surfTobs.f90
+++ b/src/gsi/gsd_terrain_match_surfTobs.f90
@@ -32,6 +32,7 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
   use gsi_metguess_mod, only: gsi_metguess_bundle
   use gsi_bundlemod, only: gsi_bundlegetpointer  
   use mpeu_util, only: die
+  use rapidrefresh_cldsurf_mod, only: i_gsd_terrain_match_mso
 
   implicit none
 
@@ -87,7 +88,7 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
      iqtflg=nint(cdata_all(9,iobsout)) == 0
 
 !here starts surface data correction   DEDE 28 April 2009
-     if(kx==181.or.kx==187) then
+     if(kx==181.or.kx==187.or.(i_gsd_terrain_match_mso==1.and.kx==188)) then
         toe     = cdata_all(1,iobsout)
         dlon    = cdata_all(2,iobsout)
         dlat    = cdata_all(3,iobsout)

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -185,7 +185,7 @@
                             i_cloud_q_innovation,i_ens_mean,DTsTmax,&
                             i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check, &
                             corp_howv, hwllp_howv, corp_gust, hwllp_gust, oerr_gust, i_howv_mask, &
-                            i_sfcrough_fgs, corp_vis, hwllp_vis
+                            i_sfcrough_fgs, corp_vis, hwllp_vis, i_gsd_terrain_match_mso
   use gsi_metguess_mod, only: gsi_metguess_init,gsi_metguess_final
   use gsi_chemguess_mod, only: gsi_chemguess_init,gsi_chemguess_final
   use tcv_mod, only: init_tcps_errvals,tcp_refps,tcp_width,tcp_ermin,tcp_ermax
@@ -1632,6 +1632,10 @@
 !                            in transformed space, not physical space
 !      hwllp_vis     - real, background error de-correlation length scale of visibility
 !                            in transformed space, not physical space
+!      i_gsd_terrain_match_mso - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
+!                                observations of Temp (188, 195)
+!                          = 0 : do not apply GSD terrain match to MESONET Obs of T (default)
+!                          = 1 : apply GSD terrain match to MESONET Obs of T
 !
   namelist/rapidrefresh_cldsurf/dfi_radar_latent_heat_time_period, &
                                 metar_impact_radius,metar_impact_radius_lowcloud, &
@@ -1654,7 +1658,7 @@
                                 i_cloud_q_innovation,i_ens_mean,DTsTmax, &
                                 i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check, &
                                 corp_howv, hwllp_howv, corp_gust, hwllp_gust, oerr_gust, i_howv_mask, &
-                                i_sfcrough_fgs, corp_vis, hwllp_vis
+                                i_sfcrough_fgs, corp_vis, hwllp_vis, i_gsd_terrain_match_mso
 
 ! chem(options for gsi chem analysis) :
 !     berror_chem       - .true. when background  for chemical species that require

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -185,7 +185,7 @@
                             i_cloud_q_innovation,i_ens_mean,DTsTmax,&
                             i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check, &
                             corp_howv, hwllp_howv, corp_gust, hwllp_gust, oerr_gust, i_howv_mask, &
-                            i_sfcrough_fgs, corp_vis, hwllp_vis, i_gsd_terrain_match_mso
+                            i_sfcrough_fgs, corp_vis, hwllp_vis, i_gsd_terrain_match_mesonet
   use gsi_metguess_mod, only: gsi_metguess_init,gsi_metguess_final
   use gsi_chemguess_mod, only: gsi_chemguess_init,gsi_chemguess_final
   use tcv_mod, only: init_tcps_errvals,tcp_refps,tcp_width,tcp_ermin,tcp_ermax
@@ -1632,7 +1632,7 @@
 !                            in transformed space, not physical space
 !      hwllp_vis     - real, background error de-correlation length scale of visibility
 !                            in transformed space, not physical space
-!      i_gsd_terrain_match_mso - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
+!      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
 !                                observations of Temp (188, 195)
 !                          = 0 : do not apply GSD terrain match to MESONET Obs of T (default)
 !                          = 1 : apply GSD terrain match to MESONET Obs of T
@@ -1658,7 +1658,7 @@
                                 i_cloud_q_innovation,i_ens_mean,DTsTmax, &
                                 i_T_Q_adjust,l_saturate_bkCloud,l_rtma3d,i_precip_vertical_check, &
                                 corp_howv, hwllp_howv, corp_gust, hwllp_gust, oerr_gust, i_howv_mask, &
-                                i_sfcrough_fgs, corp_vis, hwllp_vis, i_gsd_terrain_match_mso
+                                i_sfcrough_fgs, corp_vis, hwllp_vis, i_gsd_terrain_match_mesonet
 
 ! chem(options for gsi chem analysis) :
 !     berror_chem       - .true. when background  for chemical species that require

--- a/src/gsi/rapidrefresh_cldsurf_mod.f90
+++ b/src/gsi/rapidrefresh_cldsurf_mod.f90
@@ -251,7 +251,7 @@ module rapidrefresh_cldsurf_mod
 !                          = 0 (vis-off: default) : no analysis of visibility in 3D analysis.
 !                          = 1 (vis-on) : if variable name "vis" is found in anavinfo,
 !                                          set it to be 1 to turn on analysis of visibility;
-!      i_gsd_terrain_match_mso - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
+!      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
 !                                observations of Temp (188, 195)
 !                          = 0 : do not apply GSD terrain match to MESONET Obs of T (default)
 !                          = 1 : apply GSD terrain match to MESONET Obs of T
@@ -334,7 +334,7 @@ module rapidrefresh_cldsurf_mod
   public :: i_sfcrough_fgs
   public :: corp_vis, hwllp_vis
   public :: i_vis_3dda
-  public :: i_gsd_terrain_match_mso
+  public :: i_gsd_terrain_match_mesonet
 
   logical l_hydrometeor_bkio
   real(r_kind)  dfi_radar_latent_heat_time_period
@@ -401,7 +401,7 @@ module rapidrefresh_cldsurf_mod
   integer(i_kind)   :: i_sfcrough_fgs
   real(r_kind)      :: corp_vis, hwllp_vis
   integer(i_kind)   :: i_vis_3dda
-  integer(i_kind)   :: i_gsd_terrain_match_mso
+  integer(i_kind)   :: i_gsd_terrain_match_mesonet
 
 contains
 
@@ -551,7 +551,7 @@ contains
 
     i_vis_3dda          = 0                           ! no analysis of visibility (vis) in 3D analysis (default)
 
-    i_gsd_terrain_match_mso = 0                       ! no GSD terrain match applied to METSONET obs (default)
+    i_gsd_terrain_match_mesonet = 0                   ! no GSD terrain match applied to METSONET obs (default)
 
 !-- searching for specific variable in state variable list (reading from anavinfo)
     do i2=1,ns2d

--- a/src/gsi/rapidrefresh_cldsurf_mod.f90
+++ b/src/gsi/rapidrefresh_cldsurf_mod.f90
@@ -251,6 +251,10 @@ module rapidrefresh_cldsurf_mod
 !                          = 0 (vis-off: default) : no analysis of visibility in 3D analysis.
 !                          = 1 (vis-on) : if variable name "vis" is found in anavinfo,
 !                                          set it to be 1 to turn on analysis of visibility;
+!      i_gsd_terrain_match_mso - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
+!                                observations of Temp (188, 195)
+!                          = 0 : do not apply GSD terrain match to MESONET Obs of T (default)
+!                          = 1 : apply GSD terrain match to MESONET Obs of T
 !
 ! attributes:
 !   language: f90
@@ -330,6 +334,7 @@ module rapidrefresh_cldsurf_mod
   public :: i_sfcrough_fgs
   public :: corp_vis, hwllp_vis
   public :: i_vis_3dda
+  public :: i_gsd_terrain_match_mso
 
   logical l_hydrometeor_bkio
   real(r_kind)  dfi_radar_latent_heat_time_period
@@ -396,6 +401,7 @@ module rapidrefresh_cldsurf_mod
   integer(i_kind)   :: i_sfcrough_fgs
   real(r_kind)      :: corp_vis, hwllp_vis
   integer(i_kind)   :: i_vis_3dda
+  integer(i_kind)   :: i_gsd_terrain_match_mso
 
 contains
 
@@ -544,6 +550,8 @@ contains
                                                       ! "rapidrefresh_cldsurf" of GSI namelist file
 
     i_vis_3dda          = 0                           ! no analysis of visibility (vis) in 3D analysis (default)
+
+    i_gsd_terrain_match_mso = 0                       ! no GSD terrain match applied to METSONET obs (default)
 
 !-- searching for specific variable in state variable list (reading from anavinfo)
     do i2=1,ns2d

--- a/src/gsi/read_prepbufr.F90
+++ b/src/gsi/read_prepbufr.F90
@@ -365,6 +365,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
   real(r_kind) :: tempcldch,cldchout
   real(r_kind) :: windsensht
   real(r_kind) :: windbiasfact
+  real(r_kind) :: usage_valleyadj
 
   integer(i_kind) ivtcd,iglcd !integer virtual temp program code and GLERL program code
 
@@ -2058,6 +2059,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
 
               windbiasfact=one
 
+              usage_valleyadj=zero
               if (sfctype) then
                  if (i_gsdsfc_uselist==1 ) then
                     if (kx==188 .or. kx==195 .or. kx==288.or.kx==295)  &
@@ -2079,6 +2081,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                     call tll2xy(dlon_earth,dlat_earth,x_obs,y_obs,outside_obs)
                     if ((trim(obstype)=='t' .or. trim(obstype)=='q') .and. .not.outside_obs) then
                        call valley_adjustment(x_obs,y_obs,usage)
+                       usage_valleyadj=usage - REAL(INT(usage), kind=r_kind)
                     end if
                  end if
 
@@ -2282,6 +2285,13 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
 
               if(qm >= 8 .or. usage >= 100.0_r_kind)then
                  rusage(iout)=.false.
+              end if
+
+!             In case that the obs usage was reset by some ObsQC and the usage value adjusted by 
+!             valley-map was lost. So re-applying the valley-map adjusted usage value back to usage.
+              if (sfctype .and. (l_rtma3d .or. twodvar_regional) .and.          &
+                  (trim(obstype)=='t' .or. trim(obstype)=='q')   ) then
+                  usage=REAL(INT(usage), kind=r_kind) + usage_valleyadj
               end if
 
 !             Temperature


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

### Description

<!-- Please include relevant motivation and context. -->
**_Motivation_**
The purposes of this PR is to fix two issues as described in Issue #954 and #955:

1. The valley-map adjusted usage value of surface observation is very useful information in the ObsQC of RTMA. Recently RTMA colleague reported that for some surface observations of Q, their valley-adjusted usage values were lost and reset to some other values. Therefore the efforts were made to investigate the cause, and find a solution to fix it. For details of the motivation, see issue #954;
2. To improve the analysis of MESONET observations of Temperature, the GSD Terrain Match adjustment, which was used for surface obs of T (kx=181 & 187), is extended to Mesonet obs of T (kx=188). For details. see issue #955. 

<!-- Please include a summary of the change and which issue is fixed. -->
**_Causes to the Issues and the Solutions_**

1. For issue #954, checking the GSI code "[read_prepbufr.F90](https://github.com/NOAA-EMC/GSI/blob/develop/src/gsi/read_prepbufr.F90)", it can be noticed that, the Valley Check and Adjustment is done for 2D or 3D RTMA at [line 2078~2083](https://github.com/NOAA-EMC/GSI/blob/13b754cc5edbf3fd276a75d9de91c9f354a534fc/src/gsi/read_prepbufr.F90#L2078), then after the valley adjustment, some Obs QC procedures would set the obs usage value to specific values to mark these "problematic" observations, for example, at [line 2106-2210](https://github.com/NOAA-EMC/GSI/blob/13b754cc5edbf3fd276a75d9de91c9f354a534fc/src/gsi/read_prepbufr.F90#L2106), under some critical conditions, the usage of the observations of Td (as obs of Q) is set to be 116, 117 or 118. This explains the value of 116.0 in the example described in issue #954. 
Since the Valley-check adjustment to the usage value is to add a specific value (between 0.0 and 1.0, e.g, 0.25) to the original usage value, to fix this issue (keeping the adjust usage value 0.25 and also keeping the usage value which is set by other ObsQC procedures), one solution is to do the valley-check adjustment just before the usage value is dumped into cdata_all array for each observation, that is to move the lines 2078-2083 to the place before [line 2287](https://github.com/NOAA-EMC/GSI/blob/13b754cc5edbf3fd276a75d9de91c9f354a534fc/src/gsi/read_prepbufr.F90#L2287). Manuel pointed out that this approach ("moving the valley check to the line before cdata_all is populated") might have "a certain danger". He suggested that, if the usage value of a sfcobs is adjusted by valley-check, then saving the adjust value (0.25) to a variable usage_valleyadj, then after all the other ObsQC are done and before the the usage value is dumped to cdata_array (before line 2287), adding the adjusted value (saved in variable usage_valleyadj) to the integer part of usage value (since all the other ObsQC only assign integer values to usage variable). This approach is adopted and implemented in read_prepbufr.F90 code for this PR.

2. For issue #955, the solution is simple, just adding the kx==188 when applying terrain match to surface obs of T (in [gsd_terrain_match_surfTobs.f90](https://github.com/NOAA-EMC/GSI/blob/develop/src/gsi/gsd_terrain_match_surfTobs.f90)), [line 90](https://github.com/NOAA-EMC/GSI/blob/13b754cc5edbf3fd276a75d9de91c9f354a534fc/src/gsi/gsd_terrain_match_surfTobs.f90#L90) is modified to 

   `if(kx==181.or.kx==187.or.(i_gsd_terrain_match_mso==1.and.kx==188)) then`

    the option "i_gsd_terrain_match_mso" is introduced here to control the application of terrain match to mesonet obs of T. If it   is equal to 1, then apply the terrain match to mesonet obs. By default it is 0, so terrain match is not applied to mesonet obs in most DA system. User can set this option to be 1 in GSI namelist to turn it on for mesonet obs.

<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

Fixes #954
Fixes #955 

### Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
  
**_Checklist_**

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing tests pass with my changes
- [X] Any dependent changes have been merged and published

1. Modified GSI code was tested with real-case data (2025-09-23_00:00 and 2025-11-14_00:00) on WCOSS2-Cactus, the analysis results are reasonable as expected;
2. GSI Ctests: the modified code passed all the 6 regression tasks to confirm that the modifications do not have influence to other DA systems. Here are the GSI Ctest results:
        1. GSI  CTest results on **_WCOSS2(Cactus)_** for [commit 6a03603](https://github.com/GangZhao-NOAA/GSI/commit/6a03603c1240d21871e3289ac1d993a149a257a3) against the develop branch of emc_gsi [commit 13b754c](https://github.com/NOAA-EMC/GSI/commit/13b754cc5edbf3fd276a75d9de91c9f354a534fc)
       
```
[gang.zhao@clogin03:build] (feature/ValleyChkEnhanced_TerrainMatchMSO188_3drtma)$ ctest -N
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
  Test # 1: global_4denvar
  Test # 2: rtma
  Test # 3: rrfs_3denvar_rdasens
  Test # 4: hafs_4denvar_glbens
  Test # 5: hafs_3denvar_hybens
  Test # 6: global_enkf
Total Tests: 6
[gang.zhao@clogin03:build] (feature/ValleyChkEnhanced_TerrainMatchMSO188_3drtma)$ nohup ctest -j 6 > ./ctest_6tasks_run_ValleyChkEnh_TernMatchMSO188_run02.txt 2>&1 &
[1] 3834888
nohup: ignoring input
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 4: hafs_4denvar_glbens
    Start 6: global_enkf
    Start 5: hafs_3denvar_hybens
    Start 3: rrfs_3denvar_rdasens
1/6 Test # 3: rrfs_3denvar_rdasens .............   Passed  774.40 sec
2/6 Test # 2: rtma .............................   Passed  1223.15 sec
3/6 Test # 5: hafs_3denvar_hybens ..............   Passed  1274.29 sec
4/6 Test # 4: hafs_4denvar_glbens ..............   Passed  1512.52 sec
5/6 Test # 6: global_enkf ......................   Passed  1849.77 sec
6/6 Test # 1: global_4denvar ...................   Passed  1996.06 sec
100% tests passed, 0 tests failed out of 6
Total Test time (real) = 1996.19 sec
```
2. GSI  CTest results on **_WCOSS2(Cactus)_** for [commit a1007cb](https://github.com/NOAA-EMC/GSI/pull/957/commits/a1007cb64379ecba804eb52688bd8d85ce095df8) against the develop branch of emc_gsi [commit 13b754c](https://github.com/NOAA-EMC/GSI/commit/13b754cc5edbf3fd276a75d9de91c9f354a534fc)
```  
[gang.zhao@clogin03:build] (feature/ValleyChkEnhanced_TerrainMatchMSO188_3drtma)$ ctest -N
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
  Test 1: global_4denvar
  Test 2: rtma
  Test 3: rrfs_3denvar_rdasens
  Test 4: hafs_4denvar_glbens
  Test 5: hafs_3denvar_hybens
  Test 6: global_enkf
Total Tests: 6
[gang.zhao@clogin03:build] (feature/ValleyChkEnhanced_TerrainMatchMSO188_3drtma)$ nohup ctest -j 6 > ./ctest_6tasks_run_ValleyChkEnh_TernMatchMSO188_run03.txt 2>&1 &
[1] 2655294
nohup: ignoring input
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
    Start 4: hafs_4denvar_glbens
    Start 1: global_4denvar
    Start 6: global_enkf
    Start 5: hafs_3denvar_hybens
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
1/6 Test 3: rrfs_3denvar_rdasens .............   Passed  735.88 sec
2/6 Test 2: rtma .............................   Passed  1164.77 sec
3/6 Test 5: hafs_3denvar_hybens ..............   Passed  1230.97 sec
4/6 Test 6: global_enkf ......................   Passed  1434.93 sec
5/6 Test 4: hafs_4denvar_glbens ..............   Passed  1513.53 sec
6/6 Test 1: global_4denvar ...................   Passed  1987.67 sec
100% tests passed, 0 tests failed out of 6
Total Test time (real) = 1987.92 sec
```  