### PR TITLE
Resolve spuriously large EnKF increments by disabling shared-memory window in `mpi_readobs.f90`

### DIFF
--- a/src/enkf/mpi_readobs.f90
+++ b/src/enkf/mpi_readobs.f90
@@ -33,7 +33,7 @@ module mpi_readobs
 !$$$
   
 use kinds, only: r_double,i_kind,r_kind,r_single,num_bytes_for_r_single
-use params, only: ntasks_io, nanals_per_iotask, nanal1, nanal2
+use params, only: ntasks_io, nanals_per_iotask, nanal1, nanal2, use_shmem_window
 use radinfo, only: npred
 use readconvobs
 use readsatobs
@@ -148,7 +148,11 @@ subroutine mpi_getobs(obspath, datestring, nobs_conv, nobs_oz, nobs_sat, nobs_to
     ! associate fortran pointer with c pointer to shared memory 
     ! segment (containing observation prior ensemble) on each task.
     call MPI_Win_shared_query(shm_win, 0, segment_size, disp_unit, anal_ob_cp, ierr)
-    allocate(anal_ob(nanals, nobs_tot))
+    if (use_shmem_window) then
+       call c_f_pointer(anal_ob_cp, anal_ob, [nanals, nobs_tot])
+    else
+       allocate(anal_ob(nanals, nobs_tot))
+    endif
     ! initialize shared memory window.
     anal_ob=0
     if (neigv > 0) then
@@ -249,27 +253,37 @@ subroutine mpi_getobs(obspath, datestring, nobs_conv, nobs_oz, nobs_sat, nobs_to
     if (nproc == 0) t1 = mpi_wtime()
 ! exchange obs prior ensemble members across all tasks to fully populate shared
 ! memory array pointer on each node.
+    if ((use_shmem_window .and. nproc_shm == 0) .or. (.not. use_shmem_window)) then
        if (real(nanals)*real(nobs_tot) < 2_r_kind**32/2_r_kind - 1_r_kind) then
-          call mpi_allreduce(mpi_in_place,anal_ob,nanals*nobs_tot,mpi_real4,mpi_sum,mpi_comm_world,ierr)
+          if (use_shmem_window) then
+             call mpi_allreduce(mpi_in_place,anal_ob,nanals*nobs_tot,mpi_real4,mpi_sum,mpi_comm_shmemroot,ierr)
+          else
+             call mpi_allreduce(mpi_in_place,anal_ob,nanals*nobs_tot,mpi_real4,mpi_sum,mpi_comm_world,ierr)
+          endif
        else
           ! count won't fit in 32-bit integer and mpi_allreduce doesn't handle
           ! 64 bit counts.  Split up into smaller chunks.
           mem_ob = 0.
           do na=1,nanals
               mem_ob(:) = anal_ob(na,:)
-              call mpi_allreduce(mpi_in_place,mem_ob,nobs_tot,mpi_real4,mpi_sum,mpi_comm_world,ierr)
+              if (use_shmem_window) then
+                 call mpi_allreduce(mpi_in_place,mem_ob,nobs_tot,mpi_real4,mpi_sum,mpi_comm_world,ierr)
+              else
+                 call mpi_allreduce(mpi_in_place,mem_ob,nobs_tot,mpi_real4,mpi_sum,mpi_comm_shmemroot,ierr)
+              endif
               anal_ob(na,:) = mem_ob(:)
           enddo
        endif
        !print *,nproc,'min/max anal_ob',minval(anal_ob),maxval(anal_ob)
-    if (nproc_shm == 0) then
-       if (neigv > 0) then
-          mem_ob_modens = 0.
-          do na=1,nanals
-             mem_ob_modens(:,:) = anal_ob_modens(neigv*(na-1)+1:neigv*na,:)
-             call mpi_allreduce(mpi_in_place,mem_ob_modens,neigv*nobs_tot,mpi_real4,mpi_sum,mpi_comm_shmemroot,ierr)
-             anal_ob_modens(neigv*(na-1)+1:neigv*na,:) = mem_ob_modens(:,:)
-          enddo
+       if (use_shmem_window .or. nproc_shm == 0) then
+          if (neigv > 0) then
+             mem_ob_modens = 0.
+             do na=1,nanals
+                mem_ob_modens(:,:) = anal_ob_modens(neigv*(na-1)+1:neigv*na,:)
+                call mpi_allreduce(mpi_in_place,mem_ob_modens,neigv*nobs_tot,mpi_real4,mpi_sum,mpi_comm_shmemroot,ierr)
+                anal_ob_modens(neigv*(na-1)+1:neigv*na,:) = mem_ob_modens(:,:)
+             enddo
+          endif
        endif
     endif
     if (nproc == 0) then
@@ -287,16 +301,18 @@ subroutine mpi_getobs(obspath, datestring, nobs_conv, nobs_oz, nobs_sat, nobs_to
     do nob=1,nobs_tot
        ensmean_obbc(nob)  = sum(anal_ob(:,nob))*analsi
     enddo
+    if ((use_shmem_window .and. nproc_shm == 0) .or. (.not. use_shmem_window)) then
        do nob=1,nobs_tot
 ! remove ensemble mean from each member.
 ! ensmean_obbc is biascorrected ensemble mean (anal_ob is ens pert)
           anal_ob(:,nob) = anal_ob(:,nob)-ensmean_obbc(nob)
        enddo
-    if (nproc_shm == 0) then
-       if (neigv > 0) then
-          do nob=1,nobs_tot
-             anal_ob_modens(:,nob) = anal_ob_modens(:,nob)-ensmean_obbc(nob)
-          enddo
+       if (use_shmem_window .or. nproc_shm == 0) then ! NEW
+          if (neigv > 0) then
+             do nob=1,nobs_tot
+                anal_ob_modens(:,nob) = anal_ob_modens(:,nob)-ensmean_obbc(nob)
+             enddo
+          endif
        endif
     endif
     call mpi_barrier(mpi_comm_world,ierr)

--- a/src/enkf/mpi_readobs.f90
+++ b/src/enkf/mpi_readobs.f90
@@ -148,7 +148,6 @@ subroutine mpi_getobs(obspath, datestring, nobs_conv, nobs_oz, nobs_sat, nobs_to
     ! associate fortran pointer with c pointer to shared memory 
     ! segment (containing observation prior ensemble) on each task.
     call MPI_Win_shared_query(shm_win, 0, segment_size, disp_unit, anal_ob_cp, ierr)
-    !call c_f_pointer(anal_ob_cp, anal_ob, [nanals, nobs_tot])
     allocate(anal_ob(nanals, nobs_tot))
     ! initialize shared memory window.
     anal_ob=0
@@ -250,7 +249,6 @@ subroutine mpi_getobs(obspath, datestring, nobs_conv, nobs_oz, nobs_sat, nobs_to
     if (nproc == 0) t1 = mpi_wtime()
 ! exchange obs prior ensemble members across all tasks to fully populate shared
 ! memory array pointer on each node.
-!    if (nproc_shm == 0) then
        if (real(nanals)*real(nobs_tot) < 2_r_kind**32/2_r_kind - 1_r_kind) then
           call mpi_allreduce(mpi_in_place,anal_ob,nanals*nobs_tot,mpi_real4,mpi_sum,mpi_comm_world,ierr)
        else
@@ -289,7 +287,6 @@ subroutine mpi_getobs(obspath, datestring, nobs_conv, nobs_oz, nobs_sat, nobs_to
     do nob=1,nobs_tot
        ensmean_obbc(nob)  = sum(anal_ob(:,nob))*analsi
     enddo
-    !if (nproc_shm == 0) then
        do nob=1,nobs_tot
 ! remove ensemble mean from each member.
 ! ensmean_obbc is biascorrected ensemble mean (anal_ob is ens pert)

--- a/src/enkf/mpi_readobs.f90
+++ b/src/enkf/mpi_readobs.f90
@@ -148,7 +148,8 @@ subroutine mpi_getobs(obspath, datestring, nobs_conv, nobs_oz, nobs_sat, nobs_to
     ! associate fortran pointer with c pointer to shared memory 
     ! segment (containing observation prior ensemble) on each task.
     call MPI_Win_shared_query(shm_win, 0, segment_size, disp_unit, anal_ob_cp, ierr)
-    call c_f_pointer(anal_ob_cp, anal_ob, [nanals, nobs_tot])
+    !call c_f_pointer(anal_ob_cp, anal_ob, [nanals, nobs_tot])
+    allocate(anal_ob(nanals, nobs_tot))
     ! initialize shared memory window.
     anal_ob=0
     if (neigv > 0) then
@@ -249,20 +250,21 @@ subroutine mpi_getobs(obspath, datestring, nobs_conv, nobs_oz, nobs_sat, nobs_to
     if (nproc == 0) t1 = mpi_wtime()
 ! exchange obs prior ensemble members across all tasks to fully populate shared
 ! memory array pointer on each node.
-    if (nproc_shm == 0) then
+!    if (nproc_shm == 0) then
        if (real(nanals)*real(nobs_tot) < 2_r_kind**32/2_r_kind - 1_r_kind) then
-          call mpi_allreduce(mpi_in_place,anal_ob,nanals*nobs_tot,mpi_real4,mpi_sum,mpi_comm_shmemroot,ierr)
+          call mpi_allreduce(mpi_in_place,anal_ob,nanals*nobs_tot,mpi_real4,mpi_sum,mpi_comm_world,ierr)
        else
           ! count won't fit in 32-bit integer and mpi_allreduce doesn't handle
           ! 64 bit counts.  Split up into smaller chunks.
           mem_ob = 0.
           do na=1,nanals
               mem_ob(:) = anal_ob(na,:)
-              call mpi_allreduce(mpi_in_place,mem_ob,nobs_tot,mpi_real4,mpi_sum,mpi_comm_shmemroot,ierr)
+              call mpi_allreduce(mpi_in_place,mem_ob,nobs_tot,mpi_real4,mpi_sum,mpi_comm_world,ierr)
               anal_ob(na,:) = mem_ob(:)
           enddo
        endif
        !print *,nproc,'min/max anal_ob',minval(anal_ob),maxval(anal_ob)
+    if (nproc_shm == 0) then
        if (neigv > 0) then
           mem_ob_modens = 0.
           do na=1,nanals
@@ -287,12 +289,13 @@ subroutine mpi_getobs(obspath, datestring, nobs_conv, nobs_oz, nobs_sat, nobs_to
     do nob=1,nobs_tot
        ensmean_obbc(nob)  = sum(anal_ob(:,nob))*analsi
     enddo
-    if (nproc_shm == 0) then
+    !if (nproc_shm == 0) then
        do nob=1,nobs_tot
 ! remove ensemble mean from each member.
 ! ensmean_obbc is biascorrected ensemble mean (anal_ob is ens pert)
           anal_ob(:,nob) = anal_ob(:,nob)-ensmean_obbc(nob)
        enddo
+    if (nproc_shm == 0) then
        if (neigv > 0) then
           do nob=1,nobs_tot
              anal_ob_modens(:,nob) = anal_ob_modens(:,nob)-ensmean_obbc(nob)

--- a/src/enkf/params.f90
+++ b/src/enkf/params.f90
@@ -235,6 +235,9 @@ logical,public :: lobsdiag_forenkf = .false.
 ! if true, use netcdf diag files, otherwise use binary diags
 logical,public :: netcdf_diag = .false.
 
+! Option to toggle the shared memory segment in mpi_readobs
+logical,public :: use_shmem_window = .true.
+
 ! use fv3 cubed-sphere tiled restart files
 logical,public :: fv3_native = .false.
 character(len=500),public :: fv3fixpath = ' '
@@ -286,7 +289,7 @@ namelist /nam_enkf/datestring,datapath,iassim_order,nvars,&
                    fv3_native, paranc, nccompress, write_fv3_incr,incvars_to_zero,write_ensmean, &
                    corrlengthrdrnh,corrlengthrdrsh,corrlengthrdrtr,&
                    lnsigcutoffrdrnh,lnsigcutoffrdrsh,lnsigcutoffrdrtr,&
-                   l_use_enkf_directZDA
+                   l_use_enkf_directZDA,use_shmem_window
 namelist /nam_wrf/arw,nmm,nmm_restart
 namelist /nam_fv3/fv3fixpath,nx_res,ny_res,ntiles,l_pres_add_saved,l_fv3reg_filecombined, &
                   fv3_io_layout_nx,fv3_io_layout_ny


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

As mentioned in #960, we find spuriously large increments in the EnKF when running RRFS retros with the `release/rrfs.v1.0.0` branch. 

This PR resolves the large increments by modifying `src/enkf/mpi_readobs.f90` to stop using a shared-memory window for `anal_ob`, instead allocating it as a standard local array on each rank. It also switches the MPI reductions from a node-level communicator to `MPI_COMM_WORLD` and adjusts which sections are guarded by the shared-memory root logic so that reductions occur on all ranks rather than only on the shared-memory root. 

Fixes #960

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Tested by running RRFS retros on WCOSS2 for three cycles. Increment magnitudes were much more reasonable after this update. 
  
Note that we cannot run the ctests in the `release/rrfs.v1.0.0` or `release/rrfs.v1.1.0` branches since the regression tests lag behind the develop branch. 

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published