### PR TITLE
modify parameters sent to ufbprep to remove bufr warning message

### DIFF
--- a/regression/regression_var.sh
+++ b/regression/regression_var.sh
@@ -93,11 +93,11 @@ case $machine in
       export accnt="${accnt:-GFS-DEV}"
   ;;
   Orion | Hercules)
-      export local_or_default="${local_or_default:-/work/noaa/da/$LOGNAME}"
+      export local_or_default="${local_or_default:-/work2/noaa/da/$LOGNAME}"
       if [ -d $local_or_default ]; then
          export noscrub="$local_or_default/noscrub"
-      elif [ -d /work/noaa/global/$LOGNAME ]; then
-         export noscrub="/work/noaa/global/$LOGNAME/noscrub"
+      elif [ -d /work2/noaa/global/$LOGNAME ]; then
+         export noscrub="/work2/noaa/global/$LOGNAME/noscrub"
       fi
 
       export queue="${queue:-batch}"
@@ -110,11 +110,11 @@ case $machine in
 
       export group="${group:-global}"
       if [[ "$cmaketest" = "false" ]]; then
-         export basedir="/work/noaa/da/$LOGNAME/gsi"
+         export basedir="/work2/noaa/da/$LOGNAME/gsi"
       fi
-      export ptmp="${ptmp:-/work/noaa/stmp/$LOGNAME/${machine}/$ptmpName}"
+      export ptmp="${ptmp:-/work2/noaa/stmp/$LOGNAME/${machine}/$ptmpName}"
 
-      export casesdir="/work/noaa/da/rtreadon/CASES/regtest"
+      export casesdir="/work2/noaa/da/rtreadon/CASES/regtest"
 
       export check_resource="no"
       export accnt="${accnt:-da-cpu}"

--- a/src/gsi/read_abi.f90
+++ b/src/gsi/read_abi.f90
@@ -208,7 +208,7 @@ subroutine read_abi(mype,val_abi,ithin,rmesh,jsatid,&
   if (clrsky) then
      nchn=10
      ncld=nchn
-     nbrst=nchn
+     nbrst=nchn*2
   else if (allsky) then
      nchn=10
      ncld=2

--- a/src/gsi/read_satwnd.f90
+++ b/src/gsi/read_satwnd.f90
@@ -224,7 +224,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
   real(r_double),dimension(2) :: hdrdat_test,hdrdat_005099
 ! real(r_double),dimension(3,5) :: heightdat
 ! real(r_double),dimension(6,4) :: derdwdat
-  real(r_double),dimension(3,12) :: qcdat
+  real(r_double),dimension(3,13) :: qcdat
   real(r_double),dimension(1,1):: r_prvstg,r_sprvstg
   real(r_kind),allocatable,dimension(:):: presl_thin
   real(r_kind),allocatable,dimension(:,:):: cdata_all
@@ -571,7 +571,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
            !if(itype>=240.and.itype<=279) icnt(itype)=icnt(itype)+1             
 
            ! collect any qc data ahead of time to use it !
-           call ufbrep(lunin,qcdat,3,12,qcret,qcstr)
+           call ufbrep(lunin,qcdat,3,13,qcret,qcstr)
 
 !------------------------------------------------------------------------------------------
            select case (istype) ! special treatment for each istype        


### PR DESCRIPTION
**Description**

Address dimension inconsistency detected by bufr/12.3.0 ufbprep when called by `read_abi.f90` and `read_satwnd.f90`.

Resolves #1023 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested?**

Build `gsi.x` from `feature/llvm` and run global_4denvar ctest.  1,996,189 bufr warning messages are written to `stdout`.  Build `gsi.x` from RussTreadon-NOAA:bugfix/bufr_warning.  No bufr warning messages are written to `stdout`.  The analysis increments between the two runs are identical.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing tests pass with my changes