### PR TITLE
Address unused variables for GSI_MODE=GFS (#995)

### DIFF
--- a/src/gsi/stub_get_pseudo_ensperts.f90
+++ b/src/gsi/stub_get_pseudo_ensperts.f90
@@ -34,7 +34,10 @@ contains
     class(get_pseudo_ensperts_class), intent(inout) :: this
     type(gsi_bundle),allocatable, intent(in   ) :: en_perts(:,:,:)
     integer(i_kind),                   intent(in   ) :: nelen
-  
+
+    associate( this => this, en_perts => en_perts, nelen => nelen )
+    end associate  
+
     write(6,*)'get_pseudo_ensperts:  ***WARNING*** dummy call ... does nothing!'
   
     return

--- a/src/gsi/stub_get_wrf_mass_ensperts.f90
+++ b/src/gsi/stub_get_wrf_mass_ensperts.f90
@@ -41,6 +41,10 @@ contains
     type(gsi_bundle),allocatable, intent(in   ) :: en_perts(:,:,:)
     integer(i_kind), intent(in   ):: nelen
     type(gsi_bundle),OPTIONAL,intent(in):: en_bar
+
+    associate( this => this, mype => mype, en_perts => en_perts, nelen => nelen, en_bar => en_bar )
+    end associate
+
     write(6,*)'get_wrf_mass_ensperts:  ***WARNING*** dummy call ... does nothing!'
   return
   end subroutine ens_spread_dualres_regional_dummy
@@ -53,6 +57,10 @@ contains
     type(gsi_bundle),allocatable, intent(inout) :: en_perts(:,:,:)
     integer(i_kind), intent(in   ):: nelen
     real(r_single),dimension(:,:,:),allocatable:: ps_bar
+
+    associate( this => this, en_perts => en_perts, nelen => nelen, ps_bar => ps_bar )
+    end associate
+
     write(6,*)'get_wrf_mass_ensperts:  ***WARNING*** dummy call ... does nothing!'
   return
   end subroutine get_wrf_mass_ensperts_dummy

--- a/src/gsi/stub_get_wrf_nmm_ensperts.f90
+++ b/src/gsi/stub_get_wrf_nmm_ensperts.f90
@@ -17,7 +17,11 @@ contains
     integer(i_kind), intent(in   ):: nelen
     real(r_kind),allocatable, intent(inout):: region_lat_ens(:,:),region_lon_ens(:,:)
     real(r_single),dimension(:,:,:),allocatable, intent(inout):: ps_bar
-  
+
+    associate( this => this, en_perts => en_perts, nelen => nelen, ps_bar => ps_bar, &
+               region_lat_ens => region_lat_ens, region_lon_ens => region_lon_ens )
+    end associate 
+
     write(6,*)'GET_WRF_NMM_ENSPERTS:  ***WARNING*** dummy call ... does nothing!'
   return
   end subroutine get_wrf_nmm_ensperts_dummy
@@ -44,6 +48,9 @@ contains
   !$$$ end documentation block
     implicit none
     class(get_wrf_nmm_ensperts_class), intent(inout) :: this
+
+    associate( this => this )
+    end associate
   
     write(6,*)'CONVERT_BINARY_NMM_ENS:  ***WARNING*** dummy call ... does nothing!'
     return

--- a/src/gsi/stub_read_wrf_mass_files.f90
+++ b/src/gsi/stub_read_wrf_mass_files.f90
@@ -45,7 +45,10 @@ contains
     class(read_wrf_mass_files_class),intent(inout) :: this
     integer(i_kind),intent(in   ) :: mype
 
-  
+
+    associate( this => this, mype => mype )
+    end associate
+
     write(6,*)'READ_WRF_MASS_FILES:     ***WARNING*** dummy call ... does nothing!'
   ! End of routine
     return

--- a/src/gsi/stub_read_wrf_mass_guess.f90
+++ b/src/gsi/stub_read_wrf_mass_guess.f90
@@ -30,6 +30,10 @@ contains
     implicit none
     class(read_wrf_mass_guess_class),intent(inout) :: this
     integer(i_kind),intent(in)::mype
+
+    associate( this => this, mype => mype )
+    end associate
+
     write(6,*)'READ_WRF_MASS_BINARY_GUESS:  dummy routine, does nothing!'
   end subroutine read_wrf_mass_binary_guess_dummy
   
@@ -57,6 +61,10 @@ contains
     implicit none
     class(read_wrf_mass_guess_class),intent(inout) :: this
     integer(i_kind),intent(in)::mype
+
+    associate( this => this, mype => mype )
+    end associate
+
     write(6,*)'READ_WRF_MASS_NETCDF_GUESS:  dummy routine, does nothing!'
   end subroutine read_wrf_mass_netcdf_guess_dummy
 end module read_wrf_mass_guess_mod

--- a/src/gsi/stub_read_wrf_nmm_files.f90
+++ b/src/gsi/stub_read_wrf_nmm_files.f90
@@ -48,6 +48,9 @@ contains
     integer(i_kind),intent(in   ) :: mype
     class(read_wrf_nmm_files_class),intent(inout) :: this
   
+    associate( this => this, mype => mype )
+    end associate
+
     write(6,*)'READ_WRF_NMM_FILES:     ***WARNING*** dummy call ... does nothing!'
   
   ! End of routine
@@ -62,6 +65,9 @@ contains
     integer(i_kind),intent(in   ) :: mype
     class(read_wrf_nmm_files_class),intent(inout) :: this
   
+    associate( this => this, mype => mype )
+    end associate
+
     write(6,*)'READ_NEMS_NMMB_FILES:     ***WARNING*** dummy call ... does nothing!'
   
   ! End of routine

--- a/src/gsi/stub_read_wrf_nmm_guess.f90
+++ b/src/gsi/stub_read_wrf_nmm_guess.f90
@@ -14,6 +14,10 @@ contains
   ! Declare passed variables here
     class(read_wrf_nmm_guess_class),intent(inout) :: this
     integer(i_kind),intent(in):: mype
+
+    associate( this => this, mype => mype )
+    end associate
+
     write(6,*)'READ_WRF_NMM_BINARY_GUESS:  dummy routine, does nothing!'
   end subroutine read_wrf_nmm_binary_guess_dummy
   
@@ -24,6 +28,10 @@ contains
   ! Declare passed variables here
     class(read_wrf_nmm_guess_class),intent(inout) :: this
     integer(i_kind),intent(in):: mype
+
+    associate( this => this, mype => mype )
+    end associate
+
     write(6,*)'READ_WRF_NMM_NETCDF_GUESS:  dummy routine, does nothing!'
   end subroutine read_wrf_nmm_netcdf_guess_dummy
   subroutine read_nems_nmmb_guess_dummy(this,mype)
@@ -33,6 +41,10 @@ contains
   ! Declare passed variables here
     class(read_wrf_nmm_guess_class),intent(inout) :: this
     integer(i_kind),intent(in):: mype
+
+    associate( this => this, mype => mype )
+    end associate
+
     write(6,*)'READ_NEMS_NMMB_GUESS:  dummy routine, does nothing!'
   end subroutine read_nems_nmmb_guess_dummy
 

--- a/src/gsi/stub_regional_io.f90
+++ b/src/gsi/stub_regional_io.f90
@@ -36,6 +36,10 @@ contains
   subroutine init_regional_io_dummy(this)
     implicit none
     class(regional_io_class), intent(inout) :: this
+
+    associate( this => this )
+    end associate
+
     if(VERBOSE) write(6,*) 'DUMMY CALL to init_regional_io'
     return
   end subroutine init_regional_io_dummy
@@ -45,6 +49,10 @@ contains
     implicit none
     class(regional_io_class), intent(inout) :: this
     integer(i_kind),intent(in):: mype
+
+    associate( this => this, mype => mype )
+    end associate
+
     if(VERBOSE) write(6,*) 'DUMMY CALL to write_regional_analysis'
     return
   end subroutine write_regional_analysis_dummy
@@ -58,6 +66,10 @@ contains
     ctph0 = 0.0_r_kind
     stph0 = 0.0_r_kind
     tlm0 = 0.0_r_kind
+
+    associate( this => this, mype => mype )
+    end associate
+
     if(VERBOSE) write(6,*) 'DUMMY CALL to convert_regional_guess'
     return
   end subroutine convert_regional_guess_dummy

--- a/src/gsi/stub_wrf_binary_interface.f90
+++ b/src/gsi/stub_wrf_binary_interface.f90
@@ -25,6 +25,10 @@ contains
   subroutine convert_binary_mass_dummy(this)
     implicit none
     class(get_wrf_binary_interface_class), intent(inout) :: this
+
+    associate( this => this )
+    end associate
+
   end subroutine convert_binary_mass_dummy
 
   subroutine convert_binary_nmm_dummy(this,update_pint,ctph0,stph0,tlm0)
@@ -37,6 +41,10 @@ contains
     ctph0 = zero
     stph0 = zero
     tlm0 = zero
+
+    associate( this => this, update_pint => update_pint )
+    end associate
+
   end subroutine convert_binary_nmm_dummy
 
   subroutine convert_nems_nmmb_dummy(this,update_pint,ctph0,stph0,tlm0)
@@ -49,6 +57,10 @@ contains
     ctph0 = zero
     stph0 = zero
     tlm0 = zero
+
+    associate( this => this, update_pint => update_pint )
+    end associate
+
   end subroutine convert_nems_nmmb_dummy
 
 end module get_wrf_binary_interface_mod

--- a/src/gsi/stub_wrf_netcdf_interface.f90
+++ b/src/gsi/stub_wrf_netcdf_interface.f90
@@ -26,6 +26,10 @@ contains
     
     implicit none
     class(convert_netcdf_class) ,intent(inout) :: this
+
+    associate( this => this )
+    end associate
+
   end subroutine convert_netcdf_mass_dummy
   
   subroutine convert_netcdf_nmm_dummy(this,update_pint,ctph0,stph0,tlm0,guess)
@@ -39,12 +43,19 @@ contains
     ctph0 = zero 
     stph0 = zero 
     tlm0 = zero 
+
+    associate( this => this, update_pint => update_pint, guess => guess )
+    end associate
+
   end subroutine convert_netcdf_nmm_dummy
   
   subroutine update_netcdf_mass_dummy(this)
   
     implicit none
     class(convert_netcdf_class) ,intent(inout) :: this
+
+    associate( this => this )
+    end associate
   
   end subroutine update_netcdf_mass_dummy
   
@@ -52,6 +63,10 @@ contains
   
     implicit none
     class(convert_netcdf_class) ,intent(inout) :: this
+  
+
+    associate( this => this )
+    end associate
   
   end subroutine update_netcdf_nmm_dummy
 end module convert_netcdf_mod

--- a/src/gsi/stub_wrwrfmassa.f90
+++ b/src/gsi/stub_wrwrfmassa.f90
@@ -36,7 +36,10 @@ contains
     implicit none
     class(wrwrfmassa_class), intent(inout) :: this 
     integer(i_kind),intent(in   ) :: mype
-  
+
+    associate( this => this )
+    end associate
+
     if (mype==0) write(6,*)'WRWRFMASSA_BINARY:  enter dummy call, do nothing'
   end subroutine wrwrfmassa_binary_dummy
   
@@ -92,6 +95,9 @@ contains
     class(wrwrfmassa_class), intent(inout) :: this 
     integer(i_kind),intent(in   ) :: mype
   
+    associate( this => this )
+    end associate
+
     if (mype==0) write(6,*)'WRWRFMASSA_NETCDF:  enter dummy call, do nothing'
     
   end subroutine wrwrfmassa_netcdf_dummy

--- a/src/gsi/stub_wrwrfnmma.f90
+++ b/src/gsi/stub_wrwrfnmma.f90
@@ -35,7 +35,10 @@ contains
     implicit none
     class(wrwrfnmma_class), intent(inout) :: this 
     integer(i_kind),intent(in   ) :: mype
-  
+
+    associate( this => this )
+    end associate
+
     if (mype==0) write(6,*)'WRWRFNMMA_BINARY:  enter dummy call, do nothing'
   end subroutine  wrwrfnmma_binary_dummy
   
@@ -68,7 +71,10 @@ contains
   
     class(wrwrfnmma_class), intent(inout) :: this 
     integer(i_kind),intent(in   ) :: mype
-  
+ 
+    associate( this => this )
+    end associate
+
     if (mype==0) write(6,*)'WRNEMSNMMA_BINARY:  enter dummy call, do nothing'
   end subroutine  wrnemsnmma_binary_dummy
   
@@ -103,6 +109,9 @@ contains
     class(wrwrfnmma_class), intent(inout) :: this 
     integer(i_kind),intent(in   ) :: mype
   
+    associate( this => this )
+    end associate
+
     if (mype==0) write(6,*)'WRWRFNMMA_NETCDF:  enter dummy call, do nothing'
   end subroutine wrwrfnmma_netcdf_dummy
 end module wrwrfnmma_mod


### PR DESCRIPTION
**Description**
For the GFSv17 implementation, the GSI needs to compile in debug mode with no warnings or remarks.  This is the case when compiled using the "Regional" option.  This PR extends that to the "GFS" option as well, removing remarks about unused variables in the stub routines.

Fixes #995

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

ctests were run on Ursa and Gaea C6 with all tests eventually passing (results will be posted below)
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published