### PR TITLE
replace ufbin3 with ufbevn

### DIFF
--- a/src/gsi/read_pblh.f90
+++ b/src/gsi/read_pblh.f90
@@ -374,13 +374,13 @@
 ! OBLVL == SRC FHR <PEVN> <QEVN> <TEVN> <ZEVN> <WEVN> <CEVN> <SEVN>
 !       == SRC FHR POB PMO QOB    TOB    ZOB   UOB VOB ...  ! {P,Q,T,Z,W}EVN
 !     cnem='SRC FHR POB PMO QOB TOB ZOB UOB VOB'
-!     call ufbin3(lunin,olv,MXNM,MXRP,MXRP, nlevp,nlevo,cnem)
+!     call ufbevn(lunin,olv,MXNM,MXRP,MXRP, nlevp,nlevo,cnem)
 
 ! CEVN == CAPE CINH LI PBL TROP PWO
 !     cnem='CAPE CINH LI PBL TROP PWO'
       cnem='PBL'   ! for Caterina's files (ruc_raobs)
       clv=bmiss
-      call ufbin3(lunin,clv,MXNM,MXRP,MXRP, nlevp,nlevc,cnem)
+      call ufbevn(lunin,clv,MXNM,MXRP,MXRP, nlevp,nlevc,cnem)
 !     pblhob=clv(4,1,2)
       pblhob=clv(1,1,2)
       pblbak=clv(1,1,1)   ! model PBL; from Caterina's files
@@ -422,7 +422,7 @@
 
 ! SEVN == HOVI MXTM MITM TDO TOCC MXGS THI TCH CDBZ
 !     cnem='HOVI MXTM MITM TDO TOCC MXGS THI TCH CDBZ'
-!     call ufbin3(lunin,slv,MXNM,MXRP,MXRP, nlevp,nlevs,cnem)
+!     call ufbevn(lunin,slv,MXNM,MXRP,MXRP, nlevp,nlevs,cnem)
 
 !--Outputs
 


### PR DESCRIPTION
**Description**

[`bufr/12.3.0`](https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/681) is scheduled to be released in coming weeks.  Subroutine `ufbin3` is not available in the new bufr module.  `src/gsi/read_pblh.f90` calls `ufbin3`.  Calls to `ufbin3` need to be replaced by `ufbevn` as documented in GSI issue #952.  This changes has already been made for RRFS v1 via GSI PR #963.  

This PR replaces `ufbin3` with `ufbevn` in GSI `develop`.

Resolves #952

**Type of change**
- [x] Mainteance

**How Has This Been Tested?**
GSI ctests ran and _Passed_ on WCOSS2 (Cactus) and Hera.  See issue #952 for [ctest details](https://github.com/NOAA-EMC/GSI/issues/952#issuecomment-3637075902).
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes
