### PR TITLE
Compile in Ubuntu Intel container with spack stack 1.9.2

### DIFF
--- a/modulefiles/gsi_container.intel.lua
+++ b/modulefiles/gsi_container.intel.lua
@@ -3,26 +3,19 @@ help([[
 
 prepend_path("MODULEPATH", "/opt/spack-stack/spack-stack-1.9.2/envs/unified-env/install/modulefiles/Core")
 
-stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.0"
-stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
+local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.0"
+local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
-local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))
 load(pathJoin("cmake", cmake_ver))
 
 load("gsi_common")
-load(pathJoin("prod_util", prod_util_ver))
 
-pushenv("CFLAGS", "-march=ivybridge")
-pushenv("FFLAGS", "-march=ivybridge")
+pushenv("CFLAGS", "-xHOST")
+pushenv("FFLAGS", "-xHOST")
 
-setenv("CC","mpiicc")
-setenv("CXX","mpiicpc")
-setenv("FC","mpiifort")
-setenv("F90","mpiifort")
-setenv("F77","mpiifort")
-pushenv("USE_BUFR4", "YES")
+pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20250529")
 
 whatis("Description: GSI environment in a container with Intel Compilers")

--- a/modulefiles/gsi_container.intel.lua
+++ b/modulefiles/gsi_container.intel.lua
@@ -1,14 +1,14 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/opt/spack-stack/spack-stack-1.8.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/opt/spack-stack/spack-stack-1.9.2/envs/unified-env/install/modulefiles/Core")
 
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.12.2"
+stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.0"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
 local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 
-load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 load(pathJoin("cmake", cmake_ver))
 

--- a/modulefiles/gsi_container.intel.lua
+++ b/modulefiles/gsi_container.intel.lua
@@ -16,6 +16,7 @@ load("gsi_common")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20250529")
+-- pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20250529")
+pushenv("GSI_BINARY_SOURCE_DIR", "/scratch3/NCEPDEV/global/role.glopara/fix/gsi/20251105")
 
 whatis("Description: GSI environment in a container with Intel Compilers")

--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -24,7 +24,7 @@ load("gsi_common")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20251105")
-setenv("CRTM_FIX", pathJoin("/contrib/global-workflow-shared-data/fix/crtm", "v" .. crtm_fix_ver))
+pushenv("GSI_BINARY_SOURCE_DIR", "/lustre/fix/gsi/20251105")
+setenv("CRTM_FIX", pathJoin("/lustre/fix/crtm", "v" .. crtm_fix_ver))
 
 whatis("Description: GSI environment on NOAA Cloud with Intel Compilers")

--- a/modulefiles/gsi_noaacloud.intel.lua
+++ b/modulefiles/gsi_noaacloud.intel.lua
@@ -24,7 +24,7 @@ load("gsi_common")
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-pushenv("GSI_BINARY_SOURCE_DIR", "/lustre/fix/gsi/20251105")
-setenv("CRTM_FIX", pathJoin("/lustre/fix/crtm", "v" .. crtm_fix_ver))
+pushenv("GSI_BINARY_SOURCE_DIR", "/contrib/global-workflow-shared-data/fix/gsi/20251105")
+setenv("CRTM_FIX", pathJoin("/contrib/global-workflow-shared-data/fix/crtm", "v" .. crtm_fix_ver))
 
 whatis("Description: GSI environment on NOAA Cloud with Intel Compilers")

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -8,6 +8,11 @@
 #
 # Thank you for your contribution
 
+# Overwrite auto-detect in in container
+if [[ -v SINGULARITY_CONTAINER ]]; then
+  MACHINE_ID=container
+fi
+
 # If the MACHINE_ID variable is set, skip this script.
 [[ -n ${MACHINE_ID:-} ]] && return
 
@@ -55,10 +60,7 @@ if [[ "${MACHINE_ID}" != "UNKNOWN" ]]; then
 fi
 
 # Try searching based on paths since hostname may not match on compute nodes
-if [[ -d /opt/spack-stack ]]; then
-  # We are in a container
-  MACHINE_ID=container
-elif [[ -d /lfs/h3 ]]; then
+if [[ -d /lfs/h3 ]]; then
   # We are on NOAA Cactus or Dogwood
   MACHINE_ID=wcoss2
 elif [[ -d /lfs/h1 && ! -d /lfs/h3 ]]; then


### PR DESCRIPTION
**Description**

With Global-Workflow GFS forecast only worked in container, so want to make GSI run in container as well. As the first step, make it compiler in the Ubuntu Intel container with spack-stack 1.9.2 first.

Resolve issue: #965

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] This change requires a documentation update, later

**How Has This Been Tested?**

This need a container, on ursa, at:
/scratch3/NCEPDEV/nems/role.epic/containers/ubuntu22.04-intel-ufs-env-v1.9.2.img

On ursa, run the following command to "shell" into container, and compile there.
sif=ubuntu22.04-intel-ufs-env-v1.9.2.img
img=/scratch3/NCEPDEV/nems/role.epic/containers/${sif}
bindings="-B /scratch3 -B /scratch4"
singularity shell -e ${bindings} "${img}"

cd gwdir/sorc/gsi_enkf.fd
ush/build.sh

Also compiled on AWS.  

**Checklist**

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ x] Any dependent changes have been merged and published