### PR TITLE
set inunit independent of file existence (#987)

### DIFF
--- a/src/gsi/hybrid_ensemble_isotropic.F90
+++ b/src/gsi/hybrid_ensemble_isotropic.F90
@@ -1025,8 +1025,8 @@ subroutine normal_new_factorization_rf_x
       write(np, '(i0)') npes; np = adjustl(np)
       input= 'xnorm_new.'//trim(np)//'.'//trim(nlat)//'.'//trim(nlon)
       inquire (file=trim(input), EXIST=exists)
+      inunit=2000+mype
       if (exists) then
-        inunit=2000+mype
         open(inunit,file=trim(input),form='unformatted',action='read')
         read(inunit) xnorm_new
         close(inunit)


### PR DESCRIPTION
**Description**

This PR ensures `inunit` is set in subroutine `normal_new_factorization_rf_x` (file `hybrid_ensemble_isotropic.F90`) independent of whether or not an input file exists.  Failure to set `inunit` for the case in which the input file does not exist causes `gsi.x` to seg fault when built with the IntelLLVM 2025.2.1 ifx compiler.

Resolves #987

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Build GSI with the change from this PR in a spack-stack/2.0.0 build on Ursa.  Run hafs_3denvar_hybens and hafs_4denvar_glbens using the resulting `gsi.x`.  The `gsi.x` ran to completion for both cases.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published