### PR TITLE
Add Changes Related to HAFS TDR SuperOb

### DIFF
--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -1092,7 +1092,7 @@
 !      time_window_rad  - upper limit on time window for certain radiance input data
 !      ext_sonde        - logical for extended forward model on sonde data
 !      l_foreaft_thin -   separate TDR fore/aft scan for thinning
-!      l_tdr_thin_alongbeam - apply along-the-beam thining to TDR data. default: .true.
+!      l_tdr_thin_alongbeam - apply along-the-beam thinning to TDR data. default: .true.
 !      hofx_2m_sfcfile  - Calculate h(x) for q2m and T2m from 
 !                         same fields in sfc_data.tile files
 !                         (for use in global 2m DA) 

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -2335,9 +2335,7 @@
      write(6,jcopts)
      write(6,strongopts)
      write(6,obsqc)
-     write(6,*)'EXT_SONDE on type 120 =',ext_sonde
-     write(6,*)'hofx_2m_sfcfile =', hofx_2m_sfcfile
-     write(6,*)'ignore_2mQM =', ignore_2mQM
+     write(6,obs_input)
      ngroup=0
      do i=1,ndat
         dthin(i) = max(dthin(i),0)

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -32,7 +32,7 @@
      r_hgt_fed
 
   use obsmod, only: lwrite_predterms, &
-     lwrite_peakwt,use_limit,lrun_subdirs,l_foreaft_thin,lobsdiag_forenkf,&
+     lwrite_peakwt,use_limit,lrun_subdirs,l_foreaft_thin,l_tdr_thin_alongbeam,lobsdiag_forenkf,&
      obsmod_init_instr_table,obsmod_final_instr_table
   use obsmod, only: luse_obsdiag
   use obsmod, only: netcdf_diag, binary_diag
@@ -1092,6 +1092,7 @@
 !      time_window_rad  - upper limit on time window for certain radiance input data
 !      ext_sonde        - logical for extended forward model on sonde data
 !      l_foreaft_thin -   separate TDR fore/aft scan for thinning
+!      l_tdr_thin_alongbeam - use default along-beam thinning of TDR data
 !      hofx_2m_sfcfile  - Calculate h(x) for q2m and T2m from 
 !                         same fields in sfc_data.tile files
 !                         (for use in global 2m DA) 
@@ -1101,7 +1102,7 @@
 !                         allows use of archived prepbufr files)
 
   namelist/obs_input/dmesh,time_window_max,time_window_rad, &
-       ext_sonde,l_foreaft_thin,hofx_2m_sfcfile, ignore_2mQM
+       ext_sonde,l_foreaft_thin,l_tdr_thin_alongbeam,hofx_2m_sfcfile, ignore_2mQM
 
 ! SINGLEOB_TEST (one observation test case setup):
 !      maginnov   - magnitude of innovation for one ob

--- a/src/gsi/gsimod.F90
+++ b/src/gsi/gsimod.F90
@@ -1092,7 +1092,7 @@
 !      time_window_rad  - upper limit on time window for certain radiance input data
 !      ext_sonde        - logical for extended forward model on sonde data
 !      l_foreaft_thin -   separate TDR fore/aft scan for thinning
-!      l_tdr_thin_alongbeam - use default along-beam thinning of TDR data
+!      l_tdr_thin_alongbeam - apply along-the-beam thining to TDR data. default: .true.
 !      hofx_2m_sfcfile  - Calculate h(x) for q2m and T2m from 
 !                         same fields in sfc_data.tile files
 !                         (for use in global 2m DA) 

--- a/src/gsi/obsmod.F90
+++ b/src/gsi/obsmod.F90
@@ -163,6 +163,7 @@ module obsmod
 !  2022-03-15  K. Apodaca - add GNSS-R L2 ocean wind speed observations (CYGNSS, Spire) 
 !   2023-07-10  Y. Wang, D. Dowell - add variables for flash extent density
 !   2023-10-10  H. Wang (GSL) - add variables for flash extent density EnVar DA
+!   2023-11-01  B. Dahl  - l_tdr_thin_alongbeam to allow user to bypass hard-coded thinning of TDR data along radar beam
 ! 
 ! Subroutines Included:
 !   sub init_obsmod_dflts   - initialize obs related variables to default values
@@ -405,6 +406,7 @@ module obsmod
 !   def lrun_subdirs - logical to toggle use of subdirectories at run time for pe specific
 !                      files
 !   def l_foreaft_thin -   separate TDR fore/aft scan for thinning
+!   def l_tdr_thin_alongbeam - .false. to disable hard-coded, along-beam thinning of TDR data (default is .true.)
 !   def dval_use       -   = .true. if any dval weighting is used for satellite
 !                           data
 !   def obs_sub        - number of observations of each type in each subdomain
@@ -477,7 +479,7 @@ module obsmod
   public :: mype_pm2_5,iout_pm2_5
   public :: mype_pm10,iout_pm10
   public :: use_limit,lrun_subdirs
-  public :: l_foreaft_thin,luse_obsdiag
+  public :: l_foreaft_thin,l_tdr_thin_alongbeam,luse_obsdiag
 
   ! ==== DBZ DA ===
   public :: ntilt_radarfiles
@@ -671,6 +673,7 @@ module obsmod
   logical ext_sonde
   logical lrun_subdirs
   logical l_foreaft_thin
+  logical l_tdr_thin_alongbeam
   logical neutral_stability_windfact_2dvar
   logical use_similarity_2dvar
 
@@ -958,6 +961,7 @@ contains
     lwrite_peakwt    = .false.
     lrun_subdirs     = .false.
     l_foreaft_thin   = .false.
+    l_tdr_thin_alongbeam = .true. ! default is hard-coded thinning along TDR beam
     luse_obsdiag     = .false.
 
 !   set default on diag writing

--- a/src/gsi/read_radar.f90
+++ b/src/gsi/read_radar.f90
@@ -3131,7 +3131,7 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
   if(l_tdr_thin_alongbeam) then
     write(6,*)'READ_RADAR: # data removed by thinning along the beam ntdrvr_thin1=', ntdrvr_thin1
   else
-    write(6,*) 'READ_RADAR: # offline superob applied on TDR, thinning along the beam is disabled'
+    write(6,*) 'READ_RADAR: # thinning along the beam is disabled, (l_tdr_thin_alongbeam = .false.)'
   end if
   write(6,*)'READ_RADAR: # data retained after thinning along the beam ntdrvr_in=', ntdrvr_in
   write(6,*)'READ_RADAR: # out of domain =', noutside

--- a/src/gsi/read_radar.f90
+++ b/src/gsi/read_radar.f90
@@ -63,7 +63,7 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
 !                              listed in the OBS_INPUT table) and for added flexibility for experimental setups.
 !   2018-02-15  wu      - add code for fv3_regional option
 !   2020-05-04  wu   - no rotate_wind for fv3_regional
-!
+!   2023-11-01  B. Dahl - add l_tdr_thin_alongbeam to allow bypass of hard-coded along-beam thinning of TDR data
 !
 !   input argument list:
 !     infile   - file from which to read BUFR data
@@ -90,7 +90,7 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
       eccentricity,somigliana,grav_ratio,grav, &
       semi_major_axis,flattening,two
   use qcmod, only: erradar_inflate,vadfile,newvad
-  use obsmod, only: iadate,ianldate,l_foreaft_thin,reduce_diag
+  use obsmod, only: iadate,ianldate,l_foreaft_thin,l_tdr_thin_alongbeam,reduce_diag
   use gsi_4dvar, only: l4dvar,l4densvar,iwinbgn,winlen,time_4dvar,thin4d
   use gridmod, only: regional,nlat,nlon,tll2xy,rlats,rlons,rotate_wind_ll2xy,nsig,&
       fv3_regional
@@ -2800,22 +2800,35 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
            ii=0
            do k=1,levs
               nread=nread+1
-!             Select data every 3 km along each beam
-              if(MOD(INT(tdr_obs(1,k)-tdr_obs(1,1)),3000) < 100)then
-                 if(tdr_obs(3,k) >= 800.) then
-                    nmissing=nmissing+1     !xx
+              if(l_tdr_thin_alongbeam) then
+!                Select data every 3 km along each beam
+                 if(MOD(INT(tdr_obs(1,k)-tdr_obs(1,1)),3000) < 100)then
+                    if(tdr_obs(3,k) >= 800.) then
+                       nmissing=nmissing+1     !xx
+                    else
+                       ii=ii+1
+                       dopbin(ii)=tdr_obs(3,k)
+                       thisrange=tdr_obs(1,k)
+
+                       call getvrlocalinfo(thisrange,thisazimuth,this_stahgt,aactual,a43,selev0,celev0, &
+                                  rlon0,clat0,slat0,r8,r89_5,nsubzero,ii,z(ii),elev(ii),elat8(ii), &
+                                  elon8(ii),glob_azimuth8(ii))
+                    end if
                  else
+                    ntdrvr_thin1=ntdrvr_thin1+1
+                 endif
+              else
+                 if(tdr_obs(3,k) >= 800.) nmissing=nmissing+1     !xx
+                 if(tdr_obs(3,k) < 800.) then
                     ii=ii+1
                     dopbin(ii)=tdr_obs(3,k)
                     thisrange=tdr_obs(1,k)
 
                     call getvrlocalinfo(thisrange,thisazimuth,this_stahgt,aactual,a43,selev0,celev0, &
-                                   rlon0,clat0,slat0,r8,r89_5,nsubzero,ii,z(ii),elev(ii),elat8(ii), &
-                                   elon8(ii),glob_azimuth8(ii))
+                                rlon0,clat0,slat0,r8,r89_5,nsubzero,ii,z(ii),elev(ii),elat8(ii), &
+                                elon8(ii),glob_azimuth8(ii))
                  end if
-              else
-                 ntdrvr_thin1=ntdrvr_thin1+1
-              endif
+              end if
            end do
 
 !          Further process tail Doppler radar Vr data

--- a/src/gsi/read_radar.f90
+++ b/src/gsi/read_radar.f90
@@ -2803,7 +2803,7 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
               if(l_tdr_thin_alongbeam) then
 !                Select data every 3 km along each beam
                  if(MOD(INT(tdr_obs(1,k)-tdr_obs(1,1)),3000) < 100)then
-                    if(tdr_obs(3,k) >= 800.) then
+                    if(tdr_obs(3,k) >= 800.0_r_double) then
                        nmissing=nmissing+1     !xx
                     else
                        ii=ii+1
@@ -2818,8 +2818,8 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
                     ntdrvr_thin1=ntdrvr_thin1+1
                  endif
               else
-                 if(tdr_obs(3,k) >= 800.) nmissing=nmissing+1     !xx
-                 if(tdr_obs(3,k) < 800.) then
+                 if(tdr_obs(3,k) >= 800.0_r_double) nmissing=nmissing+1     !xx
+                 if(tdr_obs(3,k) < 800.0_r_double) then
                     ii=ii+1
                     dopbin(ii)=tdr_obs(3,k)
                     thisrange=tdr_obs(1,k)
@@ -3128,7 +3128,11 @@ subroutine read_radar(nread,ndata,nodata,infile,lunout,obstype,twind,sis,hgtl_fu
   write(6,*)'READ_RADAR: # data read in nread=', nread 
   write(6,*)'READ_RADAR: # data with missing value nmissing=', nmissing
   write(6,*)'READ_RADAR: # data likely to be below sealevel nsubzero=', nsubzero
-  write(6,*)'READ_RADAR: # data removed by thinning along the beam ntdrvr_thin1=', ntdrvr_thin1 
+  if(l_tdr_thin_alongbeam) then
+    write(6,*)'READ_RADAR: # data removed by thinning along the beam ntdrvr_thin1=', ntdrvr_thin1
+  else
+    write(6,*) 'READ_RADAR: # offline superob applied on TDR, thinning along the beam is disabled'
+  end if
   write(6,*)'READ_RADAR: # data retained after thinning along the beam ntdrvr_in=', ntdrvr_in
   write(6,*)'READ_RADAR: # out of domain =', noutside
   write(6,*)'READ_RADAR: # out of range =', nirrr


### PR DESCRIPTION
**Description**
The upcoming HAFSv2.2 will assimilate super-obbed TDR observations. To support this, the existing along-the-beam thinning function will be bypassed if the input TDR BUFR data is already super-obbed. This PR introduces a new namelist option,  `l_tdr_thin_alongbeam`,  allowing users to explicityly toggle along-the-beam thinning on or off. 

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published