### PR TITLE
Correct bug in array used for diagnostic ensemble spread calcuation

### DIFF
--- a/regression/regression_param.sh
+++ b/regression/regression_param.sh
@@ -61,8 +61,8 @@ case $regtest in
     global_4denvar)
 
         if [[ "$machine" = "Hera" ]]; then
-           topts[1]="0:10:00" ; popts[1]="12/8/" ; ropts[1]="/1"
-           topts[2]="0:10:00" ; popts[2]="12/10/" ; ropts[2]="/2"
+           topts[1]="0:15:00" ; popts[1]="12/8/" ; ropts[1]="/1"
+           topts[2]="0:15:00" ; popts[2]="12/10/" ; ropts[2]="/2"
         elif [[ "$machine" = "Ursa" ]]; then
            topts[1]="0:10:00" ; popts[1]="48/2/" ; ropts[1]="/1"
            topts[2]="0:10:00" ; popts[2]="48/3/" ; ropts[2]="/2"

--- a/src/gsi/get_gefs_ensperts_dualres.f90
+++ b/src/gsi/get_gefs_ensperts_dualres.f90
@@ -244,9 +244,13 @@ subroutine get_gefs_ensperts_dualres
        end do !c3d
        do i=1,nelen
           en_bar%values(i)=en_bar%values(i)+en_real8(n)%values(i)*bar_norm
-          en_perts(n,1,m)%valuesr4(i)=real(en_real8(n)%values(i),r_single)
        end do
 
+       if (write_ens_sprd) then
+          do i=1,nelen
+             en_perts(n,1,m)%valuesr4(i)=real(en_real8(n)%values(i),r_single)
+          end do
+       end if
 
 ! NOTE: if anyone implements alternative use of SST (as from sst2) care need
 !       be given to those applications getting SST directly from the members of

--- a/src/gsi/get_gefs_ensperts_dualres.f90
+++ b/src/gsi/get_gefs_ensperts_dualres.f90
@@ -244,6 +244,7 @@ subroutine get_gefs_ensperts_dualres
        end do !c3d
        do i=1,nelen
           en_bar%values(i)=en_bar%values(i)+en_real8(n)%values(i)*bar_norm
+          en_perts(n,1,m)%valuesr4(i)=real(en_real8(n)%values(i),r_single)
        end do
 
 


### PR DESCRIPTION
**Description**

This PR corrects a bug in how the diagnostic ensemble spread is computed.  This PR does NOT alter analysis results.  It only affects the T, q, and ps values written to a GrADS viewable binary file when `write_ens_spread=.true.` in namelist `HYBRID_ENSEMBLE`.

While running ctests on Hera, the initial run of global_4denvar failed due to the loproc job exceeding the specified 10 minute wall clock limit.  Increase the wall clock limit to 15 minutes.  The test _Passed_.  Include the updated global_4denvar wall clock limit in this PR (file `regression/regression_param.sh`).

Resolves #1018 

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested?**

Two tests have been conducted.
1. standard suite of GSI ctests on various machines.  All tests _Passed_.
2. build `develop` and `bugfix/ens_spread` `gsi.x`.  Run hybrid 3DEnVar case for 20260710 00Z gdas with a 40 member C192L127 ensemble with `write_ens_spread=.true.`.  Plot T, q, and ps spread from two runs.  Confirm `develop` is incorrect while `bugfix/ens_spread` is correct.  Also confirm that the resulting analyses from the two runs are bitwise identical.


**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] New and existing tests pass with my changes
