### PR TITLE
revert PR #837 changes to develop radinfo.f90

### DIFF
--- a/src/gsi/radinfo.f90
+++ b/src/gsi/radinfo.f90
@@ -1254,7 +1254,6 @@ contains
 ! !USES:
 
     use mpimod, only: mype
-    use constants, only: r10000
     implicit none
 
     integer(i_kind),optional, intent(in) :: pe_out
@@ -1275,11 +1274,7 @@ contains
           rewind lunout
           do jch=1,jpch_rad
              do i=1,npred
-                if (inew_rad(jch) .or. abs(ostats(jch)) .le. tiny(ostats(1))) then
-                   varx(i) = r10000
-                else
-                   varx(i)=varA(i,jch)
-                endif
+                varx(i)=varA(i,jch)
              end do
              write(lunout,'(I5,1x,A20,1x,I5,e15.7/2(4x,10e15.7/))') jch,nusis(jch),&
                   nuchan(jch),ostats(jch),(varx(ip),ip=1,npred)


### PR DESCRIPTION
**Description**

This issues reverts [changes](https://github.com/NOAA-EMC/GSI/pull/837/changes#diff-db169fdc38210452b29e4ab1bf43c3ae28c6a05c16faeb736591fc44c725f02a) made to `src/gsi/radinfo.f90` in PR #837.

Resolves #932

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Run the 20260113 00 through 12Z analysis with the revised code with the `satbias_pc.out` from each run used in the successive run.  The 2026011312 gnorm reduction curve is significantly improved with respect to the run using the current `radinfo.f90`.

ctests will be run but they are likely to show any difference since this bugfix is requires cycling to evaluate.
  
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass with my changes