### PR TITLE
Implement bugfix for tv flag handling for different BUFR libraries

### DIFF
--- a/src/gsi/oneobmod.F90
+++ b/src/gsi/oneobmod.F90
@@ -173,11 +173,11 @@ contains
     real(r_kind),dimension(1,1):: poe,qoe,toe,woe
     real(r_kind),dimension(1):: xob,yob,dhr
     real(r_kind),dimension(1,1):: pob
-    integer(i_kind) vtcd
+    integer(i_kind) ivtcd
     integer(i_kind) n,k,iret
     real(r_double) hdr(10),obs(13,255),qms(10,255),err(10,255),cld2seq(2,1), &
                  cldseq(3,10),owave(1,255),maxtmint(2,255),cldceilh(1,255),&
-                 pcd(10,255)
+                 pcd(10,255),vtcd
     character(80):: hdrstr='SID XOB YOB DHR TYP'
     character(80):: obsstr='POB QOB TOB ZOB UOB VOB CAT PWO MXGS HOVI PRSS TDO PMO'
     character(80):: qmsstr='PQM QQM TQM ZQM WQM PWQ PMQ'
@@ -286,7 +286,8 @@ contains
     call datelen(10)
     call openbf(lendian_in,'OUT',ludx)
     if (virtmp) then
-       call ufbqcd(lendian_in,'VIRTMP',vtcd)
+       call fixqcd(lendian_in,'VIRTMP',ivtcd)
+       vtcd = ivtcd
     end if
     do n=1,nobs
        hdr(1)=transfer(sid(n),hdr(1))

--- a/src/gsi/read_pblh.f90
+++ b/src/gsi/read_pblh.f90
@@ -436,8 +436,8 @@
       write(*,'(1x,f7.2,2(1x,f6.2),$)') (hdr(i),i=2,4)           ! XOB,YOB,DHR
       write(*,'(1x,i6,1x,i3,1x,i4,1x,i3,$)') (int(hdr(i)),i=5,8) ! ELV,TYP,T29,ITP
 
-      write(*,'(1x,2(2x,a,1x,i3),a,$)') '(olv=',nlevo,'nlevp=',nlevp,')'
-      write(*,'(1x,2(2x,a,1x,i3),a,$)') '(clv=',nlevc,'nlevp=',nlevp,')'
+      write(*,'("(nlevp=",i3,") ")', advance='no') nlevp
+      write(*,'("(nlevp=",i3,")")') nlevp
 
       ndata=ndata+1
       nodata=nodata+1

--- a/src/gsi/read_pblh.f90
+++ b/src/gsi/read_pblh.f90
@@ -374,13 +374,13 @@
 ! OBLVL == SRC FHR <PEVN> <QEVN> <TEVN> <ZEVN> <WEVN> <CEVN> <SEVN>
 !       == SRC FHR POB PMO QOB    TOB    ZOB   UOB VOB ...  ! {P,Q,T,Z,W}EVN
 !     cnem='SRC FHR POB PMO QOB TOB ZOB UOB VOB'
-!     call ufbevn(lunin,olv,MXNM,MXRP,MXRP, nlevp,nlevo,cnem)
+!     call ufbevn(lunin,olv,MXNM,MXRP,MXRP, nlevp,cnem)
 
 ! CEVN == CAPE CINH LI PBL TROP PWO
 !     cnem='CAPE CINH LI PBL TROP PWO'
       cnem='PBL'   ! for Caterina's files (ruc_raobs)
       clv=bmiss
-      call ufbevn(lunin,clv,MXNM,MXRP,MXRP, nlevp,nlevc,cnem)
+      call ufbevn(lunin,clv,MXNM,MXRP,MXRP, nlevp,cnem)
 !     pblhob=clv(4,1,2)
       pblhob=clv(1,1,2)
       pblbak=clv(1,1,1)   ! model PBL; from Caterina's files
@@ -422,7 +422,7 @@
 
 ! SEVN == HOVI MXTM MITM TDO TOCC MXGS THI TCH CDBZ
 !     cnem='HOVI MXTM MITM TDO TOCC MXGS THI TCH CDBZ'
-!     call ufbevn(lunin,slv,MXNM,MXRP,MXRP, nlevp,nlevs,cnem)
+!     call ufbevn(lunin,slv,MXNM,MXRP,MXRP, nlevp,cnem)
 
 !--Outputs
 

--- a/src/gsi/read_pblh.f90
+++ b/src/gsi/read_pblh.f90
@@ -436,7 +436,6 @@
       write(*,'(1x,f7.2,2(1x,f6.2),$)') (hdr(i),i=2,4)           ! XOB,YOB,DHR
       write(*,'(1x,i6,1x,i3,1x,i4,1x,i3,$)') (int(hdr(i)),i=5,8) ! ELV,TYP,T29,ITP
 
-      write(*,'("(nlevp=",i3,") ")', advance='no') nlevp
       write(*,'("(nlevp=",i3,")")') nlevp
 
       ndata=ndata+1

--- a/src/gsi/read_prepbufr.F90
+++ b/src/gsi/read_prepbufr.F90
@@ -3666,8 +3666,10 @@ subroutine fixqcd(lunit,nemo,icd)
      icd = nint(rcd)
   else if (xcd_part > tiny(0.0_r_single) .and. xcd_part < 99.0_r_single) then
      icd = nint(xcd_part)
-  else        
+  else if (jcd_part > 0 .and. jcd_part < 99) then       
      icd = jcd_part
+  else
+     icd = 99     
   endif
 
 end subroutine fixqcd

--- a/src/gsi/read_prepbufr.F90
+++ b/src/gsi/read_prepbufr.F90
@@ -3639,11 +3639,14 @@ end subroutine sonde_ext
 ! !INTERFACE:
 !
 subroutine fixqcd(lunit,nemo,icd)
+  use kinds, only: i_kind, r_single
   implicit none
-  character(*) nemo
+  integer(i_kind), intent(in)  :: lunit
+  character(*),    intent(in)  :: nemo
+  integer(i_kind), intent(out) :: icd
+  integer(i_kind) :: jcd
+  real(r_single)  :: xcd
   equivalence (jcd,xcd)
-  integer  lunit,icd,jcd
-  real xcd
   call ufbqcd(lunit,nemo,jcd)
   if(abs(jcd)<=abs(xcd).or.abs(xcd)<1) then
      icd = jcd

--- a/src/gsi/read_prepbufr.F90
+++ b/src/gsi/read_prepbufr.F90
@@ -887,7 +887,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
 !------------------------------------------------------------------------
 
 ! Obtain program code (VTCD) associated with "VIRTMP" step
-  call ufbqcd(lunin,'VIRTMP',ivtcd)
+  call fixqcd(lunin,'VIRTMP',ivtcd)
   vtcd = ivtcd
 
 !see if file contains GLERL program code (GLCD)
@@ -895,7 +895,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
   call status(lunin,lindx,idummy1,idummy2)
   call nemtab(lindx,'GLERL',idummy1,cdummy,glret)
   if (glret /= 0) then
-     call ufbqcd(lunin,'GLERL',iglcd)
+     call fixqcd(lunin,'GLERL',iglcd)
      glcd = iglcd
   else
      !warn that GLERL adjustment is not available.
@@ -3629,4 +3629,27 @@ subroutine sonde_ext(obsdat,tpc,qcmark,obserr,drfdat,levsio,kx,vtcd)
   return
 
 end subroutine sonde_ext
+
+!-------------------------------------------------------------------------
+!    NOAA/NCEP, National Centers for Environmental Prediction GSI        !
+!-------------------------------------------------------------------------
+!
+! !ROUTINE:  fixqcd - A wrapper around ufbqcd can make it work with any generation of bufrlib.
+!
+! !INTERFACE:
+!
+subroutine fixqcd(lunit,nemo,icd)
+  implicit none
+  character(*) nemo
+  equivalence (jcd,xcd)
+  integer  lunit,icd,jcd
+  real xcd
+  call ufbqcd(lunit,nemo,jcd)
+  if(abs(jcd)<=abs(xcd).or.abs(xcd)<1) then
+     icd = jcd
+  else
+     icd = nint(xcd)
+  endif
+  print*,nemo,' ',icd
+end subroutine fixqcd
 

--- a/src/gsi/read_prepbufr.F90
+++ b/src/gsi/read_prepbufr.F90
@@ -3650,6 +3650,5 @@ subroutine fixqcd(lunit,nemo,icd)
   else
      icd = nint(xcd)
   endif
-  print*,nemo,' ',icd
 end subroutine fixqcd
 

--- a/src/gsi/read_prepbufr.F90
+++ b/src/gsi/read_prepbufr.F90
@@ -3658,8 +3658,8 @@ subroutine fixqcd(lunit,nemo,icd)
   call ufbqcd(lunit,nemo,rcd)
 
   ! Extract component parts using the safe bitwise transfer intrinsic
-  xcd_part = transfer(rcd, xcd_part)
-  jcd_part = transfer(rcd, jcd_part)
+  xcd_part = transfer(rcd, 0.0_r_single)
+  jcd_part = transfer(rcd, 0_i_kind)
 
   ! Evaluate the extracted components cleanly
   if (rcd > tiny(0.0_r_double) .and. rcd < 99.0_r_double) then

--- a/src/gsi/read_prepbufr.F90
+++ b/src/gsi/read_prepbufr.F90
@@ -3630,14 +3630,14 @@ subroutine sonde_ext(obsdat,tpc,qcmark,obserr,drfdat,levsio,kx,vtcd)
 
 end subroutine sonde_ext
 
-!-------------------------------------------------------------------------
-!    NOAA/NCEP, National Centers for Environmental Prediction GSI        !
-!-------------------------------------------------------------------------
-!       
+!--------------------------------------------------------------------------!
+!    NOAA/NCEP, National Centers for Environmental Prediction GSI  !
+!--------------------------------------------------------------------------!
+!
 ! !ROUTINE:  fixqcd - A wrapper around ufbqcd can make it work with any generation of bufrlib.
-!       
+!
 ! !INTERFACE:
-!          
+!
 subroutine fixqcd(lunit,nemo,icd)
   use kinds, only: i_kind, r_single, r_double
   implicit none
@@ -3645,20 +3645,29 @@ subroutine fixqcd(lunit,nemo,icd)
   integer(i_kind), intent(in)  :: lunit
   character(*),    intent(in)  :: nemo
   integer(i_kind), intent(out) :: icd
-  integer(i_kind) :: jcd(2)
-  real(r_single)  :: xcd(2)
-  real(r_double)  :: rcd
-  equivalence (xcd,rcd)
-  equivalence (jcd,xcd)
 
+  ! Use distinct variables instead of equivalence overlays
+  real(r_double)  :: rcd
+  real(r_single)  :: xcd_part
+  integer(i_kind) :: jcd_part
+
+  ! Always initialize to prevent leftover garbage memory bugs
+  rcd = 0.0_r_double
+
+  ! Safe library call filling the full 8-byte block
   call ufbqcd(lunit,nemo,rcd)
 
-  if(rcd>tiny(rcd).and.rcd<99) then
+  ! Extract component parts using the safe bitwise transfer intrinsic
+  xcd_part = transfer(rcd, xcd_part)
+  jcd_part = transfer(rcd, jcd_part)
+
+  ! Evaluate the extracted components cleanly
+  if (rcd > tiny(0.0_r_double) .and. rcd < 99.0_r_double) then
      icd = nint(rcd)
-  elseif(xcd(1)>tiny(xcd(1)).and.xcd(1)<99) then
-     icd = nint(xcd(1))
+  else if (xcd_part > tiny(0.0_r_single) .and. xcd_part < 99.0_r_single) then
+     icd = nint(xcd_part)
   else        
-     icd = jcd(1)
+     icd = jcd_part
   endif
 
 end subroutine fixqcd

--- a/src/gsi/read_prepbufr.F90
+++ b/src/gsi/read_prepbufr.F90
@@ -3651,14 +3651,14 @@ subroutine fixqcd(lunit,nemo,icd)
   equivalence (xcd,rcd)
   equivalence (jcd,xcd)
 
-  call ufbqcd(lunit,nemo,rcd) 
+  call ufbqcd(lunit,nemo,rcd)
 
-  if(rcd>0.and.rcd<99) then
+  if(rcd>tiny(rcd).and.rcd<99) then
      icd = nint(rcd)
-  elseif(xcd(1)>0.and.xcd(1)<99) then
+  elseif(xcd(1)>tiny(xcd(1)).and.xcd(1)<99) then
      icd = nint(xcd(1))
   else        
      icd = jcd(1)
-  endif    
+  endif
 
 end subroutine fixqcd

--- a/src/gsi/read_prepbufr.F90
+++ b/src/gsi/read_prepbufr.F90
@@ -3633,25 +3633,32 @@ end subroutine sonde_ext
 !-------------------------------------------------------------------------
 !    NOAA/NCEP, National Centers for Environmental Prediction GSI        !
 !-------------------------------------------------------------------------
-!
+!       
 ! !ROUTINE:  fixqcd - A wrapper around ufbqcd can make it work with any generation of bufrlib.
-!
+!       
 ! !INTERFACE:
-!
+!          
 subroutine fixqcd(lunit,nemo,icd)
-  use kinds, only: i_kind, r_single
+  use kinds, only: i_kind, r_single, r_double
   implicit none
+
   integer(i_kind), intent(in)  :: lunit
   character(*),    intent(in)  :: nemo
   integer(i_kind), intent(out) :: icd
-  integer(i_kind) :: jcd
-  real(r_single)  :: xcd
+  integer(i_kind) :: jcd(2)
+  real(r_single)  :: xcd(2)
+  real(r_double)  :: rcd
+  equivalence (xcd,rcd)
   equivalence (jcd,xcd)
-  call ufbqcd(lunit,nemo,jcd)
-  if(abs(jcd)<=abs(xcd).or.abs(xcd)<1) then
-     icd = jcd
-  else
-     icd = nint(xcd)
-  endif
-end subroutine fixqcd
 
+  call ufbqcd(lunit,nemo,rcd) 
+
+  if(rcd>0.and.rcd<99) then
+     icd = nint(rcd)
+  elseif(xcd(1)>0.and.xcd(1)<99) then
+     icd = nint(xcd(1))
+  else        
+     icd = jcd(1)
+  endif    
+
+end subroutine fixqcd


### PR DESCRIPTION
**Description**

An issue was identified with the virtual temperature flag handling in read_prepbufr following the update to the BUFR@12.1.0 package.

This PR implements a wrapper around `ufbqcd`, named `fixqcd`, proposed by @jack-woollen, to ensure compatibility across different generations of bufrlib.

Fixes #1009

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

The modified code was built successfully, and cycled experiments were conducted with soil DA enabled.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published