### PR TITLE
Applying GSD Terrain Match to MESONET Obs of T with missing pressure and Adjusting bad report upper-limit to use aircraft reject list for 3DRTMA

### DIFF
--- a/src/gsi/aircraftobsqc.f90
+++ b/src/gsi/aircraftobsqc.f90
@@ -76,7 +76,7 @@ subroutine init_aircraft_rjlists
   integer(i_kind) aircraft_unit,m
   character(80) cstring
 
-  integer(i_kind), parameter::nmax=500
+  integer(i_kind), parameter::nmax=5000
 
   data aircraft_unit / 20 /
 !**************************************************************************
@@ -114,7 +114,7 @@ subroutine init_aircraft_rjlists
        q_aircraft_rjlist(nqrjs_aircraft,1)=cstring(1:8)
        q_aircraft_rjlist(nqrjs_aircraft,2)=cstring(22:29)
     endif
-    if(max(ntrjs_aircraft,nqrjs_aircraft,nqrjs_aircraft) == nmax)then
+    if(max(ntrjs_aircraft,nwrjs_aircraft,nqrjs_aircraft) == nmax)then
       print*, 'aircraft_rjlist reached maximum ', nmax, ' stop reading list -- increase nmax'
       exit read_loop
     end if

--- a/src/gsi/gsd_terrain_match_surfTobs.f90
+++ b/src/gsi/gsd_terrain_match_surfTobs.f90
@@ -89,8 +89,7 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
 
 !here starts surface data correction   DEDE 28 April 2009
      if(kx==181.or.kx==187.or.                                                  &
-        (i_gsd_terrain_match_mesonet==1.and.kx==188).or.                        &
-        (i_gsd_terrain_match_mesonet==2.and.(kx==188.or.kx==192.or.kx==193.or.kx==195))) then
+        (i_gsd_terrain_match_mesonet==1.and.(kx==188.or.kx==192.or.kx==193.or.kx==195))) then
         toe     = cdata_all(1,iobsout)
         dlon    = cdata_all(2,iobsout)
         dlat    = cdata_all(3,iobsout)

--- a/src/gsi/gsd_terrain_match_surfTobs.f90
+++ b/src/gsi/gsd_terrain_match_surfTobs.f90
@@ -88,7 +88,9 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
      iqtflg=nint(cdata_all(9,iobsout)) == 0
 
 !here starts surface data correction   DEDE 28 April 2009
-     if(kx==181.or.kx==187.or.(i_gsd_terrain_match_mesonet==1.and.kx==188)) then
+     if(kx==181.or.kx==187.or.                                                  &
+        (i_gsd_terrain_match_mesonet==1.and.kx==188).or.                        &
+        (i_gsd_terrain_match_mesonet==2.and.(kx==188.or.kx==192.or.kx==193.or.kx==195))) then
         toe     = cdata_all(1,iobsout)
         dlon    = cdata_all(2,iobsout)
         dlat    = cdata_all(3,iobsout)

--- a/src/gsi/gsd_terrain_match_surfTobs.f90
+++ b/src/gsi/gsd_terrain_match_surfTobs.f90
@@ -32,7 +32,7 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
   use gsi_metguess_mod, only: gsi_metguess_bundle
   use gsi_bundlemod, only: gsi_bundlegetpointer  
   use mpeu_util, only: die
-  use rapidrefresh_cldsurf_mod, only: i_gsd_terrain_match_mesonet
+  use rapidrefresh_cldsurf_mod, only: i_gsd_terrain_match_mesonet, l_rtma3d
 
   implicit none
 
@@ -62,6 +62,7 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
   integer(i_kind) iobsout, kx, nc, ier, istatus
   real(r_kind) toe,dlat,dlon
   real(r_kind) stnelev, dlnpob, usage
+  real(r_kind) oe_factor
 
   real(r_kind),dimension(:,:  ),pointer:: ges_ps_nt=>NULL()
   real(r_kind),dimension(:,:  ),pointer:: ges_z_nt =>NULL()
@@ -89,7 +90,7 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
 
 !here starts surface data correction   DEDE 28 April 2009
      if(kx==181.or.kx==187.or.                                                  &
-        (i_gsd_terrain_match_mesonet==1.and.(kx==188.or.kx==192.or.kx==193.or.kx==195))) then
+        (i_gsd_terrain_match_mesonet>=1.and.(kx==188.or.kx==192.or.kx==193.or.kx==195))) then
         toe     = cdata_all(1,iobsout)
         dlon    = cdata_all(2,iobsout)
         dlat    = cdata_all(3,iobsout)
@@ -117,7 +118,27 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
         dlnpob=log(pres1)
 
         toe=cdata_all(1,iobsout)
-        if(kx>179.and.kx<190) toe=toe*r0_5  !DEDE 12 Feb 2009
+!       adjustment of observation error
+        if(kx>179.and.kx<200) then
+!           special treatment of obs error for RTMA3D run
+            if (l_rtma3d) then
+                oe_factor=1.0_r_kind
+                select case (i_gsd_terrain_match_mesonet)
+                    case (0:1)    ! default: no adjustment to oberr, because very small oberr is used
+                                  !          for surface obs in 3DRTMA (1/16 of oberr used in HRRR).
+                        oe_factor=1.0_r_kind
+                    case (2:10)   ! for tunning oberr with gsd terrain matching
+                        oe_factor=real(i_gsd_terrain_match_mesonet, r_kind)/10.0_r_kind
+                    case (11:)    ! adjusted in the same way as the original setup by GSD developer
+                        oe_factor=r0_5
+                    case ( :-1)   ! only kx=181/187 is adjusted in the same way as the original setup by GSD developer
+                        oe_factor=r0_5
+                end select
+                toe=toe*oe_factor
+            else
+                toe=toe*r0_5  !DEDE 12 Feb 2009 (original setup by GSD developer)
+            end if
+        end if
 
         cdata_all(1,iobsout)=toe
         cdata_all(4,iobsout)=dlnpob

--- a/src/gsi/gsd_terrain_match_surfTobs.f90
+++ b/src/gsi/gsd_terrain_match_surfTobs.f90
@@ -89,8 +89,8 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
      iqtflg=nint(cdata_all(9,iobsout)) == 0
 
 !here starts surface data correction   DEDE 28 April 2009
-     if(kx==181.or.kx==187.or.                                                  &
-        (i_gsd_terrain_match_mesonet>=1.and.(kx==188.or.kx==192.or.kx==193.or.kx==195))) then
+     if(  kx==181.or.kx==187.or.                                                &
+        ((kx==188.or.kx==195.or.kx==192.or.kx==193).and.i_gsd_terrain_match_mesonet>=1) ) then
         toe     = cdata_all(1,iobsout)
         dlon    = cdata_all(2,iobsout)
         dlat    = cdata_all(3,iobsout)
@@ -120,18 +120,19 @@ subroutine gsd_terrain_match_surfTobs(mype,nreal,ndata,cdata_all)
         toe=cdata_all(1,iobsout)
 !       adjustment of observation error
         if(kx>179.and.kx<200) then
-!           special treatment of obs error for RTMA3D run
-            if (l_rtma3d) then
+            if (l_rtma3d) then    ! special treatment of obs error for 3DRTMA run
+                                  ! because very small oberr is used for sfcobs (1/16 of oberr as used in HRRR).
                 oe_factor=1.0_r_kind
                 select case (i_gsd_terrain_match_mesonet)
-                    case (0:1)    ! default: no adjustment to oberr, because very small oberr is used
-                                  !          for surface obs in 3DRTMA (1/16 of oberr used in HRRR).
+                    case (0)      ! default: no adjustment to oberr of kx=181/187,
+                                  !          because very small oberr is used in 3DRTMA
                         oe_factor=1.0_r_kind
-                    case (2:10)   ! for tunning oberr with gsd terrain matching
-                        oe_factor=real(i_gsd_terrain_match_mesonet, r_kind)/10.0_r_kind
-                    case (11:)    ! adjusted in the same way as the original setup by GSD developer
+                    case (1)      ! no adjustment to oberr of kx=181/187/188/192/193/195
+                        oe_factor=1.0_r_kind
+                    case (2:)     ! oberr is adjusted to half of pre-defined value for kx=181/187/188/192/193/195
+                                  ! (the same way as the original setup by GSD developer)
                         oe_factor=r0_5
-                    case ( :-1)   ! only kx=181/187 is adjusted in the same way as the original setup by GSD developer
+                    case (:-1)    ! oberr is adjusted to half of pre-defined value for kx=181/187
                         oe_factor=r0_5
                 end select
                 toe=toe*oe_factor

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -1635,7 +1635,8 @@
 !      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
 !                                observations of Temp (188, 195)
 !                          = 0 : do not apply GSD terrain match to MESONET Obs of T (default)
-!                          = 1 : apply GSD terrain match to MESONET Obs of T
+!                          = 1 : apply GSD terrain match to MESONET Obs of T (kx=188)
+!                          = 2 : apply GSD terrain match to MESONET Obs of T (kx=188/192/193/195)
 !
   namelist/rapidrefresh_cldsurf/dfi_radar_latent_heat_time_period, &
                                 metar_impact_radius,metar_impact_radius_lowcloud, &

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -1638,8 +1638,9 @@
 !                                (kx=192/193, 192 corresponding to 181 with missing pressure, and 193 to 187.)
 !                          = 0 : apply GSD terrain match ONLY to surface obs of T with type kx=181/187
 !                                (default, using initial setup in gsd_terrain_match_surfTobs.f90 by GSD developer.)
-!                          = 1 : apply GSD terrain match to more surface Obs type, kx=188/195/192/193.
-!                                (recommended for 3DRTMA run, see gsd_terrain_match_surfTobs.f90.)
+!                          = 1 : apply GSD terrain match to more surface Obs type, kx=181/187/188/195/192/193.
+!                                (recommended for 3DRTMA run, see gsd_terrain_match_surfTobs.f90 for the details
+!                                 on the adjustment of the observation error for 3DRTMA run.)
 !
   namelist/rapidrefresh_cldsurf/dfi_radar_latent_heat_time_period, &
                                 metar_impact_radius,metar_impact_radius_lowcloud, &

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -1633,10 +1633,9 @@
 !      hwllp_vis     - real, background error de-correlation length scale of visibility
 !                            in transformed space, not physical space
 !      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
-!                                observations of Temp (188, 195)
+!                                observations of Temp (188/195) and some types of surface t obs (192/193)
 !                          = 0 : do not apply GSD terrain match to MESONET Obs of T (default)
-!                          = 1 : apply GSD terrain match to MESONET Obs of T (kx=188)
-!                          = 2 : apply GSD terrain match to MESONET Obs of T (kx=188/192/193/195)
+!                          = 1 : apply GSD terrain match to MESONET Obs of T (kx=188/195, and 193/195)
 !
   namelist/rapidrefresh_cldsurf/dfi_radar_latent_heat_time_period, &
                                 metar_impact_radius,metar_impact_radius_lowcloud, &

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -1633,15 +1633,18 @@
 !                            in transformed space, not physical space
 !      hwllp_vis     - real, background error de-correlation length scale of visibility
 !                            in transformed space, not physical space
-!      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to more 
-!                                types of surface observations of temperature, including MESONET obs-type
-!                                (kx=188/195) and other types of surface t obs with missing pressure
-!                                (kx=192/193, 192 corresponding to 181 with missing pressure, and 193 to 187.)
-!                          = 0 : apply GSD terrain match ONLY to surface obs of T with type kx=181/187
-!                                (default, using initial setup in gsd_terrain_match_surfTobs.f90 by GSD developer.)
-!                          = 1 : apply GSD terrain match to more surface Obs type, kx=181/187/188/195/192/193.
-!                                (recommended for 3DRTMA run, see gsd_terrain_match_surfTobs.f90 for the details
-!                                 on the adjustment of the observation error for 3DRTMA run.)
+!      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match adjustment to more 
+!                                type of surface observations of temperature, including MESONET obs-type (kx=188)
+!                                and other types of surface obs of T with missing pressure (kx=192/193/195,
+!                                192 corresponding to 181 with missing pressure, 193 to 187, 195 to 188.)
+!                          = 0 : apply terrain match adjustment to kx=181/187 only; (default)
+!                                and the obs error of the adjusted obs is halved.
+!                                But in 3DRTMA (l_rtma3d=.true.), obs error is NOT halved;
+!                          = 1 : apply terrain match adjustment to kx=181/187/188/195/192/193.
+!                                and obs error is halved. But in 3DRTMA, obs error is NOT halved;
+!                          > 1 : like 1, and in 3DRTMA, also halve pre-defined obs error for these kx
+!                          < 0 : like 0, and in 3DRTMA, also halve pre-defined obs error
+!                                (see gsd_terrain_match_surfTobs.f90 for details.)
 !
   namelist/rapidrefresh_cldsurf/dfi_radar_latent_heat_time_period, &
                                 metar_impact_radius,metar_impact_radius_lowcloud, &

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -1632,10 +1632,14 @@
 !                            in transformed space, not physical space
 !      hwllp_vis     - real, background error de-correlation length scale of visibility
 !                            in transformed space, not physical space
-!      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
-!                                observations of Temp (188/195) and some types of surface t obs (192/193)
-!                          = 0 : do not apply GSD terrain match to MESONET Obs of T (default)
-!                          = 1 : apply GSD terrain match to MESONET Obs of T (kx=188/195, and 193/195)
+!      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to more 
+!                                types of surface observations of temperature, including MESONET obs-type
+!                                (kx=188/195) and other types of surface t obs with missing pressure
+!                                (kx=192/193, 192 corresponding to 181 with missing pressure, and 193 to 187.)
+!                          = 0 : apply GSD terrain match ONLY to surface obs of T with type kx=181/187
+!                                (default, using initial setup in gsd_terrain_match_surfTobs.f90 by GSD developer.)
+!                          = 1 : apply GSD terrain match to more surface Obs type, kx=188/195/192/193.
+!                                (recommended for 3DRTMA run, see gsd_terrain_match_surfTobs.f90.)
 !
   namelist/rapidrefresh_cldsurf/dfi_radar_latent_heat_time_period, &
                                 metar_impact_radius,metar_impact_radius_lowcloud, &

--- a/src/gsi/rapidrefresh_cldsurf_mod.f90
+++ b/src/gsi/rapidrefresh_cldsurf_mod.f90
@@ -251,10 +251,14 @@ module rapidrefresh_cldsurf_mod
 !                          = 0 (vis-off: default) : no analysis of visibility in 3D analysis.
 !                          = 1 (vis-on) : if variable name "vis" is found in anavinfo,
 !                                          set it to be 1 to turn on analysis of visibility;
-!      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
-!                                observations of Temp (188/195) and some types of surface t obs (192/193)
-!                          = 0 : do not apply GSD terrain match to MESONET Obs of T (default)
-!                          = 1 : apply GSD terrain match to MESONET Obs of T (kx=188/195, and 192/193)
+!      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to more 
+!                                types of surface observations of temperature, including MESONET obs-type
+!                                (kx=188/195) and other types of surface t obs with missing pressure
+!                                (kx=192/193, 192 corresponding to 181 with missing pressure, and 193 to 187.)
+!                          = 0 : apply GSD terrain match ONLY to surface obs of T with type kx=181/187
+!                                (default, using initial setup in gsd_terrain_match_surfTobs.f90 by GSD developer.)
+!                          = 1 : apply GSD terrain match to more surface Obs type, kx=188/195/192/193.
+!                                (recommended for 3DRTMA run, see gsd_terrain_match_surfTobs.f90.)
 !
 ! attributes:
 !   language: f90

--- a/src/gsi/rapidrefresh_cldsurf_mod.f90
+++ b/src/gsi/rapidrefresh_cldsurf_mod.f90
@@ -254,7 +254,8 @@ module rapidrefresh_cldsurf_mod
 !      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
 !                                observations of Temp (188, 195)
 !                          = 0 : do not apply GSD terrain match to MESONET Obs of T (default)
-!                          = 1 : apply GSD terrain match to MESONET Obs of T
+!                          = 1 : apply GSD terrain match to MESONET Obs of T (kx=188)
+!                          = 2 : apply GSD terrain match to MESONET Obs of T (kx=188/192/193/195)
 !
 ! attributes:
 !   language: f90

--- a/src/gsi/rapidrefresh_cldsurf_mod.f90
+++ b/src/gsi/rapidrefresh_cldsurf_mod.f90
@@ -252,10 +252,9 @@ module rapidrefresh_cldsurf_mod
 !                          = 1 (vis-on) : if variable name "vis" is found in anavinfo,
 !                                          set it to be 1 to turn on analysis of visibility;
 !      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to MESONET (MSO)
-!                                observations of Temp (188, 195)
+!                                observations of Temp (188/195) and some types of surface t obs (192/193)
 !                          = 0 : do not apply GSD terrain match to MESONET Obs of T (default)
-!                          = 1 : apply GSD terrain match to MESONET Obs of T (kx=188)
-!                          = 2 : apply GSD terrain match to MESONET Obs of T (kx=188/192/193/195)
+!                          = 1 : apply GSD terrain match to MESONET Obs of T (kx=188/195, and 192/193)
 !
 ! attributes:
 !   language: f90

--- a/src/gsi/rapidrefresh_cldsurf_mod.f90
+++ b/src/gsi/rapidrefresh_cldsurf_mod.f90
@@ -251,15 +251,18 @@ module rapidrefresh_cldsurf_mod
 !                          = 0 (vis-off: default) : no analysis of visibility in 3D analysis.
 !                          = 1 (vis-on) : if variable name "vis" is found in anavinfo,
 !                                          set it to be 1 to turn on analysis of visibility;
-!      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match to more 
-!                                types of surface observations of temperature, including MESONET obs-type
-!                                (kx=188/195) and other types of surface t obs with missing pressure
-!                                (kx=192/193, 192 corresponding to 181 with missing pressure, and 193 to 187.)
-!                          = 0 : apply GSD terrain match ONLY to surface obs of T with type kx=181/187
-!                                (default, using initial setup in gsd_terrain_match_surfTobs.f90 by GSD developer.)
-!                          = 1 : apply GSD terrain match to more surface Obs type, kx=181/187/188/195/192/193.
-!                                (recommended for 3DRTMA run, see gsd_terrain_match_surfTobs.f90 for the details
-!                                 on the adjustment of the observation error for 3DRTMA run.)
+!      i_gsd_terrain_match_mesonet - namelist integer, control application of GSD Terrain Match adjustment to more 
+!                                type of surface observations of temperature, including MESONET obs-type (kx=188)
+!                                and other types of surface obs of T with missing pressure (kx=192/193/195,
+!                                192 corresponding to 181 with missing pressure, 193 to 187, 195 to 188.)
+!                          = 0 : apply terrain match adjustment to kx=181/187 only; (default)
+!                                and the obs error of the adjusted obs is halved.
+!                                But in 3DRTMA (l_rtma3d=.true.), obs error is NOT halved;
+!                          = 1 : apply terrain match adjustment to kx=181/187/188/195/192/193.
+!                                and obs error is halved. But in 3DRTMA, obs error is NOT halved;
+!                          > 1 : like 1, and in 3DRTMA, also halve pre-defined obs error for these kx
+!                          < 0 : like 0, and in 3DRTMA, also halve pre-defined obs error
+!                                (see gsd_terrain_match_surfTobs.f90 for details.)
 !
 ! attributes:
 !   language: f90

--- a/src/gsi/rapidrefresh_cldsurf_mod.f90
+++ b/src/gsi/rapidrefresh_cldsurf_mod.f90
@@ -257,8 +257,9 @@ module rapidrefresh_cldsurf_mod
 !                                (kx=192/193, 192 corresponding to 181 with missing pressure, and 193 to 187.)
 !                          = 0 : apply GSD terrain match ONLY to surface obs of T with type kx=181/187
 !                                (default, using initial setup in gsd_terrain_match_surfTobs.f90 by GSD developer.)
-!                          = 1 : apply GSD terrain match to more surface Obs type, kx=188/195/192/193.
-!                                (recommended for 3DRTMA run, see gsd_terrain_match_surfTobs.f90.)
+!                          = 1 : apply GSD terrain match to more surface Obs type, kx=181/187/188/195/192/193.
+!                                (recommended for 3DRTMA run, see gsd_terrain_match_surfTobs.f90 for the details
+!                                 on the adjustment of the observation error for 3DRTMA run.)
 !
 ! attributes:
 !   language: f90

--- a/src/gsi/read_prepbufr.F90
+++ b/src/gsi/read_prepbufr.F90
@@ -1199,7 +1199,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
            if (sfctype) then
               call ufbint(lunin,r_prvstg,1,1,iret,prvstr)
               call ufbint(lunin,r_sprvstg,1,1,iret,sprvstr)
-           else if(kx == 120 .and. tob .or. qob .or. psob)then
+           else if(kx == 120 .and. (tob .or. qob .or. psob))then
               c_prvstg=cspval
               c_sprvstg='PREP'
            else if(kx == 220 .and. uvob)then


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
1. applying GSD terrain matching to MESONET obs of T with missing pressure (gsd_terrain_match_surfTobs.f90);
2. adjust the maximum value nmax to 5000 to use new aircraft report reject list generated by Matthew Morris's AutoQC. (aircraftobsqc.f90);
3. fixed a minor bug in read_prpebufr.F90;
<!-- Please include relevant motivation and context. -->
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- List any dependencies that are required for this change. -->

<!-- Please provide reference to the issue this pull request is addressing. -->
<!-- For e.g. Fixes #IssueNumber -->
Fixes #1001

**Type of change**

Please delete options that are not relevant.

- [x] bug fixes (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published

- Regression tests were done successfully on WCOSS2/Cactus:

[gang.zhao@clogin05:build] (feature/gsdterrainmatch19x_3drtma)$ ctest -N
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
  Test # 1: global_4denvar
  Test # 2: rtma
  Test # 3: rrfs_3denvar_rdasens
  Test # 4: hafs_4denvar_glbens
  Test # 5: hafs_3denvar_hybens
  Test # 6: global_enkf

Total Tests: 6
[gang.zhao@clogin05:build] (feature/gsdterrainmatch19x_3drtma)$ ctest -j 6
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
    Start 1: global_4denvar
    Start 2: rtma
    Start 3: rrfs_3denvar_rdasens
    Start 4: hafs_4denvar_glbens
    Start 5: hafs_3denvar_hybens
    Start 6: global_enkf
1/6 Test # 3: rrfs_3denvar_rdasens .............   Passed  736.98 sec
2/6 Test # 2: rtma .............................   Passed  1219.40 sec
3/6 Test # 5: hafs_3denvar_hybens ..............   Passed  1286.99 sec
4/6 Test # 4: hafs_4denvar_glbens ..............***Failed  1405.37 sec
5/6 Test # 6: global_enkf ......................   Passed  1478.98 sec
6/6 Test # 1: global_4denvar ...................   Passed  1987.47 sec

83% tests passed, 1 tests failed out of 6

Total Test time (real) = 1987.48 sec

The following tests FAILED:
          4 - hafs_4denvar_glbens (Failed)
Errors while running CTest
Output from these tests are in: /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
[gang.zhao@clogin05:build] (feature/gsdterrainmatch19x_3drtma)$ ctest -R hafs_4denvar_glbens
Test project /lfs/h2/emc/da/save/gang.zhao/WorkDir/ProdGSI_dev/gsi_dev/build
    Start 4: hafs_4denvar_glbens
1/1 Test # 4: hafs_4denvar_glbens ..............   Passed  1412.02 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) = 1412.22 sec
