### PR TITLE
Remove distribution sbatch setting for noaacloud RTs

### DIFF
--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -332,5 +332,5 @@ elif [[ "$machine" = "wcoss2" || "$machine" = "acorn" ]]; then
    export APRUN="mpiexec -n \$ntasks -ppn \$ppn --cpu-bind core --depth \$threads"
 elif [[ "$machine" = "noaacloud" ]]; then
    export I_MPI_ADJUST_ALLREDUCE=5
-   export APRUN="srun --exclusive --distribution=cyclic:block --mpi=pmi2 -n \$ntasks --cpus-per-task=\$threads"
+   export APRUN="srun --exclusive --mpi=pmi2 -n \$ntasks --cpus-per-task=\$threads"
 fi


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**

<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->

This PR removes the sbatch distribution directive for noaacloud CTests. As reported in #970, this option slightly improved computational performance (specifically with `gsi.x`) but introduced reproducibility issues (specifically with `enkf.x`) that was missed in #953. Apologies for missing this issue.

Resolves #970   

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

Ran global CTests on AWS noaacloud with control and update set at head of GSI develop with proposed changes. Results:

```
[Taylor.Roper@gsiglobalrts-20 build]$ ctest -R global
Test project /contrib/dev/GSI/update/build
    Start 1: global_4denvar
1/2 Test #1: global_4denvar ...................   Passed  1681.77 sec
    Start 6: global_enkf
2/2 Test #6: global_enkf ......................   Passed  971.14 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) = 2652.98 sec
```
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published